### PR TITLE
feat: Add maven-shade-plugin for exe package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out/
 qodana.sarif.json
 **/integration-test-screenshots/**
 .flattened-pom.xml
+dependency-reduced-pom.xml
 
 ### NetBeans ###
 /nbproject/private/

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,11 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-help-plugin.version>3.4.1</maven-help-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
-        <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>
+        <impsort-maven-plugin.version>1.10.0</impsort-maven-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven.wagon.http.ssl.insecure>true</maven.wagon.http.ssl.insecure>
         <maven.wagon.http.ssl.allowall>true</maven.wagon.http.ssl.allowall>
@@ -1566,6 +1567,26 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${maven-assembly-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>shade</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <transformers>
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        </transformers>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -220,26 +220,15 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
+                        <artifactId>maven-shade-plugin</artifactId>
                         <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                            <archive>
-                                <manifest>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.tlcsdm.smc.SmcSampler</mainClass>
-                                </manifest>
-                            </archive>
+                                </transformer>
+                            </transformers>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>com.akathist.maven.plugins.launch4j</groupId>
@@ -255,7 +244,7 @@
                                     <headerType>gui</headerType>
                                     <outfile>target/SmcTool.exe</outfile>
                                     <downloadUrl>https://adoptium.net/?variant=openjdk17</downloadUrl>
-                                    <jar>target/${project.artifactId}-jar-with-dependencies.jar</jar>
+                                    <jar>target/${project.artifactId}.jar</jar>
                                     <errTitle>Launching error</errTitle>
                                     <icon>config/logo.ico</icon>
                                     <classPath>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1578

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 更新了`.gitignore`文件，添加了`dependency-reduced-pom.xml`。
  - 在`pom.xml`文件中，将`maven-shade-plugin`版本更新至`3.6.0`，将`impsort-maven-plugin`版本降级至`1.10.0`。
  - 更新了`smc/pom.xml`文件，将Maven插件从`maven-assembly-plugin`更改为`maven-shade-plugin`，并调整了相关配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->