### PR TITLE
fix: 修复升级javadoc的生成路径修改问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1262,6 +1262,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
                     <doctitle>${project.name} Documentation (Version ${project.version})</doctitle>
                     <windowtitle>${project.name} Documentation (Version ${project.version})</windowtitle>
                     <show>private</show>
@@ -1289,7 +1290,7 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>aggregate-jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增强了文档输出配置，允许用户自定义生成的Javadoc目录。
	- 改变了构建过程，生成的JAR文件现在为聚合JAR，包含依赖项和其他模块。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->