### PR TITLE
feat: Upgrade javadoc

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -79,7 +79,7 @@ jobs:
           cp ${{ matrix.mod }}/target/javafxTool-${{ matrix.mod }}.jar ${result_path}/javafxTool-${{ matrix.mod }}.jar
           cp -r ${{ matrix.mod }}/target/lib ${result_path}/lib
           cp -r docs ${result_path}/docs
-          cp -r ${{ matrix.mod }}/target/apidocs ${result_path}/apidocs
+          cp -r ${{ matrix.mod }}/target/reports/apidocs ${result_path}/apidocs
           cp -r ${{ matrix.mod }}/target/license ${result_path}/license
           cp -r `ls -A jenkins/${{ matrix.buildos }}/${{ matrix.mod }}/*` ${result_path}
       - name: Artifact

--- a/jenkins/package.sh
+++ b/jenkins/package.sh
@@ -40,7 +40,7 @@ do
 $M2_HOME/bin/mvn -f ${mod}/pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=win -Dmaven.test.skip=true package
 cp ${mod}/target/javafxTool-${mod}.jar javafxTool-${mod}.jar
 cp -r ${mod}/target/lib lib
-cp -r ${mod}/target/apidocs apidocs
+cp -r ${mod}/target/reports/apidocs apidocs
 cp -r ${mod}/target/license license
 zip -r ${mod}Tool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-${mod}.jar lib apidocs license
 zip -uj ${mod}Tool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/win/${mod}/*
@@ -57,7 +57,7 @@ do
 $M2_HOME/bin/mvn -f ${mod}/pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=mac -Dmaven.test.skip=true package
 cp ${mod}/target/javafxTool-${mod}.jar javafxTool-${mod}.jar
 cp -r ${mod}/target/lib lib
-cp -r ${mod}/target/apidocs apidocs
+cp -r ${mod}/target/reports/apidocs apidocs
 cp -r ${mod}/target/license license
 zip -r ${mod}Tool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-${mod}.jar lib apidocs license
 zip -uj ${mod}Tool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/mac/${mod}/*
@@ -74,7 +74,7 @@ do
 $M2_HOME/bin/mvn -f ${mod}/pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=linux -Dmaven.test.skip=true package
 cp ${mod}/target/javafxTool-${mod}.jar javafxTool-${mod}.jar
 cp -r ${mod}/target/lib lib
-cp -r ${mod}/target/apidocs apidocs
+cp -r ${mod}/target/reports/apidocs apidocs
 cp -r ${mod}/target/license license
 zip -r ${mod}Tool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-${mod}.jar lib apidocs license
 zip -uj ${mod}Tool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/linux/${mod}/*

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the path for Javadoc files in both the packaging script and the GitHub Actions workflow to reflect the new directory structure under 'reports/apidocs'.

Enhancements:
- Update the path for copying Javadoc files in the packaging script to reflect the new directory structure.

CI:
- Modify the GitHub Actions workflow to update the path for copying Javadoc files, aligning with the new directory structure.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 更新API文档的复制路径，确保文档从正确位置生成。
- **New Features**
	- 升级Maven Javadoc插件版本，可能带来文档生成的增强和新功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->