### PR TITLE
feat: Add ListImageView

### DIFF
--- a/core/src/main/java/com/tlcsdm/core/javafx/control/ListImageView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/ListImageView.java
@@ -42,7 +42,7 @@ public class ListImageView extends Control {
     private ListProperty<Photo> items;
 
     public ListImageView() {
-        new ListImageView(FXCollections.observableArrayList());
+        this(FXCollections.observableArrayList());
     }
 
     public ListImageView(ObservableList<Photo> listOfPhotos) {

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/ListImageView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/ListImageView.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.javafx.control;
+
+import com.tlcsdm.core.javafx.control.skin.ListImageViewSkin;
+import javafx.beans.DefaultProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+
+@DefaultProperty("items")
+public class ListImageView extends Control {
+
+    private ListProperty<Photo> items;
+
+    public ListImageView() {
+        new ListImageView(FXCollections.observableArrayList());
+    }
+
+    public ListImageView(ObservableList<Photo> listOfPhotos) {
+        super();
+        getStyleClass().add("list-image-view");
+        items = new SimpleListProperty<>(this, "items");
+        items.set(listOfPhotos);
+    }
+
+    public final ListProperty<Photo> itemsProperty() {
+        return items;
+    }
+
+    public void setItems(ObservableList<Photo> photoList) {
+        this.items.set(photoList);
+    }
+
+    public ObservableList<Photo> getItems() {
+        return items.get();
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new ListImageViewSkin(this);
+    }
+
+    public record Photo(String location, String title) {
+    }
+
+}

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ListImageViewSkin.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ListImageViewSkin.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.javafx.control.skin;
+
+import com.tlcsdm.core.javafx.control.ListImageView;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.SkinBase;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.text.TextAlignment;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ListImageViewSkin extends SkinBase<ListImageView> {
+
+    private BorderPane borderPane;
+    private ListView<ListImageView.Photo> listView;
+    private ImageView imageView;
+    private Pane imageViewPane;
+    private Map<String, Image> imageCacheMap;
+    private ListImageView control;
+
+    public ListImageViewSkin(ListImageView listImageView) {
+        super(listImageView);
+        this.control = listImageView;
+
+        listView = new ListView<>();
+
+        imageView = new ImageView();
+        imageView.setPickOnBounds(true);
+        imageView.setPreserveRatio(true);
+        imageViewPane = new Pane(imageView);
+        imageViewPane.setBackground(new Background(new BackgroundFill(Color.WHITE, CornerRadii.EMPTY, Insets.EMPTY)));
+
+        borderPane = new BorderPane();
+        borderPane.setLeft(listView);
+        borderPane.setCenter(imageViewPane);
+        borderPane.setFocusTraversable(false);
+        borderPane.setPadding(new Insets(8));
+
+        getChildren().add(borderPane);
+
+        imageCacheMap = new HashMap<>();
+        listView.itemsProperty().bind(getSkinnable().itemsProperty());
+        listView.setCellFactory((imageView) -> new ImageTextCell());
+        listView.getSelectionModel()
+            .selectedItemProperty()
+            .addListener((obValue, oldPhoto, newPhoto) -> {
+                final Image image = Optional.ofNullable(imageCacheMap.get(newPhoto.location()))
+                    .orElse(new Image(newPhoto.location()));
+                imageCacheMap.putIfAbsent(newPhoto.location(), image);
+                imageView.setImage(image);
+            });
+        imageView.fitWidthProperty().bind(imageViewPane.widthProperty());
+        imageView.fitHeightProperty().bind(imageViewPane.heightProperty());
+    }
+
+    private static class ImageTextCell extends ListCell<ListImageView.Photo> {
+
+        private final VBox vbox = new VBox(8.0);
+        private final Label label = new Label();
+        private final ImageView thumbImageView = new ImageView();
+
+
+        {
+            thumbImageView.setFitHeight(100.0);
+            thumbImageView.setPreserveRatio(true);
+
+            label.setWrapText(true);
+            label.setTextAlignment(TextAlignment.CENTER);
+            label.setLabelFor(thumbImageView);
+            label.underlineProperty().setValue(true);
+            label.managedProperty().bind(label.textProperty().isEmpty().not());
+
+            vbox.setAlignment(Pos.CENTER);
+            vbox.getChildren().addAll(thumbImageView, label);
+            vbox.cursorProperty().setValue(Cursor.HAND);
+        }
+
+        @Override
+        protected void updateItem(final ListImageView.Photo photo, final boolean empty) {
+            super.updateItem(photo, empty);
+            if (empty || photo == null) {
+                setGraphic(null);
+                return;
+            }
+            label.setText(photo.title());
+            thumbImageView.setImage(new Image(photo.location()));
+            setGraphic(vbox);
+        }
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/javafx/ListImageViewApp.java
+++ b/core/src/test/java/com/tlcsdm/core/javafx/ListImageViewApp.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.javafx;
+
+import com.tlcsdm.core.javafx.control.ListImageViewTest;
+import com.tlcsdm.core.javafx.control.ZoomViewTest;
+import javafx.application.Application;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class ListImageViewApp {
+    public static void main(String[] args) {
+        Application.launch(ListImageViewTest.class, args);
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/javafx/control/ListImageViewTest.java
+++ b/core/src/test/java/com/tlcsdm/core/javafx/control/ListImageViewTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.javafx.control;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import javafx.application.Application;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class ListImageViewTest extends Application {
+    @Override
+    public void start(Stage stage) throws Exception {
+        ObservableList<ListImageView.Photo> photoList = FXCollections.observableArrayList();
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), "park"));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("imageio/dbeaver1.png").toExternalForm(), ""));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), ""));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), ""));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), ""));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), ""));
+        photoList.add(new ListImageView.Photo(ResourceUtil.getResource("javafx/park.jpg").toExternalForm(), ""));
+        ListImageView view = new ListImageView(photoList);
+        view.setPrefSize(800, 600);
+        stage.setScene(new Scene(view));
+        stage.setTitle("Scalable Content Pane Demo");
+        stage.show();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) {
+        launch(args);
+    }
+}


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1689 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [x] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [x] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new ListImageView control to the JavaFX library, enabling users to display and interact with a list of images. This includes the implementation of the control, its skin, and a test application to showcase its usage.

New Features:
- Introduce a new ListImageView control that allows displaying a list of images with associated titles in a JavaFX application.

Tests:
- Add ListImageViewTest to demonstrate and test the functionality of the new ListImageView control, including setting up a scene with sample images.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入了 `ListImageView` 控件，用于显示图像列表。
  - 添加了 `ListImageViewSkin` 自定义外观，增强了控件的视觉效果和交互功能。
  - 创建了 `ListImageViewApp` 应用程序，用于启动和测试 `ListImageView` 控件。
  - 实现了 `ListImageViewTest` 应用程序，展示了 `ListImageView` 的功能，支持多图像加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->