### PR TITLE
feat: Improve ZoomImageView

### DIFF
--- a/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
@@ -28,6 +28,7 @@
 package com.tlcsdm.core.javafx.control;
 
 import com.tlcsdm.core.javafx.control.skin.ZoomImageViewSkin;
+import com.tlcsdm.core.javafx.control.skin.ZoomImageViewSkin2;
 import javafx.beans.DefaultProperty;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -200,7 +201,7 @@ public class ZoomImageView extends Control {
 
     @Override
     protected Skin<?> createDefaultSkin() {
-        return new ZoomImageViewSkin(this);
+        return new ZoomImageViewSkin2(this);
     }
 
     @Override

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
@@ -80,7 +80,7 @@ public class ZoomImageView extends Control {
     /**
      * Sets the upper bounds for zoom operations. The default value is "4".
      */
-    private final DoubleProperty maxZoomFactor = new SimpleDoubleProperty(this, "maxZoomFactor", 4);
+    private final DoubleProperty maxZoomFactor = new SimpleDoubleProperty(this, "maxZoomFactor", 20);
 
     public final double getMaxZoomFactor() {
         return maxZoomFactor.get();

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/ZoomImageView.java
@@ -50,7 +50,7 @@ public class ZoomImageView extends Control {
 
     public ZoomImageView() {
         super();
-        getStyleClass().add("zoom-view");
+        getStyleClass().add("zoom-image-view");
         setFocusTraversable(false);
         getStylesheets().add(getUserAgentStylesheet());
     }
@@ -201,7 +201,7 @@ public class ZoomImageView extends Control {
 
     @Override
     protected Skin<?> createDefaultSkin() {
-        return new ZoomImageViewSkin2(this);
+        return new ZoomImageViewSkin(this);
     }
 
     @Override

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ListImageViewSkin.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ListImageViewSkin.java
@@ -57,11 +57,9 @@ public class ListImageViewSkin extends SkinBase<ListImageView> {
     private ImageView imageView;
     private Pane imageViewPane;
     private Map<String, Image> imageCacheMap;
-    private ListImageView control;
 
     public ListImageViewSkin(ListImageView listImageView) {
         super(listImageView);
-        this.control = listImageView;
 
         listView = new ListView<>();
 
@@ -76,6 +74,7 @@ public class ListImageViewSkin extends SkinBase<ListImageView> {
         borderPane.setCenter(imageViewPane);
         borderPane.setFocusTraversable(false);
         borderPane.setPadding(new Insets(8));
+        borderPane.getLeft().managedProperty().bind(getSkinnable().itemsProperty().sizeProperty().greaterThan(1));
 
         getChildren().add(borderPane);
 
@@ -92,6 +91,9 @@ public class ListImageViewSkin extends SkinBase<ListImageView> {
             });
         imageView.fitWidthProperty().bind(imageViewPane.widthProperty());
         imageView.fitHeightProperty().bind(imageViewPane.heightProperty());
+        if (!getSkinnable().itemsProperty().get().isEmpty()) {
+            listView.getSelectionModel().select(0);
+        }
     }
 
     private static class ImageTextCell extends ListCell<ListImageView.Photo> {
@@ -99,7 +101,6 @@ public class ListImageViewSkin extends SkinBase<ListImageView> {
         private final VBox vbox = new VBox(8.0);
         private final Label label = new Label();
         private final ImageView thumbImageView = new ImageView();
-
 
         {
             thumbImageView.setFitHeight(100.0);

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ZoomImageViewSkin.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ZoomImageViewSkin.java
@@ -29,6 +29,8 @@ package com.tlcsdm.core.javafx.control.skin;
 
 import com.tlcsdm.core.javafx.control.ZoomImageView;
 import com.tlcsdm.core.javafx.helper.LayoutHelper;
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Bounds;
 import javafx.geometry.Orientation;
 import javafx.scene.Group;
 import javafx.scene.control.Button;
@@ -36,7 +38,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Separator;
 import javafx.scene.control.SkinBase;
-import javafx.scene.control.Slider;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToolBar;
 import javafx.scene.control.Tooltip;
@@ -105,17 +106,11 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
             LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/rotate-right.png")));
         rotateRight.setOnAction(evt -> view.rotateRight());
 
-        // zoom slider
-        Slider zoomSlider = new Slider();
-        zoomSlider.minProperty().bind(view.minZoomFactorProperty());
-        zoomSlider.maxProperty().bind(view.maxZoomFactorProperty());
-        zoomSlider.valueProperty().bindBidirectional(view.zoomFactorProperty());
-        zoomSlider.disableProperty().bind(view.showAllProperty());
-
         Button zoomIn = new Button();
         zoomIn.getStyleClass().addAll("tool-bar-button", "zoom-in");
         zoomIn.setTooltip(new Tooltip("Zoom in"));
         zoomIn.setGraphic(LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/zoom-in.png")));
+        zoomIn.disableProperty().bind(showAll.selectedProperty());
         zoomIn.setOnAction(evt -> increaseZoomFactor(0.5));
 
         Button zoomOut = new Button();
@@ -124,6 +119,7 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
         zoomOut.setGraphic(
             LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/zoom-out.png")));
         zoomOut.setOnAction(evt -> decreaseZoomFactor(0.5));
+        zoomOut.disableProperty().bind(showAll.selectedProperty());
 
         Label zoomLabel = new Label("Zoom");
         zoomLabel.disableProperty().bind(view.showAllProperty());
@@ -132,7 +128,7 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
         // toolbar
-        return new ToolBar(showAll, new Separator(Orientation.VERTICAL), zoomLabel, zoomSlider, zoomIn, zoomOut,
+        return new ToolBar(showAll, new Separator(Orientation.VERTICAL), zoomLabel, zoomIn, zoomOut,
             new Separator(Orientation.VERTICAL), rotateLeft, rotateRight, spacer);
     }
 
@@ -189,7 +185,7 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
                     pane.setMinWidth(prefWidth);
 
                     if (zoomView.isShowAll()) {
-                        pane.setPrefHeight(newBounds.getHeight() - 5);
+                        // pane.setPrefHeight(newBounds.getHeight() - 5);
                     } else {
                         Image image = zoomView.getImage();
                         if (image != null) {
@@ -208,7 +204,7 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
                     pane.setPrefHeight(prefHeight);
                     pane.setMinHeight(prefHeight);
                     if (zoomView.isShowAll()) {
-                        pane.setPrefWidth(newBounds.getWidth() - 5);
+                        // pane.setPrefWidth(newBounds.getWidth() - 5);
                     } else {
                         Image image = zoomView.getImage();
                         if (image != null) {
@@ -234,6 +230,10 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
             });
             zoomView.zoomFactorProperty().addListener(it -> {
                 updateScrollbarPolicies();
+                Bounds bounds = mainArea.getViewportBounds();
+                Bounds newBounds = new BoundingBox(bounds.getMinX() - 1, bounds.getMinY(), bounds.getMinZ(),
+                    bounds.getWidth());
+                mainArea.setViewportBounds(newBounds);
                 requestLayout();
             });
             updateScrollbarPolicies();
@@ -244,6 +244,7 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
             wrapper.getChildren().setAll(imageView);
             requestLayout();
             if (getSkinnable().isShowAll()) {
+                getSkinnable().zoomFactorProperty().set(1.0);
                 fitAll(imageView);
             } else {
                 fitWidth(imageView);
@@ -252,21 +253,21 @@ public class ZoomImageViewSkin extends SkinBase<ZoomImageView> {
 
         private void fitWidth(ImageView imageView) {
             if (isPortrait()) {
-                imageView.fitWidthProperty().bind(pane.widthProperty().subtract(40));
+                imageView.fitWidthProperty().bind(pane.prefWidthProperty().subtract(8));
                 imageView.fitHeightProperty().unbind();
             } else {
-                imageView.fitWidthProperty().bind(pane.heightProperty().subtract(40));
+                imageView.fitWidthProperty().bind(pane.prefHeightProperty().subtract(8));
                 imageView.fitHeightProperty().unbind();
             }
         }
 
         private void fitAll(ImageView imageView) {
             if (isPortrait()) {
-                imageView.fitWidthProperty().bind(pane.widthProperty().subtract(40));
-                imageView.fitHeightProperty().bind(pane.heightProperty().subtract(40));
+                imageView.fitWidthProperty().bind(pane.prefWidthProperty().subtract(8));
+                imageView.fitHeightProperty().bind(pane.prefHeightProperty().subtract(8));
             } else {
-                imageView.fitWidthProperty().bind(pane.heightProperty().subtract(40));
-                imageView.fitHeightProperty().bind(pane.widthProperty().subtract(40));
+                imageView.fitWidthProperty().bind(pane.prefWidthProperty().subtract(8));
+                imageView.fitHeightProperty().bind(pane.prefHeightProperty().subtract(8));
             }
         }
 

--- a/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ZoomImageViewSkin2.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/control/skin/ZoomImageViewSkin2.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.javafx.control.skin;
+
+import com.tlcsdm.core.javafx.control.ZoomImageView;
+import com.tlcsdm.core.javafx.helper.LayoutHelper;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.event.EventHandler;
+import javafx.geometry.Orientation;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Separator;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToolBar;
+import javafx.scene.control.Tooltip;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class ZoomImageViewSkin2 extends SkinBase<ZoomImageView> {
+
+    private final MainAreaScrollPane mainArea;
+
+    public ZoomImageViewSkin2(ZoomImageView zoomView) {
+        super(zoomView);
+
+        ToolBar toolBar = createToolBar(zoomView);
+        toolBar.visibleProperty().bind(zoomView.showToolBarProperty());
+        toolBar.managedProperty().bind(zoomView.showToolBarProperty());
+        mainArea = new MainAreaScrollPane();
+        VBox.setVgrow(mainArea, Priority.ALWAYS);
+
+        VBox rightSide = new VBox(mainArea);
+        rightSide.getStyleClass().add("main-area");
+        rightSide.setFillWidth(true);
+
+        BorderPane borderPane = new BorderPane();
+        borderPane.setTop(toolBar);
+        borderPane.setCenter(rightSide);
+        borderPane.setFocusTraversable(false);
+
+        getChildren().add(borderPane);
+    }
+
+    private ToolBar createToolBar(ZoomImageView zoomView) {
+        ZoomImageView view = getSkinnable();
+
+        // show all
+        ToggleButton showAll = new ToggleButton();
+        showAll.setGraphic(
+            LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/fullscreen.png")));
+        showAll.getStyleClass().addAll("tool-bar-button", "show-all-button");
+        showAll.setTooltip(new Tooltip("Show all / whole page"));
+        showAll.selectedProperty().bindBidirectional(zoomView.showAllProperty());
+
+        // rotate buttons
+        Button rotateLeft = new Button();
+        rotateLeft.getStyleClass().addAll("tool-bar-button", "rotate-left");
+        rotateLeft.setTooltip(new Tooltip("Rotate page left"));
+        rotateLeft.setGraphic(
+            LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/rotate-left.png")));
+        rotateLeft.setOnAction(evt -> view.rotateLeft());
+
+        Button rotateRight = new Button();
+        rotateRight.getStyleClass().addAll("tool-bar-button", "rotate-right");
+        rotateRight.setTooltip(new Tooltip("Rotate page right"));
+        rotateRight.setGraphic(
+            LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/rotate-right.png")));
+        rotateRight.setOnAction(evt -> view.rotateRight());
+
+        Button zoomIn = new Button();
+        zoomIn.getStyleClass().addAll("tool-bar-button", "zoom-in");
+        zoomIn.setTooltip(new Tooltip("Zoom in"));
+        zoomIn.setGraphic(LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/zoom-in.png")));
+        zoomIn.setOnAction(evt -> increaseZoomFactor(0.5));
+
+        Button zoomOut = new Button();
+        zoomOut.getStyleClass().addAll("tool-bar-button", "zoom-out");
+        zoomOut.setTooltip(new Tooltip("Zoom out"));
+        zoomOut.setGraphic(
+            LayoutHelper.iconView(getClass().getResource("/com/tlcsdm/core/static/graphic/zoom-out.png")));
+        zoomOut.setOnAction(evt -> decreaseZoomFactor(0.5));
+
+        Label zoomLabel = new Label("Zoom");
+        zoomLabel.disableProperty().bind(view.showAllProperty());
+
+        Region spacer = new Region();
+        HBox.setHgrow(spacer, Priority.ALWAYS);
+
+        // toolbar
+        return new ToolBar(showAll, new Separator(Orientation.VERTICAL), zoomLabel, zoomIn, zoomOut,
+            new Separator(Orientation.VERTICAL), rotateLeft, rotateRight, spacer);
+    }
+
+    class MainAreaScrollPane extends ScrollPane {
+
+        private ImageView imageView;
+        private ObjectProperty<Point2D> mouseDown = new SimpleObjectProperty<>();
+
+        public MainAreaScrollPane() {
+            AnchorPane.setLeftAnchor(this, 0.0);
+            AnchorPane.setRightAnchor(this, 0.0);
+            AnchorPane.setTopAnchor(this, 0.0);
+            AnchorPane.setBottomAnchor(this, 0.0);
+
+            ZoomImageView zoomView = getSkinnable();
+            imageView = new ImageView();
+            imageView.imageProperty().bind(zoomView.imageProperty());
+            imageView.setPreserveRatio(true);
+            imageView.setViewport(new Rectangle2D(0, 0, imageView.getImage().getWidth(), imageView.getImage().getHeight()));
+            setFitToWidth(true);
+            setFitToHeight(true);
+            setPannable(true);
+            this.setContent(imageView);
+            imageView.rotateProperty().bind(zoomView.pageRotationProperty());
+            imageView.addEventHandler(ScrollEvent.ANY, evt -> {
+                if (evt.isShortcutDown()) {
+                    if (evt.getDeltaY() > 0) {
+                        increaseZoomFactor(0.5);
+                    } else {
+                        decreaseZoomFactor(0.5);
+                    }
+                    evt.consume();
+                }
+            });
+
+            imageView.setOnMousePressed(e -> {
+
+                Point2D mousePress = imageViewToImage(imageView, new Point2D(e.getX(), e.getY()));
+                mouseDown.set(mousePress);
+            });
+
+            imageView.setOnMouseDragged(e -> {
+                Point2D dragPoint = imageViewToImage(imageView, new Point2D(e.getX(), e.getY()));
+                shift(imageView, dragPoint.subtract(mouseDown.get()));
+                mouseDown.set(imageViewToImage(imageView, new Point2D(e.getX(), e.getY())));
+            });
+
+
+            zoomView.showAllProperty().addListener(it -> {
+                requestLayout();
+            });
+            zoomView.pageRotationProperty().addListener(it -> {
+            });
+            zoomView.zoomFactorProperty().addListener(it -> {
+                imageView.setFitHeight(imageView.getImage().getHeight() * (zoomView.zoomFactorProperty().get()));
+                //updateScrollbarPolicies();
+                requestLayout();
+            });
+
+            init();
+        }
+
+        private void init() {
+            double width = imageView.getImage().getWidth();
+            double height = imageView.getImage().getHeight();
+            double imageRatio = width / height;
+            double parentRatio = this.getWidth() / this.getHeight();
+
+            if (imageRatio > parentRatio && width > this.getWidth()) {
+                imageView.setFitWidth(this.getWidth());
+            } else if (imageRatio < parentRatio && height > this.getHeight()) {
+                imageView.setFitHeight(this.getHeight());
+            }
+
+        }
+    }
+
+    /**
+     * Method to decrease the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (decrease) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+    private boolean decreaseZoomFactor(double delta) {
+        ZoomImageView zoomView = getSkinnable();
+        double currentZoomFactor = zoomView.getZoomFactor();
+        //if (!zoomView.isShowAll()) {
+            zoomView.setZoomFactor(Math.max(zoomView.getMinZoomFactor(), currentZoomFactor - delta));
+        //}
+        return currentZoomFactor != zoomView.getZoomFactor();
+    }
+
+    /**
+     * Method to increase the zoom factor for value specified as {@code delta}.
+     *
+     * @param delta zoom factor (increase) delta
+     * @return true if the operation actually did cause a zoom change
+     */
+    private boolean increaseZoomFactor(double delta) {
+        ZoomImageView zoomView = getSkinnable();
+        double currentZoomFactor = zoomView.getZoomFactor();
+        //if (!zoomView.isShowAll()) {
+            zoomView.setZoomFactor(Math.min(zoomView.getMaxZoomFactor(), currentZoomFactor + delta));
+       // }
+        return currentZoomFactor != zoomView.getZoomFactor();
+    }
+
+    // shift the viewport of the imageView by the specified delta, clamping so
+    // the viewport does not move off the actual image:
+    private void shift(ImageView imageView, Point2D delta) {
+        Rectangle2D viewport = imageView.getViewport();
+
+        double width = imageView.getImage().getWidth();
+        double height = imageView.getImage().getHeight();
+
+        double maxX = width - viewport.getWidth();
+        double maxY = height - viewport.getHeight();
+
+        double minX = clamp(viewport.getMinX() - delta.getX(), 0, maxX);
+        double minY = clamp(viewport.getMinY() - delta.getY(), 0, maxY);
+
+        imageView.setViewport(new Rectangle2D(minX, minY, viewport.getWidth(), viewport.getHeight()));
+    }
+
+    private double clamp(double value, double min, double max) {
+
+        if (value < min)
+            return min;
+        if (value > max)
+            return max;
+        return value;
+    }
+
+    // convert mouse coordinates in the imageView to coordinates in the actual image:
+    private Point2D imageViewToImage(ImageView imageView, Point2D imageViewCoordinates) {
+        double xProportion = imageViewCoordinates.getX() / imageView.getBoundsInLocal().getWidth();
+        double yProportion = imageViewCoordinates.getY() / imageView.getBoundsInLocal().getHeight();
+
+        Rectangle2D viewport = imageView.getViewport();
+        return new Point2D(
+            viewport.getMinX() + xProportion * viewport.getWidth(),
+            viewport.getMinY() + yProportion * viewport.getHeight());
+    }
+}

--- a/core/src/main/resources/com/tlcsdm/core/static/javafx/control/zoomimageview.css
+++ b/core/src/main/resources/com/tlcsdm/core/static/javafx/control/zoomimageview.css
@@ -25,22 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.zoom-view {
+.zoom-image-view {
 }
 
-.zoom-view .label {
+.zoom-image-view .label {
     -fx-text-fill: -fx-text-background-color;
 }
 
-.zoom-view .scroll-pane {
+.zoom-image-view .scroll-pane {
 }
 
-.zoom-view .scroll-pane .image-view-wrapper {
+.zoom-image-view .scroll-pane .image-view-wrapper {
     -fx-background-color: white;
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, .1), 6, 0.2, 0, 0);
 }
 
-.zoom-view .tool-bar .tool-bar-button .ikonli-font-icon {
+.zoom-image-view .tool-bar .tool-bar-button {
     -fx-icon-size: 18px;
     -fx-icon-color: -fx-text-background-color;
 }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1679

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the ListImageViewSkin by binding the managed property of the left node to the items size and auto-selecting the first item if available. Increase the maximum zoom factor in ZoomImageView to 20.

New Features:
- Increase the maximum zoom factor in ZoomImageView from 4 to 20, allowing for greater zoom capabilities.

Enhancements:
- Bind the managed property of the left node in the border pane to the size property of the items, ensuring it is only managed when there is more than one item.
- Automatically select the first item in the list view if the items property is not empty.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增加了 `ZoomImageView` 组件的最大缩放因子，从 4 增加到 20，提升了用户的缩放体验。
	- 引入了新的 `ZoomImageViewSkin2` 组件，提供更好的图像交互和缩放功能，包括旋转和工具栏操作。
	- 改进了 `ListImageViewSkin` 的动态行为，确保左侧组件的可见性与项目数量相匹配，并在初始化时正确选择第一个项目。

- **改进**
	- 优化了 `ZoomImageViewSkin` 的布局管理，移除了缩放滑块，增强了用户界面的交互性。
	- 更新了 CSS 样式类名称，提高了命名的清晰度和特异性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->