### PR TITLE
fix: 修复升级javadoc的生成路径修改问题

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,8 +28,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
-      - name: Install
-        run: mvn --file pom.xml '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' clean install
       - name: Build with Maven in Mac
         if: runner.os == 'Macos'
         run: mvn -B clean package --file pom.xml -DskipTests '-Dmaven.javadoc.skip=true' '-Djavafx.platform=mac'

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the Maven install step from the GitHub Actions workflow to streamline the build process on MacOS.

CI:
- Remove the Maven install step from the GitHub Actions workflow for MacOS.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 更新了 `maven-javadoc-plugin` 的版本，从 `3.10.0` 回退至 `3.8.0`，可能修复了文档生成过程中的问题。
  
- **Chores**
	- 修改了 GitHub Actions 工作流，移除了不再需要的 Maven 安装步骤，以简化构建过程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->