### PR TITLE
fix: 修复mac 下动画闪屏后UI未显示的问题

### DIFF
--- a/frame/src/main/java/com/tlcsdm/frame/FXSampler.java
+++ b/frame/src/main/java/com/tlcsdm/frame/FXSampler.java
@@ -196,6 +196,7 @@ public final class FXSampler extends Application {
         hasPrepared = true;
         if (loadingStage != null && loadingStage.isShowing() && supportAnim && animationFinished) {
             stage.show();
+            stage.requestFocus();
         }
     }
 
@@ -204,6 +205,7 @@ public final class FXSampler extends Application {
         animationFinished = true;
         if (loadingStage != null && loadingStage.isShowing() && hasPrepared) {
             stage.show();
+            stage.requestFocus();
         }
     }
 
@@ -371,8 +373,9 @@ public final class FXSampler extends Application {
         });
         if (!supportAnim) {
             stage.show();
+            stage.requestFocus();
         }
-        stage.requestFocus();
+
         stopWatch.stop();
         Console.log(String.format("Started Application in %.3f seconds", stopWatch.getTotalTimeSeconds()));
         samplesTreeView.requestFocus();


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #834

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation 