### PR TITLE
feat: Disable EasterEgg in MAC

### DIFF
--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
@@ -36,6 +36,7 @@ import com.dlsc.preferencesfx.util.VisibilityProperty;
 import com.tlcsdm.core.javafx.FxApp;
 import com.tlcsdm.core.javafx.util.Config;
 import com.tlcsdm.core.javafx.util.Keys;
+import com.tlcsdm.core.javafx.util.OSUtil;
 import com.tlcsdm.core.util.I18nUtils;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -87,6 +88,9 @@ public class PreferencesView extends StackPane {
     }
 
     private void initVisibilityProperty(Keys... excludeKeys) {
+        if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
+            supUseEasterEgg.setValue(false);
+        }
         for (Keys key : excludeKeys) {
             switch (key) {
                 case ConfirmExit -> supExitShowAlert.setValue(false);

--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
@@ -31,6 +31,7 @@ import com.tlcsdm.core.event.ConfigRefreshEvent;
 import com.tlcsdm.core.eventbus.EventBus;
 import com.tlcsdm.core.javafx.util.Config;
 import com.tlcsdm.core.javafx.util.Keys;
+import com.tlcsdm.core.javafx.util.OSUtil;
 import com.tlcsdm.core.javafx.view.AbstractSystemSettingView;
 import javafx.scene.Node;
 
@@ -65,6 +66,9 @@ public class SystemSettingController extends AbstractSystemSettingView {
      * @param excludeKeys Keys
      */
     public void disableKeys(Keys... excludeKeys) {
+        if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
+            disableNode(useEasterEggCheckBox);
+        }
         for (Keys key : excludeKeys) {
             switch (key) {
                 case ConfirmExit -> disableNode(exitShowAlertCheckBox);

--- a/frame/src/main/java/com/tlcsdm/frame/FXSampler.java
+++ b/frame/src/main/java/com/tlcsdm/frame/FXSampler.java
@@ -50,6 +50,7 @@ import com.tlcsdm.core.javafx.helper.LayoutHelper;
 import com.tlcsdm.core.javafx.util.Config;
 import com.tlcsdm.core.javafx.util.JavaFxSystemUtil;
 import com.tlcsdm.core.javafx.util.Keys;
+import com.tlcsdm.core.javafx.util.OSUtil;
 import com.tlcsdm.core.javafx.util.StageUtil;
 import com.tlcsdm.core.util.CoreConstant;
 import com.tlcsdm.core.util.CoreUtil;
@@ -440,7 +441,9 @@ public final class FXSampler extends Application {
         for (EasterEggService easterEggService : easterEggServices) {
             easterEggList.add(easterEggService);
         }
-        executeEasterEggs();
+        if (!OSUtil.getOS().equals(OSUtil.OS.MAC)) {
+            executeEasterEggs();
+        }
     }
 
     private void executeEasterEggs() {
@@ -456,6 +459,9 @@ public final class FXSampler extends Application {
 
     @Subscribe
     public void refreshEasterEggs(ConfigRefreshEvent event) {
+        if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
+            return;
+        }
         if (event.getKey() == null || Keys.UseEasterEgg.getKeyName().equals(event.getKey())) {
             executeEasterEggs();
         }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1497 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Disable the Easter Egg feature on macOS by adding checks to prevent its execution and hide related UI elements in the application.

New Features:
- Disable the Easter Egg feature on macOS by preventing its execution and hiding related UI elements.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 针对macOS用户，禁用复活节彩蛋功能，优化了用户体验。
- **改进**
	- 根据操作系统类型调整了设置和控制逻辑，确保在macOS上不执行复活节彩蛋。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->