### PR TITLE
ci: Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,12 +28,14 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
+      - name: Install
+        run: mvn --file pom.xml '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' clean install
       - name: Build with Maven in Mac
         if: runner.os == 'Macos'
-        run: mvn -B package --file pom.xml -DskipTests '-Dmaven.javadoc.skip=true' '-Djavafx.platform=mac'
+        run: mvn -B clean package --file pom.xml -DskipTests '-Dmaven.javadoc.skip=true' '-Djavafx.platform=mac'
       - name: Build with Maven
         if: runner.os != 'Macos'
-        run: mvn -B package --file pom.xml -DskipTests '-Dmaven.javadoc.skip=true'
+        run: mvn -B clean package --file pom.xml -DskipTests '-Dmaven.javadoc.skip=true'
       - name: Test with Maven in Mac
         if: runner.os == 'Macos'
         run: mvn test --file pom.xml -DworkEnv=ci '-Djavafx.platform=mac' '-Dkotest.framework.classpath.scanning.autoscan.disable=true'


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Maven CI workflow to include a new installation step and ensure a clean build process by adding a clean operation before packaging in both Mac and non-Mac environments.

CI:
- Add a new 'Install' step in the Maven workflow to perform a clean install while skipping tests and javadoc generation.
- Modify the 'Build with Maven in Mac' and 'Build with Maven' steps to include a clean operation before packaging.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的安装步骤以加快 Maven 项目的构建过程。
  
- **改进**
  - 更新了构建命令，确保从干净状态开始构建，提高了构建过程的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->