### PR TITLE
feat: Add CS+ .map parse test

### DIFF
--- a/qe/src/main/java/module-info.java
+++ b/qe/src/main/java/module-info.java
@@ -66,6 +66,7 @@ module com.tlcsdm.qe {
     requires javafx.base;
     requires com.fasterxml.jackson.databind;
     requires net.jonathangiles.tools.teenyhttpd;
+    requires org.apache.commons.io;
 
     exports com.tlcsdm.qe;
     exports com.tlcsdm.qe.provider to com.tlcsdm.core, com.tlcsdm.frame, com.tlcsdm.login;

--- a/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
+++ b/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.qe;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class MemoryMappingTest {
+
+    private final String optionsFlag = "*** Options ***";
+    private final String symbolFlag = "*** Symbol List ***";
+    private final String romStartFlag = "-ROm=";
+    private final String sectionStartFlag = "SECTION=";
+    private final String endFlag = "*** ";
+    private final String globalVarFlag = "data ,g";
+    List<String> sections = new ArrayList<>();
+    List<String> varContent = new ArrayList<>();
+    List<Symbol> symbols = new ArrayList<>();
+    private boolean inOptions = false;
+    private boolean inSymbol = false;
+    private boolean inRomSectionFlag = false;
+
+    @Test
+    public void read() throws IOException {
+        File file = new File(ResourceUtil.getResource("cs+.map").getPath());
+        List<String> content = FileUtils.readLines(file, StandardCharsets.UTF_8);
+        for (String line : content) {
+            if (!inOptions && !inSymbol && line.equals(optionsFlag)) {
+                inOptions = true;
+            } else if (inOptions) {
+                if (line.startsWith(romStartFlag)) {
+                    String[] section = line.split("=", 3);
+                    if (!section[2].isEmpty()) {
+                        sections.add(section[2]);
+                    }
+                } else if (line.startsWith(endFlag) && !line.equals(optionsFlag)) {
+                    inOptions = false;
+                }
+            }
+
+            if (!inOptions && !inSymbol && line.equals(symbolFlag)) {
+                inSymbol = true;
+            } else if (inSymbol) {
+                if (line.startsWith(sectionStartFlag)) {
+                    String sect = line.substring(sectionStartFlag.length());
+                    if (sections.contains(sect)) {
+                        inRomSectionFlag = true;
+                    } else {
+                        inRomSectionFlag = false;
+                    }
+                } else if (inRomSectionFlag) {
+                    if (line.contains(globalVarFlag)) {
+                        String[] data = line.split("\\s+");
+                        symbols.add(new Symbol(varContent.get(varContent.size() - 1).trim(), data[1],
+                            Integer.parseInt(data[2])));
+                    } else {
+                        varContent.add(line);
+                    }
+                }
+                if (line.startsWith(endFlag) && !line.equals(symbolFlag)) {
+                    inSymbol = false;
+                    break;
+                }
+            }
+        }
+        varContent = null;
+        sections = null;
+        content = null;
+        System.out.println(symbols);
+    }
+
+    private record Symbol(String name, String address, int size) {
+
+    }
+}

--- a/qe/src/test/resources/cs+.map
+++ b/qe/src/test/resources/cs+.map
@@ -1,0 +1,8897 @@
+Renesas Optimizing Linker (W3.07.00 )             04-Oct-2024 00:41:51
+
+*** Options ***
+
+-subcommand=DefaultBuild\DALI102_207_209_sample.clnk
+-Input=DefaultBuild\r_memory_banks.obj
+-Input=DefaultBuild\r_nvm.obj
+-Input=DefaultBuild\r_random.obj
+-Input=DefaultBuild\r_unit0_memory_bank.obj
+-Input=DefaultBuild\r_unit1_memory_bank.obj
+-Input=DefaultBuild\r_unit2_memory_bank.obj
+-Input=DefaultBuild\r_cg.obj
+-Input=DefaultBuild\r_debug.obj
+-Input=DefaultBuild\r_main.obj
+-Input=DefaultBuild\r_memory_bank.obj
+-Input=DefaultBuild\r_dali101.obj
+-Input=DefaultBuild\r_dali101_bft.obj
+-Input=DefaultBuild\r_dali101_rx.obj
+-Input=DefaultBuild\r_led.obj
+-Input=DefaultBuild\r_led1.obj
+-Input=DefaultBuild\r_led2.obj
+-Input=DefaultBuild\r_led3.obj
+-Input=DefaultBuild\r_port.obj
+-Input=DefaultBuild\r_timer16.obj
+-Input=DefaultBuild\r_rfd_data_flash_api.obj
+-Input=DefaultBuild\r_rfd_common_extension_api.obj
+-Input=DefaultBuild\r_rfd_common_get_api.obj
+-Input=DefaultBuild\r_rfd_common_api.obj
+-Input=DefaultBuild\r_rfd_common_control_api.obj
+-Input=DefaultBuild\r_rfd_common_userown.obj
+-Input=DefaultBuild\Config_ADC.obj
+-Input=DefaultBuild\Config_ADC_user.obj
+-Input=DefaultBuild\Config_COMP0.obj
+-Input=DefaultBuild\Config_COMP0_user.obj
+-Input=DefaultBuild\Config_COMP1.obj
+-Input=DefaultBuild\Config_COMP1_user.obj
+-Input=DefaultBuild\Config_COMP2.obj
+-Input=DefaultBuild\Config_COMP2_user.obj
+-Input=DefaultBuild\Config_DAC0.obj
+-Input=DefaultBuild\Config_DAC0_user.obj
+-Input=DefaultBuild\Config_PGA.obj
+-Input=DefaultBuild\Config_PGA_user.obj
+-Input=DefaultBuild\Config_PORT.obj
+-Input=DefaultBuild\Config_PORT_user.obj
+-Input=DefaultBuild\Config_TAU0_1.obj
+-Input=DefaultBuild\Config_TAU0_1_user.obj
+-Input=DefaultBuild\Config_TAU0_2.obj
+-Input=DefaultBuild\Config_TAU0_2_user.obj
+-Input=DefaultBuild\Config_TAU0_3.obj
+-Input=DefaultBuild\Config_TAU0_3_user.obj
+-Input=DefaultBuild\Config_TKB0.obj
+-Input=DefaultBuild\Config_TKB0_user.obj
+-Input=DefaultBuild\Config_TKB1.obj
+-Input=DefaultBuild\Config_TKB1_user.obj
+-Input=DefaultBuild\Config_WDT.obj
+-Input=DefaultBuild\Config_WDT_user.obj
+-Input=DefaultBuild\r_cg_ad_common.obj
+-Input=DefaultBuild\r_cg_da_common.obj
+-Input=DefaultBuild\r_cg_pgacomp_common.obj
+-Input=DefaultBuild\r_cg_sau_common.obj
+-Input=DefaultBuild\r_cg_systeminit.obj
+-Input=DefaultBuild\r_cg_tau_common.obj
+-Input=DefaultBuild\r_cg_tkb_common.obj
+-Input=DefaultBuild\hdwinit.obj
+-Input=DefaultBuild\r_bsp_init.obj
+-Input=DefaultBuild\stkinit.obj
+-Input=DefaultBuild\cstart.obj
+-Input=DefaultBuild\r_bsp_common.obj
+-Input=DefaultBuild\r_bsp_common_ccrl.obj
+-Input=DefaultBuild\mcu_clocks.obj
+-Input=DefaultBuild\r_lamp_tc.obj
+-Input=DefaultBuild\r_trng.obj
+-Input=DefaultBuild\r_cg_lvd_common.obj
+-Input=DefaultBuild\r_cg_lvd_common_user.obj
+-Input=DefaultBuild\r_lamp.obj
+-Input=DefaultBuild\r_lamp_rgbwaf.obj
+-Input=DefaultBuild\r_lamp_xy.obj
+-Input=DefaultBuild\Config_DALI.obj
+-Input=DefaultBuild\Config_DALI_user.obj
+-Input=DefaultBuild\Config_TAU.obj
+-Input=DefaultBuild\Config_TAU_user.obj
+-Input=DefaultBuild\Pin.obj
+-Input=DefaultBuild\Config_UART.obj
+-Input=DefaultBuild\Config_UART_user.obj
+-LIBrary=Library\DALI207\r_dali_207_cc_gen2_v1_01.lib
+-LIBrary=Library\DALI102\r_dali_102_cc_gen2_v1_01.lib
+-LIBrary=Library\DALI209\r_dali_209_cc_gen2_v2_00.lib
+-SECURITY_ID=00000000000000000000
+-DEVICE=C:\Program Files (x86)\Renesas Electronics\CS+\CC\Device\RL78\Devicefile\DR7F101GLG.DVF
+-DEBug
+-NOCOmpress
+-NOOPtimize
+-OUtput=DefaultBuild\DALI102_207_209_sample.abs
+-LIBrary=C:\Program Files (x86)\Renesas Electronics\CS+\CC\CC-RL\V1.14.00\lib\rl78em4s99.lib
+-LIBrary=C:\Program Files (x86)\Renesas Electronics\CS+\CC\CC-RL\V1.14.00\lib\malloc_n.lib
+-LIBrary=C:\Program Files (x86)\Renesas Electronics\CS+\CC\CC-RL\V1.14.00\lib\rl78em4r.lib
+-OCDBG=84
+-DEBUG_MONITOR=1FE00-1FFFF
+-USER_OPT_BYTE=71FBEA
+-LISt=DefaultBuild\DALI102_207_209_sample.map
+-SHow=ALL
+-AUTO_SECTION_LAYOUT
+-STARt=.const,.text,.RLIB,.SLIB,.textf,.constf,.data,.sdata,RFD_DATA_n,RFD_CMN_f,RFD_DF_f,NVM_f/02000,.dataR,.stack_bss,.bss,RFD_DATA_nR/FCF00,.sdataR,.sbss/FFE20
+-ROm=.data=.dataR
+-ROm=.sdata=.sdataR
+-ROm=RFD_DATA_n=RFD_DATA_nR
+-NOMessage
+-NOLOgo
+-end
+
+*** Error information ***
+
+*** Mapping List ***
+
+SECTION                            START      END         SIZE   ALIGN
+.vect
+                                  00000000  0000007f        80   0
+.init_array
+                                  00000080  00000080         0   2
+.option_byte
+                                  000000c0  000000c3         4   1
+.security_id
+                                  000000c4  000000cd         a   1
+.monitor1
+                                  000000ce  000000d7         a   1
+.const
+                                  00002000  000043bc      23bd   2
+.text
+                                  000043bd  000045ed       231   1
+.RLIB
+                                  000045ee  000051bc       bcf   1
+.SLIB
+                                  000051bd  00006ed9      1d1d   1
+.textf
+                                  00006eda  000149a4      dacb   1
+.constf
+                                  000149a6  000149b9        14   2
+.data
+                                  000149ba  00014ecb       512   2
+.sdata
+                                  00014ecc  00014efd        32   2
+RFD_DATA_n
+                                  00014efe  00014f02         5   2
+RFD_CMN_f
+                                  00014f03  000150e0       1de   1
+RFD_DF_f
+                                  000150e1  0001512d        4d   1
+NVM_f
+                                  0001512e  00015b7e       a51   1
+.monitor2
+                                  0001fe00  0001ffff       200   1
+.dataR
+                                  000fcf00  000fd411       512   2
+.stack_bss
+                                  000fd412  000fd611       200   2
+.bss
+                                  000fd612  000fde2f       81e   2
+RFD_DATA_nR
+                                  000fde30  000fde34         5   2
+.sdataR
+                                  000ffe20  000ffe51        32   2
+.sbss
+                                  000ffe52  000ffe52         0   2
+
+*** Total Section Size ***
+
+RAMDATA SECTION:  00000f67 Byte(s)
+ROMDATA SECTION:  00002bb2 Byte(s)
+PROGRAM SECTION:  00011264 Byte(s)
+
+*** Symbol List ***
+
+SECTION=
+FILE=                               START        END    SIZE
+  SYMBOL                            ADDR        SIZE    INFO      COUNTS  OPT
+    STRUCT                                      SIZE
+      MEMBER                        ADDR        SIZE    INFO
+
+SECTION=.vect
+FILE=rlink_generates_04
+                                  00000000  0000007f        80
+
+SECTION=.option_byte
+FILE=rlink_generates_01
+                                  000000c0  000000c3         4
+
+SECTION=.security_id
+FILE=rlink_generates_03
+                                  000000c4  000000cd         a
+
+SECTION=.monitor1
+FILE=rlink_generates_02
+                                  000000ce  000000d7         a
+
+SECTION=.const
+FILE=DefaultBuild\r_nvm.obj
+                                  00002000  00002021        22
+FILE=DefaultBuild\r_unit0_memory_bank.obj
+                                  00002022  00002131       110
+  _gs_memory_map0@1
+                                  00002022       10e   data ,l         1
+    struct  {
+                                                   a
+      _gs_memory_map0@1.memory_type
+                                  00002022         1   enum
+      _gs_memory_map0@1.lockable
+                                  00002023         1   _Bool
+      _gs_memory_map0@1.default_value
+                                  00002024         1   unsigned char
+      _gs_memory_map0@1.reset_value
+                                  00002026         2   signed short
+      _gs_memory_map0@1.p_data
+                                  00002028         4   [near pointer]
+      _gs_memory_map0@1.multi_byte
+                                  0000202a         2
+    struct  {
+                                                   2
+      _gs_memory_map0@1.multi_byte.size
+                                  0000202a         1   unsigned char
+      _gs_memory_map0@1.multi_byte.index
+                                  0000202b         1   unsigned char
+    }
+    }
+  _g_unit0_memory_bank_info_list
+                                  00002130         2   data ,g         1
+    struct  {
+                                                   2
+      _g_unit0_memory_bank_info_list.p_map
+                                  00002130         4   [near pointer]
+    }
+FILE=DefaultBuild\r_unit1_memory_bank.obj
+                                  00002132  00002241       110
+  _gs_memory_map0@1
+                                  00002132       10e   data ,l         1
+    struct  {
+                                                   a
+      _gs_memory_map0@1.memory_type
+                                  00002132         1   enum
+      _gs_memory_map0@1.lockable
+                                  00002133         1   _Bool
+      _gs_memory_map0@1.default_value
+                                  00002134         1   unsigned char
+      _gs_memory_map0@1.reset_value
+                                  00002136         2   signed short
+      _gs_memory_map0@1.p_data
+                                  00002138         4   [near pointer]
+      _gs_memory_map0@1.multi_byte
+                                  0000213a         2
+    struct  {
+                                                   2
+      _gs_memory_map0@1.multi_byte.size
+                                  0000213a         1   unsigned char
+      _gs_memory_map0@1.multi_byte.index
+                                  0000213b         1   unsigned char
+    }
+    }
+  _g_unit1_memory_bank_info_list
+                                  00002240         2   data ,g         0
+    struct  {
+                                                   2
+      _g_unit1_memory_bank_info_list.p_map
+                                  00002240         4   [near pointer]
+    }
+FILE=DefaultBuild\r_unit2_memory_bank.obj
+                                  00002242  00002351       110
+  _gs_memory_map0@1
+                                  00002242       10e   data ,l         1
+    struct  {
+                                                   a
+      _gs_memory_map0@1.memory_type
+                                  00002242         1   enum
+      _gs_memory_map0@1.lockable
+                                  00002243         1   _Bool
+      _gs_memory_map0@1.default_value
+                                  00002244         1   unsigned char
+      _gs_memory_map0@1.reset_value
+                                  00002246         2   signed short
+      _gs_memory_map0@1.p_data
+                                  00002248         4   [near pointer]
+      _gs_memory_map0@1.multi_byte
+                                  0000224a         2
+    struct  {
+                                                   2
+      _gs_memory_map0@1.multi_byte.size
+                                  0000224a         1   unsigned char
+      _gs_memory_map0@1.multi_byte.index
+                                  0000224b         1   unsigned char
+    }
+    }
+  _g_unit2_memory_bank_info_list
+                                  00002350         2   data ,g         0
+    struct  {
+                                                   2
+      _g_unit2_memory_bank_info_list.p_map
+                                  00002350         4   [near pointer]
+    }
+FILE=DefaultBuild\r_cg.obj
+                                  00002352  00002432        e1
+  ___T1000000@1
+                                  00002352         2   data ,l         1
+  ___T1000001@2
+                                  00002354         5   data ,l         1
+  ___T1000002@3
+                                  0000235a        28   data ,l         1
+  ___T1000003@4
+                                  00002382         2   data ,l         1
+  ___T1000004@5
+                                  00002384         2   data ,l         1
+  _gs_dali102_general_callback@12
+                                  00002386         4   data ,l         1
+    struct  {
+                                                   4
+      _gs_dali102_general_callback@12.GetRandomValue
+                                  00002386         4   [far pointer]
+    }
+  _gs_dali102_mb_if_callback@13
+                                  0000238a        14   data ,l         1
+    struct  {
+                                                  14
+      _gs_dali102_mb_if_callback@13.Reset
+                                  0000238a         4   [far pointer]
+      _gs_dali102_mb_if_callback@13.Read
+                                  0000238e         4   [far pointer]
+      _gs_dali102_mb_if_callback@13.Write
+                                  00002392         4   [far pointer]
+      _gs_dali102_mb_if_callback@13.UnlatchRead
+                                  00002396         4   [far pointer]
+      _gs_dali102_mb_if_callback@13.CancelWrite
+                                  0000239a         4   [far pointer]
+    }
+FILE=DefaultBuild\r_debug.obj
+                                  00002434  00002926       4f3
+FILE=DefaultBuild\r_main.obj
+                                  00002928  0000292b         4
+FILE=DefaultBuild\r_led.obj
+                                  0000292c  0000292e         3
+  _feedback_led@3@R_LED_Init
+                                  0000292c         3   data ,l         1
+FILE=DefaultBuild\r_port.obj
+                                  00002930  00002959        2a
+  _port_addr@1@get_port_address@1
+                                  00002930        2a   data ,l         2
+FILE=DefaultBuild\r_bsp_common.obj
+                                  0000295a  00002971        18
+  _g_bsp_delay_time
+                                  0000295a        18   data ,g         2
+FILE=DefaultBuild\mcu_clocks.obj
+                                  00002972  00002a81       110
+  _g_fih_hz
+                                  00002972       100   data ,g         1
+  _g_fim_hz
+                                  00002a72        10   data ,g         1
+FILE=DefaultBuild\r_lamp.obj
+                                  00002a82  00003a1b       f9a
+  _g_dimming_table
+                                  00002a82       c00   data ,g        11
+  _g_dimming_rate
+                                  00003682       200   data ,g         1
+  _gs_convert_tc_to_xy_table@1
+                                  00003882       17a   data ,l         8
+  _g_dali209_general_callback
+                                  000039fc        20   data ,g         1
+    struct  {
+                                                  20
+      _g_dali209_general_callback.TranslateToLightOutput
+                                  000039fc         4   [far pointer]
+      _g_dali209_general_callback.ColourIsAttainable
+                                  00003a00         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueTCtoRGB
+                                  00003a04         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueRGBtoTC
+                                  00003a08         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueTCtoXY
+                                  00003a0c         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueXYtoTC
+                                  00003a10         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueXYtoRGB
+                                  00003a14         4   [far pointer]
+      _g_dali209_general_callback.TranslateColourValueRGBtoXY
+                                  00003a18         4   [far pointer]
+    }
+FILE=r_dali207_api
+                                  00003a1c  00003a57        3c
+  _gs_dtx_sc@1
+                                  00003a1c        30   data ,l         1
+  _gs_dt6_sc@2
+                                  00003a4c         c   data ,l         1
+FILE=r_dali209_api
+                                  00003a58  00003a97        40
+  _gs_dtx_sc@1
+                                  00003a58        30   data ,l         1
+  _gs_dt8_sc@2
+                                  00003a88        10   data ,l         1
+FILE=r_dali207
+                                  00003a98  00003b07        70
+  _fast_fade_time_ms@1@get_fast_fade_time_ms@1
+                                  00003a98        70   data ,l         1
+FILE=r_dali207_cmd
+                                  00003b08  00003c0f       108
+  _gs_execute_extended_cmd@1
+                                  00003b08        7c   data ,l         1
+  _gs_ex_command_execute_condition@2
+                                  00003b84        1f   data ,l         1
+  _gs_command_execute_condition@3
+                                  00003ba3        56   data ,l         1
+FILE=r_dali102_cmd
+                                  00003c10  00003f91       382
+  _gs_standard_command_num@1
+                                  00003c10       100   data ,l         1
+  _gs_special_command_num@2
+                                  00003d10        2c   data ,l         1
+  _gs_command_execute_condition@3
+                                  00003d3c        ac   data ,l         1
+  _gs_execute_command@4
+                                  00003de8       158   data ,l         1
+FILE=r_dali102_fade
+                                  00003f92  00004021        90
+  _fade_rate_steps_per_200ms@1@R_DALI102_FADE_GetRelativeLevel
+                                  00003f92        20   data ,l         1
+  _fade_time_ms@2@R_DALI102_FADE_GetFadeTimeMs
+                                  00003fb2        40   data ,l         1
+  _extended_fade_time_multiplier@4@R_DALI102_FADE_GetExFadeTimeMs
+                                  00003ff2        20   data ,l         1
+  _extended_fade_time_base@3@R_DALI102_FADE_GetExFadeTimeMs
+                                  00004012        10   data ,l         1
+FILE=r_dali209_cmd
+                                  00004022  000043bc       39b
+  _gs_extended_command_num@1
+                                  00004022        1f   data ,l         1
+  _gs_replacement_command@2
+                                  00004042       158   data ,l         2
+  _gs_additional_process@3
+                                  0000419a       158   data ,l         1
+  _gs_command_execute_extended_condition@4
+                                  000042f2        32   data ,l         1
+  _gs_execute_application_extended_command@5
+                                  00004324        80   data ,l         1
+
+SECTION=.text
+FILE=DefaultBuild\r_led.obj
+                                  000043bd  000043f1        35
+  _r_tau0_channel1_isr@1
+                                  000043bd        35   func ,l         0
+FILE=DefaultBuild\Config_TAU0_2_user.obj
+                                  000043f2  0000440b        1a
+  _r_Config_TAU0_2_interrupt@1
+                                  000043f2        1a   func ,l         0
+FILE=DefaultBuild\Config_TAU0_3_user.obj
+                                  0000440c  00004425        1a
+  _r_Config_TAU0_3_interrupt@1
+                                  0000440c        1a   func ,l         0
+FILE=DefaultBuild\cstart.obj
+                                  00004426  0000449c        77
+  _start
+                                  00004426         0   none ,g         0
+  _exit
+                                  0000449a         0   none ,g         1
+  _atexit
+                                  0000449c         0   none ,g         0
+FILE=DefaultBuild\r_bsp_common_ccrl.obj
+                                  0000449d  000044a8         c
+  _delay_wait
+                                  0000449d         0   none ,g         1
+  loop
+                                  0000449d         0   none ,l         2
+  check
+                                  000044a4         0   none ,l         1
+  _exit
+                                  000044a8         0   none ,l         0
+FILE=DefaultBuild\Config_DALI_user.obj
+                                  000044a9  00004530        88
+  _r_Config_DALI_interrupt_power_down_detection@1
+                                  000044a9        23   func ,l         0
+  _r_Config_DALI_interrupt_falling_edge_detection@1
+                                  000044cc        1a   func ,l         0
+  _r_Config_DALI_interrupt_stop_bit_detection@1
+                                  000044e6        4b   func ,l         0
+FILE=DefaultBuild\Config_TAU_user.obj
+                                  00004531  00004549        19
+  _r_Config_TAU_interrupt@1
+                                  00004531        19   func ,l         0
+FILE=DefaultBuild\Config_UART_user.obj
+                                  0000454a  000045ed        a4
+  _r_Config_UART_interrupt_send@1
+                                  0000454a        31   func ,l         0
+  _r_Config_UART_interrupt_receive@1
+                                  0000457b        43   func ,l         0
+  _r_Config_UART_interrupt_error@1
+                                  000045be        30   func ,l         0
+
+SECTION=.RLIB
+FILE=memcpy
+                                  000045ee  000045fd        10
+  _memcpy
+                                  000045ee         0   none ,g        25
+FILE=memset
+                                  000045fe  0000460b         e
+  _memset
+                                  000045fe         0   none ,g         5
+FILE=_COM_faddsub
+                                  0000460c  00004746       13b
+  __COM_fsub
+                                  00004668         0   none ,g         4
+  __COM_fadd
+                                  00004670         0   none ,g        20
+FILE=_COM_fdiv
+                                  00004747  00004874       12e
+  __COM_fdiv
+                                  000047a6         0   none ,g        13
+FILE=_COM_fle
+                                  00004875  0000488a        16
+  __COM_fle
+                                  00004875         0   none ,g         6
+FILE=_COM_fmul
+                                  0000488b  00004977        ed
+  __COM_fmul
+                                  000048d6         0   none ,g        2b
+FILE=_COM_ftoul
+                                  00004978  00004983         c
+  __COM_ftoul
+                                  00004978         0   none ,g        11
+FILE=_COM_llmul
+                                  00004984  000049cd        4a
+  __COM_llmul
+                                  00004984         0   none ,g         c
+  __REL_llmul_addh
+                                  000049bc         0   none ,g         2
+FILE=_COM_macsi
+                                  000049ce  000049f5        28
+  __COM_macsi
+                                  000049ce         0   none ,g         6
+FILE=_COM_sltof
+                                  000049f6  00004a0d        18
+  __COM_sltof
+                                  000049f6         0   none ,g         6
+FILE=_COM_ulldiv
+                                  00004a0e  00004a37        2a
+  __COM_ulldiv
+                                  00004a0e         0   none ,g         b
+FILE=_COM_ultof
+                                  00004a38  00004a3d         6
+  __COM_ultof
+                                  00004a38         0   none ,g        11
+FILE=_COM_lmul
+                                  00004a3e  00004a57        1a
+  __COM_lmul
+                                  00004a3e         0   none ,g        1c
+FILE=_COM_mulul
+                                  00004a58  00004aa6        4f
+  __COM_mulul
+                                  00004a58         0   none ,g         1
+FILE=_REL_fcmp
+                                  00004aa7  00004ade        38
+  __REL_fcmp
+                                  00004aa7         0   none ,g         4
+FILE=_REL_fordered_core
+                                  00004adf  00004afa        1c
+  __REL_fordered_core
+                                  00004adf         0   none ,g         5
+FILE=_REL_ftol
+                                  00004afb  00004b2f        35
+  __REL_ftol
+                                  00004afb         0   none ,g         2
+FILE=_REL_f_inf
+                                  00004b30  00004b37         8
+  __REL_f_inf
+                                  00004b30         0   none ,g         5
+FILE=_REL_f_norm
+                                  00004b38  00004b47        10
+  __REL_f_norm
+                                  00004b38         0   none ,g         3
+FILE=_REL_f_round
+                                  00004b48  00004b5a        13
+  __REL_f_round
+                                  00004b48         0   none ,g         4
+FILE=_REL_lldiv
+                                  00004b5b  00004d60       206
+  __REL_lldiv
+                                  00004b77         0   none ,g         2
+FILE=_REL_ltof
+                                  00004d61  00004daa        4a
+  __REL_ltof
+                                  00004d61         0   none ,g         2
+FILE=_COM_feq
+                                  00004dab  00004dc0        16
+  __COM_feq
+                                  00004dab         0   none ,g         2
+FILE=_COM_fge
+                                  00004dc1  00004dd6        16
+  __COM_fge
+                                  00004dc1         0   none ,g         1
+FILE=_COM_flt
+                                  00004dd7  00004dec        16
+  __COM_flt
+                                  00004dd7         0   none ,g         3
+FILE=_COM_fne
+                                  00004ded  00004dfd        11
+  __COM_fne
+                                  00004ded         0   none ,g         3
+FILE=_COM_ftosl
+                                  00004dfe  00004e05         8
+  __COM_ftosl
+                                  00004dfe         0   none ,g         1
+FILE=_COM_funordered
+                                  00004e06  00004e10         b
+  __COM_funordered
+                                  00004e06         0   none ,g         1
+FILE=_COM_lshr
+                                  00004e11  00004e31        21
+  __COM_lshr
+                                  00004e1b         0   none ,g         1
+FILE=_COM_sidiv
+                                  00004e32  00004e53        22
+  __COM_sidiv
+                                  00004e34         0   none ,g         2
+FILE=_COM_sirem
+                                  00004e54  00004e73        20
+  __COM_sirem
+                                  00004e54         0   none ,g         1
+FILE=_COM_sldiv
+                                  00004e74  00004ec2        4f
+  __COM_sldiv
+                                  00004e79         0   none ,g         2
+FILE=_COM_slldiv
+                                  00004ec3  00004f15        53
+  __COM_slldiv
+                                  00004ec3         0   none ,g         5
+FILE=_COM_uidiv
+                                  00004f16  00004f23         e
+  __COM_uidiv
+                                  00004f18         0   none ,g         2
+FILE=_COM_uldiv
+                                  00004f24  00004f42        1f
+  __COM_uldiv
+                                  00004f29         0   none ,g         3
+FILE=_COM_ullrem
+                                  00004f43  00004f73        31
+  __COM_ullrem
+                                  00004f43         0   none ,g         1
+FILE=_REL_llrem
+                                  00004f74  00005177       204
+  __REL_llrem
+                                  00004f91         0   none ,g         1
+FILE=_REL_llrev
+                                  00005178  00005197        20
+  __REL_llrev
+                                  00005178         0   none ,g         3
+FILE=_REL_ltosl
+                                  00005198  000051bc        25
+  __REL_ltosl
+                                  00005198         0   none ,g         1
+
+SECTION=.SLIB
+FILE=sprintf
+                                  000051bd  00005278        bc
+  _sprintf
+                                  000051bd        a4   func ,g         6
+  __REL_sp@1
+                                  00005261        18   func ,l         2
+FILE=strlen
+                                  00005279  00005283         b
+  _strlen
+                                  00005279         0   none ,g         3
+FILE=_REL_print
+                                  00005284  00006ebd      1c3a
+  __REL_print
+                                  00005284      133b   func ,g         1
+  __CommonCode@115
+                                  000065bf         4   func ,l         c
+  __CommonCode@112
+                                  000065c3         7   func ,l         2
+  __CommonCode@110
+                                  000065ca         5   func ,l         2
+  __CommonCode@109
+                                  000065cf         5   func ,l         2
+  __CommonCode@102
+                                  000065d4         7   func ,l         4
+  __CommonCode@101
+                                  000065db         4   func ,l         2
+  __CommonCode@114
+                                  000065df         9   func ,l         2
+  __CommonCode@100
+                                  000065e8         7   func ,l         2
+  __CommonCode@99
+                                  000065ef         5   func ,l         5
+  __CommonCode@98
+                                  000065f4         4   func ,l         4
+  __CommonCode@107
+                                  000065f8         8   func ,l         2
+  __CommonCode@96
+                                  00006600         8   func ,l         4
+  __CommonCode@95
+                                  00006608         4   func ,l         3
+  __CommonCode@88
+                                  0000660c         2   func ,l         3
+  __CommonCode@103
+                                  0000660e         3   func ,l        11
+  __CommonCode@81
+                                  00006611         4   func ,l         4
+  __CommonCode@79
+                                  00006615         4   func ,l         5
+  __CommonCode@78
+                                  00006619         5   func ,l         2
+  __CommonCode@94
+                                  0000661e         8   func ,l         2
+  __CommonCode@93
+                                  00006626         7   func ,l         4
+  __CommonCode@77
+                                  0000662d         d   func ,l         2
+  __CommonCode@76
+                                  0000663a         9   func ,l         2
+  __CommonCode@89
+                                  00006643         7   func ,l         2
+  __CommonCode@113
+                                  0000664a         4   func ,l         2
+  __CommonCode@117
+                                  0000664e         6   func ,l         5
+  __CommonCode@75
+                                  00006654         6   func ,l         2
+  __CommonCode@74
+                                  0000665a         6   func ,l         2
+  __CommonCode@73
+                                  00006660         a   func ,l         6
+  __CommonCode@72
+                                  0000666a         9   func ,l         2
+  __CommonCode@71
+                                  00006673         e   func ,l         2
+  __CommonCode@70
+                                  00006681         7   func ,l         3
+  __CommonCode@69
+                                  00006688         c   func ,l         2
+  __CommonCode@68
+                                  00006694         4   func ,l         2
+  __CommonCode@91
+                                  00006698         8   func ,l         2
+  __CommonCode@67
+                                  000066a0         5   func ,l         2
+  __CommonCode@90
+                                  000066a5         a   func ,l         2
+  __CommonCode@92
+                                  000066af         6   func ,l         3
+  __CommonCode@104
+                                  000066b5         7   func ,l         2
+  __CommonCode@66
+                                  000066bc         a   func ,l         2
+  __CommonCode@65
+                                  000066c6         a   func ,l         2
+  __CommonCode@64
+                                  000066d0        24   func ,l         2
+  __CommonCode@63
+                                  000066f4        1e   func ,l         2
+  __CommonCode@62
+                                  00006712         d   func ,l         2
+  __CommonCode@61
+                                  0000671f        11   func ,l         2
+  __CommonCode@60
+                                  00006730         3   func ,l         2
+  __CommonCode@111
+                                  00006733         6   func ,l         5
+  __CommonCode@59
+                                  00006739         9   func ,l         2
+  __CommonCode@58
+                                  00006742         8   func ,l         5
+  __CommonCode@57
+                                  0000674a         c   func ,l         2
+  __CommonCode@56
+                                  00006756         a   func ,l         2
+  __CommonCode@55
+                                  00006760         5   func ,l         3
+  __CommonCode@54
+                                  00006765         7   func ,l         2
+  __CommonCode@53
+                                  0000676c        10   func ,l         2
+  __CommonCode@52
+                                  0000677c         a   func ,l         2
+  __CommonCode@51
+                                  00006786         8   func ,l         2
+  __CommonCode@50
+                                  0000678e         9   func ,l         2
+  __CommonCode@49
+                                  00006797         9   func ,l         2
+  __CommonCode@48
+                                  000067a0         d   func ,l         2
+  __CommonCode@47
+                                  000067ad         4   func ,l         4
+  __CommonCode@45
+                                  000067b1         a   func ,l         2
+  __CommonCode@43
+                                  000067bb         5   func ,l         2
+  __CommonCode@42
+                                  000067c0         2   func ,l         2
+  __CommonCode@87
+                                  000067c2         8   func ,l         3
+  __CommonCode@41
+                                  000067ca         6   func ,l         3
+  __CommonCode@40
+                                  000067d0         7   func ,l         2
+  __CommonCode@39
+                                  000067d7         8   func ,l         2
+  __CommonCode@38
+                                  000067df         6   func ,l         4
+  __CommonCode@37
+                                  000067e5         5   func ,l         2
+  __CommonCode@36
+                                  000067ea         5   func ,l         2
+  __CommonCode@35
+                                  000067ef         5   func ,l         6
+  __CommonCode@34
+                                  000067f4         f   func ,l         2
+  __CommonCode@33
+                                  00006803        16   func ,l         2
+  __CommonCode@84
+                                  00006819         e   func ,l         2
+  __CommonCode@85
+                                  00006827        11   func ,l         2
+  __CommonCode@32
+                                  00006838         7   func ,l         2
+  __CommonCode@108
+                                  0000683f         6   func ,l         4
+  __CommonCode@31
+                                  00006845        18   func ,l         2
+  __CommonCode@30
+                                  0000685d         7   func ,l         2
+  __CommonCode@29
+                                  00006864         a   func ,l         2
+  __CommonCode@28
+                                  0000686e         9   func ,l         2
+  __CommonCode@27
+                                  00006877         7   func ,l         2
+  __CommonCode@26
+                                  0000687e         4   func ,l         3
+  __CommonCode@83
+                                  00006882         3   func ,l         2
+  __CommonCode@106
+                                  00006885         1   func ,l         2
+  __CommonCode@118
+                                  00006886         8   func ,l         7
+  __CommonCode@25
+                                  0000688e         6   func ,l         7
+  __CommonCode@23
+                                  00006894         8   func ,l         2
+  __CommonCode@80
+                                  0000689c         3   func ,l         a
+  __CommonCode@22
+                                  0000689f         d   func ,l         3
+  __CommonCode@21
+                                  000068ac         8   func ,l         2
+  __CommonCode@20
+                                  000068b4        12   func ,l         2
+  __CommonCode@19
+                                  000068c6         6   func ,l         5
+  __CommonCode@18
+                                  000068cc         6   func ,l         4
+  __CommonCode@17
+                                  000068d2         6   func ,l         3
+  __CommonCode@16
+                                  000068d8         6   func ,l         3
+  __CommonCode@15
+                                  000068de         d   func ,l         3
+  __CommonCode@14
+                                  000068eb        17   func ,l         7
+  __CommonCode@105
+                                  00006902         8   func ,l         3
+  __CommonCode@13
+                                  0000690a         7   func ,l         4
+  __CommonCode@12
+                                  00006911         c   func ,l         4
+  __CommonCode@11
+                                  0000691d         9   func ,l         2
+  __CommonCode@10
+                                  00006926         5   func ,l        12
+  __CommonCode@9
+                                  0000692b         4   func ,l         4
+  __CommonCode@8
+                                  0000692f         4   func ,l         4
+  __CommonCode@7
+                                  00006933         6   func ,l         5
+  __CommonCode@5
+                                  00006939         6   func ,l         4
+  __CommonCode@46
+                                  0000693f         4   func ,l         2
+  __REL_henkan1@1
+                                  00006943        1d   func ,l         2
+  __CommonCode@24
+                                  00006960         c   func ,l         2
+  __REL_pri@1
+                                  0000696c       22c   func ,l         2
+  __CommonCode@6
+                                  00006b98         7   func ,l         2
+  __CommonCode@4
+                                  00006b9f         7   func ,l         2
+  __CommonCode@82
+                                  00006ba6         8   func ,l         3
+  __CommonCode@3
+                                  00006bae         9   func ,l         2
+  __CommonCode@2
+                                  00006bb7         a   func ,l         2
+  __CommonCode@1
+                                  00006bc1         c   func ,l         2
+  __REL_fltgeti@1
+                                  00006bcd       1ae   func ,l         1
+  __CommonCode@44
+                                  00006d7b         7   func ,l         2
+  __REL_inmod@1
+                                  00006d82       133   func ,l         1
+  __CommonCode@0
+                                  00006eb5         9   func ,l         2
+FILE=isdigit
+                                  00006ebe  00006ec7         a
+  _isdigit
+                                  00006ebe         0   none ,g         1
+FILE=memcmp
+                                  00006ec8  00006ed9        12
+  _memcmp
+                                  00006ec8         0   none ,g         1
+
+SECTION=.textf
+FILE=DefaultBuild\r_memory_banks.obj
+                                  00006eda  000072b9       3e0
+  _R_MemoryBanks_Init
+                                  00006eda        67   func ,g         1
+  _R_MemoryBanks_NvmIsChanged
+                                  00006f41        39   func ,g         0
+  _R_MemoryBanks_Reset
+                                  00006f7a        1c   func ,g         1
+  _R_MemoryBanks_Read
+                                  00006f96       165   func ,g         1
+  _R_MemoryBanks_Write
+                                  000070fb       179   func ,g         1
+  _R_MemoryBanks_UnlatchRead
+                                  00007274        19   func ,g         2
+  _R_MemoryBanks_CancelWrite
+                                  0000728d        1a   func ,g         2
+  _bank_is_implemented@1
+                                  000072a7        13   func ,l         1
+FILE=DefaultBuild\r_random.obj
+                                  000072ba  00007344        8b
+  _R_RANDOM_Init
+                                  000072ba        1f   func ,g         1
+  _R_RANDOM_Generate
+                                  000072d9        4e   func ,g         2
+  _R_RANDOM_IncrementSeed
+                                  00007327        1e   func ,g         1
+FILE=DefaultBuild\r_cg.obj
+                                  00007345  000082c4       f80
+  _R_CG_Init
+                                  00007345        fe   func ,g         1
+  _R_CG_Load
+                                  00007443       386   func ,g         1
+  _R_CG_Start
+                                  000077c9        26   func ,g         1
+  _R_CG_Task
+                                  000077ef       579   func ,g         1
+  _update_storage0@1
+                                  00007d68        b1   func ,l         2
+  _update_storage1@1
+                                  00007e19       43b   func ,l         2
+  _memory_bank_reset@1
+                                  00008254        15   func ,l         2
+  _memory_bank_read@1
+                                  00008269        1b   func ,l         2
+  _memory_bank_write@1
+                                  00008284        23   func ,l         2
+  _memory_bank_unlatch_read@1
+                                  000082a7         f   func ,l         2
+  _memory_bank_cancel_write@1
+                                  000082b6         f   func ,l         2
+FILE=DefaultBuild\r_debug.obj
+                                  000082c5  00008447       183
+  _R_DEBUG_Init
+                                  000082c5         b   func ,g         0
+  _R_DEBUG_NvmIsValid
+                                  000082d0         2   func ,g         1
+  _R_DEBUG_NvmIsChanged
+                                  000082d2         4   func ,g         1
+  _R_DEBUG_ClearChangeFlag
+                                  000082d6         4   func ,g         1
+  _R_DEBUG_SetNvm
+                                  000082da         8   func ,g         1
+  _R_DEBUG_GetNvm
+                                  000082e2         8   func ,g         2
+  _R_DEBUG_ChangeStatus
+                                  000082ea       145   func ,g         0
+  _R_DEBUG_GetLampStatus
+                                  0000842f         4   func ,g         0
+  _R_DEBUG_GetControlGearStatus
+                                  00008433         4   func ,g         1
+  _R_DEBUG_GetFailureProcedure
+                                  00008437         4   func ,g         4
+  _R_DEBUG_ReferenceMeasurementIsFinished
+                                  0000843b         d   func ,g         1
+FILE=DefaultBuild\r_main.obj
+                                  00008448  00008b46       6ff
+  _main
+                                  00008448        31   func ,g         1
+  _send_main
+                                  00008479        39   func ,g         1
+  _QE4LigHTHING_COMM_AnalysisPacket
+                                  000084b2       34c   func ,g         1
+  _getVariableData
+                                  000087fe       2c6   func ,g         1
+  _QE4LIGHTING_COMMON_GetSerialNum
+                                  00008ac4        2d   func ,g         0
+  _QE4LIGHTING_COMMON_ClearSerialNum
+                                  00008af1         8   func ,g         0
+  _receive_main
+                                  00008af9        4e   func ,g         1
+FILE=DefaultBuild\r_memory_bank.obj
+                                  00008b47  00008cf2       1ac
+  _R_MemoryBank_Init
+                                  00008b47        44   func ,g         2
+  _R_MemoryBank_NvmIsChanged
+                                  00008b8b         e   func ,g         1
+  _R_MemoryBank_Reset
+                                  00008b99        66   func ,g         1
+  _R_MemoryBank_Read
+                                  00008bff        47   func ,g         2
+  _R_MemoryBank_Write
+                                  00008c46        9a   func ,g         2
+  _R_MemoryBank_IsImplemented
+                                  00008ce0         b   func ,g         3
+  _R_MemoryBank_GetLastAccessibleLocation
+                                  00008ceb         8   func ,g         2
+FILE=DefaultBuild\r_dali101.obj
+                                  00008cf3  00008d2b        39
+  _R_DALI101_Init
+                                  00008cf3         8   func ,g         1
+  _R_DALI101_Start
+                                  00008cfb        19   func ,g         1
+  _R_DALI101_Tick1ms
+                                  00008d14         4   func ,g         0
+  _R_DALI101_Task
+                                  00008d18         8   func ,g         1
+  _R_DALI101_GetReceivedFrame
+                                  00008d20         4   func ,g         1
+  _R_DALI101_SystemFailureIsDetected
+                                  00008d24         4   func ,g         1
+  _R_DALI101_SendBackwardFrame
+                                  00008d28         4   func ,g         1
+FILE=DefaultBuild\r_dali101_bft.obj
+                                  00008d2c  00008dab        80
+  _R_Config_TAU0_3_Isr
+                                  00008d2c         8   func ,g         1
+  _R_DALI101_BFT_Init
+                                  00008d34         a   func ,g         1
+  _R_DALI101_BFT_Start
+                                  00008d3e         1   func ,g         1
+  _R_DALI101_BFT_Tick1ms
+                                  00008d3f         7   func ,g         1
+  _R_DALI101_BFT_Task
+                                  00008d46        34   func ,g         1
+  _R_DALI101_BFT_Send
+                                  00008d7a        26   func ,g         1
+  _backward_init@1
+                                  00008da0         c   func ,l         1
+FILE=DefaultBuild\r_dali101_rx.obj
+                                  00008dac  00008f4f       1a4
+  _R_Config_TAU0_2_Isr
+                                  00008dac        4e   func ,g         1
+  _R_Config_DALI_FED_ISR
+                                  00008dfa        1b   func ,g         1
+  _R_Config_DALI_BPD_ISR
+                                  00008e15        12   func ,g         1
+  _R_Config_DALI_SDD_ISR
+                                  00008e27        11   func ,g         1
+  _R_DALI101_RX_Init
+                                  00008e38        32   func ,g         1
+  _R_DALI101_RX_Start
+                                  00008e6a        12   func ,g         1
+  _R_DALI101_RX_Task
+                                  00008e7c        85   func ,g         1
+  _R_DALI101_RX_GetReceivedFrame
+                                  00008f01        42   func ,g         1
+  _R_DALI101_RX_SystemFailureIsDetected
+                                  00008f43         d   func ,g         1
+FILE=DefaultBuild\r_led.obj
+                                  00008f50  0000947c       52d
+  _R_LED_Init
+                                  00008f50        79   func ,g         1
+  _R_LED_Start
+                                  00008fc9        1c   func ,g         1
+  _R_LED_SetLevel
+                                  00008fe5        19   func ,g        11
+  _R_LED_IsOn
+                                  00008ffe        17   func ,g         c
+  _R_LED_IsFailed
+                                  00009015        17   func ,g         3
+  _led1_feedback_operation@1
+                                  0000902c       170   func ,l         1
+  _led2_feedback_operation@1
+                                  0000919c       170   func ,l         1
+  _led3_feedback_operation@1
+                                  0000930c       171   func ,l         1
+FILE=DefaultBuild\r_led1.obj
+                                  0000947d  000094f1        75
+  _R_LED1_Init
+                                  0000947d        26   func ,g         1
+  _R_LED1_SetLevel
+                                  000094a3        47   func ,g         1
+  _R_LED1_IsFailed
+                                  000094ea         8   func ,g         1
+FILE=DefaultBuild\r_led2.obj
+                                  000094f2  00009566        75
+  _R_LED2_Init
+                                  000094f2        26   func ,g         1
+  _R_LED2_SetLevel
+                                  00009518        47   func ,g         1
+  _R_LED2_IsFailed
+                                  0000955f         8   func ,g         1
+FILE=DefaultBuild\r_led3.obj
+                                  00009567  000095db        75
+  _R_LED3_Init
+                                  00009567        26   func ,g         1
+  _R_LED3_SetLevel
+                                  0000958d        47   func ,g         1
+  _R_LED3_IsFailed
+                                  000095d4         8   func ,g         1
+FILE=DefaultBuild\r_port.obj
+                                  000095dc  00009648        6d
+  _R_PORT_PinWrite
+                                  000095dc        3c   func ,g         0
+  _R_PORT_PinRead
+                                  00009618        31   func ,g         1
+FILE=DefaultBuild\r_timer16.obj
+                                  00009649  00009680        38
+  _R_TIMER16_Init
+                                  00009649         8   func ,g         5
+  _R_TIMER16_Tick
+                                  00009651         f   func ,g         3
+  _R_TIMER16_Start
+                                  00009660         4   func ,g         8
+  _R_TIMER16_Stop
+                                  00009664         8   func ,g         4
+  _R_TIMER16_IsRunning
+                                  0000966c         a   func ,g         3
+  _R_TIMER16_Expires
+                                  00009676         b   func ,g         5
+FILE=DefaultBuild\Config_ADC.obj
+                                  00009681  00009741        c1
+  _R_Config_ADC_Create
+                                  00009681        9f   func ,g         1
+  _R_Config_ADC_ADS0_Execute
+                                  00009720        22   func ,g         0
+FILE=DefaultBuild\Config_ADC_user.obj
+                                  00009742  00009742         1
+  _R_Config_ADC_Create_UserInit
+                                  00009742         1   func ,g         1
+FILE=DefaultBuild\Config_COMP0.obj
+                                  00009743  0000979b        59
+  _R_Config_COMP0_Create
+                                  00009743        36   func ,g         1
+  _R_Config_COMP0_Start
+                                  00009779        1e   func ,g         1
+  _R_Config_COMP0_Stop
+                                  00009797         5   func ,g         0
+FILE=DefaultBuild\Config_COMP0_user.obj
+                                  0000979c  0000979c         1
+  _R_Config_COMP0_Create_UserInit
+                                  0000979c         1   func ,g         1
+FILE=DefaultBuild\Config_COMP1.obj
+                                  0000979d  000097f5        59
+  _R_Config_COMP1_Create
+                                  0000979d        36   func ,g         1
+  _R_Config_COMP1_Start
+                                  000097d3        1e   func ,g         1
+  _R_Config_COMP1_Stop
+                                  000097f1         5   func ,g         0
+FILE=DefaultBuild\Config_COMP1_user.obj
+                                  000097f6  000097f6         1
+  _R_Config_COMP1_Create_UserInit
+                                  000097f6         1   func ,g         1
+FILE=DefaultBuild\Config_COMP2.obj
+                                  000097f7  00009851        5b
+  _R_Config_COMP2_Create
+                                  000097f7        38   func ,g         1
+  _R_Config_COMP2_Start
+                                  0000982f        1e   func ,g         1
+  _R_Config_COMP2_Stop
+                                  0000984d         5   func ,g         0
+FILE=DefaultBuild\Config_COMP2_user.obj
+                                  00009852  00009852         1
+  _R_Config_COMP2_Create_UserInit
+                                  00009852         1   func ,g         1
+FILE=DefaultBuild\Config_DAC0.obj
+                                  00009853  00009888        36
+  _R_Config_DAC0_Create
+                                  00009853        26   func ,g         1
+  _R_Config_DAC0_Start
+                                  00009879         5   func ,g         1
+  _R_Config_DAC0_Stop
+                                  0000987e         5   func ,g         0
+  _R_Config_DAC0_Set_ConversionValue_10bit
+                                  00009883         6   func ,g         0
+FILE=DefaultBuild\Config_DAC0_user.obj
+                                  00009889  00009889         1
+  _R_Config_DAC0_Create_UserInit
+                                  00009889         1   func ,g         1
+FILE=DefaultBuild\Config_PGA.obj
+                                  0000988a  000098d7        4e
+  _R_Config_PGA_Create
+                                  0000988a        2b   func ,g         1
+  _R_Config_PGA_Start
+                                  000098b5        1e   func ,g         0
+  _R_Config_PGA_Stop
+                                  000098d3         5   func ,g         0
+FILE=DefaultBuild\Config_PGA_user.obj
+                                  000098d8  000098d8         1
+  _R_Config_PGA_Create_UserInit
+                                  000098d8         1   func ,g         1
+FILE=DefaultBuild\Config_PORT.obj
+                                  000098d9  00009969        91
+  _R_Config_PORT_Create
+                                  000098d9        91   func ,g         1
+FILE=DefaultBuild\Config_PORT_user.obj
+                                  0000996a  0000996a         1
+  _R_Config_PORT_Create_UserInit
+                                  0000996a         1   func ,g         1
+FILE=DefaultBuild\Config_TAU0_1.obj
+                                  0000996b  000099e6        7c
+  _R_Config_TAU0_1_Create
+                                  0000996b        5a   func ,g         1
+  _R_Config_TAU0_1_Start
+                                  000099c5        11   func ,g         1
+  _R_Config_TAU0_1_Stop
+                                  000099d6        11   func ,g         0
+FILE=DefaultBuild\Config_TAU0_1_user.obj
+                                  000099e7  000099e7         1
+  _R_Config_TAU0_1_Create_UserInit
+                                  000099e7         1   func ,g         1
+FILE=DefaultBuild\Config_TAU0_2.obj
+                                  000099e8  00009a63        7c
+  _R_Config_TAU0_2_Create
+                                  000099e8        5a   func ,g         1
+  _R_Config_TAU0_2_Start
+                                  00009a42        11   func ,g         3
+  _R_Config_TAU0_2_Stop
+                                  00009a53        11   func ,g         4
+FILE=DefaultBuild\Config_TAU0_2_user.obj
+                                  00009a64  00009a64         1
+  _R_Config_TAU0_2_Create_UserInit
+                                  00009a64         1   func ,g         1
+FILE=DefaultBuild\Config_TAU0_3.obj
+                                  00009a65  00009ae6        82
+  _R_Config_TAU0_3_Create
+                                  00009a65        60   func ,g         1
+  _R_Config_TAU0_3_Start
+                                  00009ac5        11   func ,g         1
+  _R_Config_TAU0_3_Stop
+                                  00009ad6        11   func ,g         1
+FILE=DefaultBuild\Config_TAU0_3_user.obj
+                                  00009ae7  00009ae7         1
+  _R_Config_TAU0_3_Create_UserInit
+                                  00009ae7         1   func ,g         1
+FILE=DefaultBuild\Config_TKB0.obj
+                                  00009ae8  00009bea       103
+  _R_Config_TKB0_Create
+                                  00009ae8        b0   func ,g         1
+  _R_Config_TKB0_Start
+                                  00009b98         d   func ,g         1
+  _R_Config_TKB0_Stop
+                                  00009ba5         9   func ,g         0
+  _R_Config_TKB0_TKBO00_DitheringFunction_Start
+                                  00009bae         9   func ,g         0
+  _R_Config_TKB0_TKBO00_DitheringFunction_Stop
+                                  00009bb7         a   func ,g         0
+  _R_Config_TKB0_TKBO01_DitheringFunction_Start
+                                  00009bc1         9   func ,g         0
+  _R_Config_TKB0_TKBO01_DitheringFunction_Stop
+                                  00009bca         a   func ,g         0
+  _R_Config_TKB0_Set_BatchOverwriteRequestOn
+                                  00009bd4         5   func ,g         4
+  _R_Config_TKB0_TKBO00_Forced_Output_Stop_Function1_Start
+                                  00009bd9         4   func ,g         0
+  _R_Config_TKB0_TKBO00_Forced_Output_Stop_Function1_Stop
+                                  00009bdd         4   func ,g         0
+  _R_Config_TKB0_TKBO01_Forced_Output_Stop_Function1_Start
+                                  00009be1         5   func ,g         0
+  _R_Config_TKB0_TKBO01_Forced_Output_Stop_Function1_Stop
+                                  00009be6         5   func ,g         0
+FILE=DefaultBuild\Config_TKB0_user.obj
+                                  00009beb  00009beb         1
+  _R_Config_TKB0_Create_UserInit
+                                  00009beb         1   func ,g         1
+FILE=DefaultBuild\Config_TKB1.obj
+                                  00009bec  00009cab        c0
+  _R_Config_TKB1_Create
+                                  00009bec        8b   func ,g         1
+  _R_Config_TKB1_Start
+                                  00009c77         c   func ,g         1
+  _R_Config_TKB1_Stop
+                                  00009c83         9   func ,g         0
+  _R_Config_TKB1_TKBO10_DitheringFunction_Start
+                                  00009c8c         9   func ,g         0
+  _R_Config_TKB1_TKBO10_DitheringFunction_Stop
+                                  00009c95         a   func ,g         0
+  _R_Config_TKB1_Set_BatchOverwriteRequestOn
+                                  00009c9f         5   func ,g         2
+  _R_Config_TKB1_TKBO10_Forced_Output_Stop_Function1_Start
+                                  00009ca4         4   func ,g         0
+  _R_Config_TKB1_TKBO10_Forced_Output_Stop_Function1_Stop
+                                  00009ca8         4   func ,g         0
+FILE=DefaultBuild\Config_TKB1_user.obj
+                                  00009cac  00009cac         1
+  _R_Config_TKB1_Create_UserInit
+                                  00009cac         1   func ,g         1
+FILE=DefaultBuild\Config_WDT.obj
+                                  00009cad  00009cba         e
+  _R_Config_WDT_Create
+                                  00009cad         a   func ,g         1
+  _R_Config_WDT_Restart
+                                  00009cb7         4   func ,g         1
+FILE=DefaultBuild\Config_WDT_user.obj
+                                  00009cbb  00009cbb         1
+  _R_Config_WDT_Create_UserInit
+                                  00009cbb         1   func ,g         1
+FILE=DefaultBuild\r_cg_ad_common.obj
+                                  00009cbc  00009ccf        14
+  _R_ADC_Set_PowerOn
+                                  00009cbc         5   func ,g         0
+  _R_ADC_Set_PowerOff
+                                  00009cc1         5   func ,g         0
+  _R_ADC_Set_Reset
+                                  00009cc6         5   func ,g         0
+  _R_ADC_Release_Reset
+                                  00009ccb         5   func ,g         0
+FILE=DefaultBuild\r_cg_da_common.obj
+                                  00009cd0  00009ceb        1c
+  _R_DAC_Create
+                                  00009cd0         8   func ,g         1
+  _R_DAC_Set_PowerOn
+                                  00009cd8         5   func ,g         0
+  _R_DAC_Set_PowerOff
+                                  00009cdd         5   func ,g         0
+  _R_DAC_Set_Reset
+                                  00009ce2         5   func ,g         0
+  _R_DAC_Release_Reset
+                                  00009ce7         5   func ,g         0
+FILE=DefaultBuild\r_cg_pgacomp_common.obj
+                                  00009cec  00009d13        28
+  _R_PGACOMP_Create
+                                  00009cec        14   func ,g         1
+  _R_PGACOMP_Set_PowerOn
+                                  00009d00         5   func ,g         0
+  _R_PGACOMP_Set_PowerOff
+                                  00009d05         5   func ,g         0
+  _R_PGACOMP_Set_Reset
+                                  00009d0a         5   func ,g         0
+  _R_PGACOMP_Release_Reset
+                                  00009d0f         5   func ,g         0
+FILE=DefaultBuild\r_cg_sau_common.obj
+                                  00009d14  00009d5e        4b
+  _R_SAU0_Create
+                                  00009d14         8   func ,g         1
+  _R_SAU1_Create
+                                  00009d1c         5   func ,g         0
+  _R_SAU0_Set_PowerOn
+                                  00009d21         5   func ,g         0
+  _R_SAU0_Set_PowerOff
+                                  00009d26         5   func ,g         0
+  _R_SAU1_Set_PowerOn
+                                  00009d2b         5   func ,g         0
+  _R_SAU1_Set_PowerOff
+                                  00009d30         5   func ,g         0
+  _R_SAU0_Set_Reset
+                                  00009d35         5   func ,g         0
+  _R_SAU0_Release_Reset
+                                  00009d3a         5   func ,g         0
+  _R_SAU1_Set_Reset
+                                  00009d3f         5   func ,g         0
+  _R_SAU1_Release_Reset
+                                  00009d44         5   func ,g         0
+  _R_SAU0_Set_SnoozeOn
+                                  00009d49         b   func ,g         0
+  _R_SAU0_Set_SnoozeOff
+                                  00009d54         b   func ,g         0
+FILE=DefaultBuild\r_cg_systeminit.obj
+                                  00009d5f  00009d93        35
+  _R_Systeminit
+                                  00009d5f        35   func ,g         1
+FILE=DefaultBuild\r_cg_tau_common.obj
+                                  00009d94  00009dbb        28
+  _R_TAU0_Create
+                                  00009d94        14   func ,g         1
+  _R_TAU0_Set_PowerOn
+                                  00009da8         5   func ,g         0
+  _R_TAU0_Set_PowerOff
+                                  00009dad         5   func ,g         0
+  _R_TAU0_Set_Reset
+                                  00009db2         5   func ,g         0
+  _R_TAU0_Release_Reset
+                                  00009db7         5   func ,g         0
+FILE=DefaultBuild\r_cg_tkb_common.obj
+                                  00009dbc  00009ddb        20
+  _R_TKB_Create
+                                  00009dbc         c   func ,g         1
+  _R_TKB_Set_PowerOn
+                                  00009dc8         5   func ,g         0
+  _R_TKB_Set_PowerOff
+                                  00009dcd         5   func ,g         0
+  _R_TKB_Set_Reset
+                                  00009dd2         5   func ,g         0
+  _R_TKB_Release_Reset
+                                  00009dd7         5   func ,g         0
+FILE=DefaultBuild\hdwinit.obj
+                                  00009ddc  00009de5         a
+  _hdwinit
+                                  00009ddc         a   func ,g         1
+FILE=DefaultBuild\r_bsp_init.obj
+                                  00009de6  00009dfb        16
+  _bsp_init_system
+                                  00009de6        12   func ,g         1
+  _bsp_init_hardware
+                                  00009df8         4   func ,g         1
+FILE=DefaultBuild\stkinit.obj
+                                  00009dfc  00009e3f        44
+  _stkinit
+                                  00009dfc         0   none ,g         1
+  LSTINIT1
+                                  00009e0a         0   none ,l         1
+  LSTINIT2
+                                  00009e34         0   none ,l         2
+  LSTINIT3
+                                  00009e3f         0   none ,l         2
+FILE=DefaultBuild\r_bsp_common.obj
+                                  00009e40  0000a076       237
+  _R_BSP_StartClock
+                                  00009e40         4   func ,g         0
+  _R_BSP_StopClock
+                                  00009e44         4   func ,g         0
+  _R_BSP_SetClockSource
+                                  00009e48         4   func ,g         0
+  _R_BSP_GetFclkFreqHz
+                                  00009e4c         4   func ,g         0
+  _R_BSP_ChangeClockSetting
+                                  00009e50         4   func ,g         0
+  _R_BSP_SoftwareDelay
+                                  00009e54       223   func ,g         0
+FILE=DefaultBuild\mcu_clocks.obj
+                                  0000a077  0000a6f4       67e
+  _start_clock
+                                  0000a077       10c   func ,g         1
+  _stop_clock
+                                  0000a183        30   func ,g         1
+  _set_fclk_clock_source
+                                  0000a1b3       186   func ,g         1
+  _get_fclk_freq_hz
+                                  0000a339       113   func ,g         2
+  _change_clock_setting
+                                  0000a44c       1cd   func ,g         1
+  _mcu_clock_setup
+                                  0000a619        dc   func ,g         1
+FILE=DefaultBuild\r_lamp_tc.obj
+                                  0000a6f5  0000a866       172
+  _R_LAMP_InitColourTypeTc
+                                  0000a6f5         8   func ,g         3
+  _R_LAMP_DimmingFlashTc
+                                  0000a6fd        7b   func ,g         1
+  _R_LAMP_DimmingTc
+                                  0000a778        ef   func ,g         1
+FILE=DefaultBuild\r_trng.obj
+                                  0000a867  0000a8a8        42
+  _R_TRNG_Create
+                                  0000a867         5   func ,g         1
+  _R_TRNG_GenerateRandomNumber
+                                  0000a86c         9   func ,g         1
+  _R_TRNG_WaitCompletion
+                                  0000a875         7   func ,g         1
+  _R_TRNG_GetRandomNumber
+                                  0000a87c        2d   func ,g         1
+FILE=DefaultBuild\r_lamp.obj
+                                  0000a8a9  0000b3ea       b42
+  _R_LAMP_Init
+                                  0000a8a9        31   func ,g         1
+  _R_LAMP_Start
+                                  0000a8da         4   func ,g         1
+  _R_LAMP_Tick1ms
+                                  0000a8de         e   func ,g         0
+  _R_LAMP_Task
+                                  0000a8ec        d8   func ,g         1
+  _R_LAMP_IsOn
+                                  0000a9c4        4f   func ,g         1
+  _R_LAMP_IsFailure
+                                  0000aa13        4a   func ,g         1
+  _R_LAMP_IsFailureSpecified
+                                  0000aa5d        41   func ,g        10
+  _R_LAMP_IsStartup
+                                  0000aa9e         7   func ,g         3
+  _R_LAMP_Startup
+                                  0000aaa5        5d   func ,g         6
+  _R_LAMP_SetActiveColourSpace
+                                  0000ab02         4   func ,g         3
+  _R_LAMP_SetDimmingCurve
+                                  0000ab06         4   func ,g         1
+  _R_LAMP_SetDimmingLevelTc
+                                  0000ab0a         8   func ,g         1
+  _R_LAMP_SetDimmingLevelXy
+                                  0000ab12         c   func ,g         1
+  _R_LAMP_SetDimmingLevelRgbwaf
+                                  0000ab1e        1a   func ,g         1
+  _R_LAMP_GetDimmingRate
+                                  0000ab38        1b   func ,g         2
+  _R_LAMP_ColourIsAttainable
+                                  0000ab53         2   func ,g         2
+  _R_LAMP_TranslateColourValueTCtoRGB
+                                  0000ab55       122   func ,g         2
+  _R_LAMP_TranslateColourValueRGBtoTC
+                                  0000ac77       2ce   func ,g         2
+  _R_LAMP_TranslateColourValueTCtoXY
+                                  0000af45        85   func ,g         2
+  _R_LAMP_TranslateColourValueXYtoTC
+                                  0000afca       127   func ,g         2
+  _R_LAMP_TranslateColourValueXYtoRGB
+                                  0000b0f1        bd   func ,g         2
+  _R_LAMP_TranslateColourValueRGBtoXY
+                                  0000b1ae       219   func ,g         2
+  _R_LAMP_EnableFlashing
+                                  0000b3c7        15   func ,g         1
+  _R_LAMP_DisableFlashing
+                                  0000b3dc         7   func ,g         1
+  _R_LAMP_EnableCurrentProtector
+                                  0000b3e3         4   func ,g         1
+  _R_LAMP_DisableCurrentProtector
+                                  0000b3e7         4   func ,g         1
+FILE=DefaultBuild\r_lamp_rgbwaf.obj
+                                  0000b3eb  0000b8c6       4dc
+  _R_LAMP_InitColourTypeRgbwaf
+                                  0000b3eb         b   func ,g         3
+  _R_LAMP_DimmingFlashRgbwaf
+                                  0000b3f6        b6   func ,g         1
+  _R_LAMP_DimmingRgbwaf
+                                  0000b4ac       41b   func ,g         1
+FILE=DefaultBuild\r_lamp_xy.obj
+                                  0000b8c7  0000bfa6       6e0
+  _R_LAMP_InitColourTypeXy
+                                  0000b8c7         b   func ,g         3
+  _R_LAMP_DimmingFlashXy
+                                  0000b8d2        a6   func ,g         1
+  _R_LAMP_DimmingXy
+                                  0000b978       3ee   func ,g         1
+  _R_LAMP_CalculateForLinerRgbFromXy
+                                  0000bd66       241   func ,g         2
+FILE=DefaultBuild\Config_DALI.obj
+                                  0000bfa7  0000c10f       169
+  _R_Config_DALI_Create
+                                  0000bfa7        a3   func ,g         1
+  _R_Config_DALI_Start
+                                  0000c04a        2c   func ,g         1
+  _R_Config_DALI_Stop
+                                  0000c076        20   func ,g         0
+  _R_Config_DALI_Softwarereset
+                                  0000c096         5   func ,g         0
+  _R_Config_DALI_Send8bit
+                                  0000c09b        38   func ,g         1
+  _R_Config_DALI_GetReceivedFrame
+                                  0000c0d3        28   func ,g         1
+  _R_Config_DALI_IsBusPowerDown
+                                  0000c0fb         9   func ,g         1
+  _R_Config_DALI_EnableForceActiveState
+                                  0000c104         7   func ,g         1
+  _R_Config_DALI_DisableForceActiveState
+                                  0000c10b         5   func ,g         1
+FILE=DefaultBuild\Config_DALI_user.obj
+                                  0000c110  0000c110         1
+  _R_Config_DALI_Create_UserInit
+                                  0000c110         1   func ,g         1
+FILE=DefaultBuild\Config_TAU.obj
+                                  0000c111  0000c178        68
+  _R_Config_TAU_Create
+                                  0000c111        46   func ,g         1
+  _R_Config_TAU_Start
+                                  0000c157        11   func ,g         1
+  _R_Config_TAU_Stop
+                                  0000c168        11   func ,g         1
+FILE=DefaultBuild\Config_TAU_user.obj
+                                  0000c179  0000c185         d
+  _R_Config_TAU_Create_UserInit
+                                  0000c179         1   func ,g         1
+  _r_Config_TAU_getTImerFlag
+                                  0000c17a         4   func ,g         1
+  _r_Config_TAU_setTImerFlag
+                                  0000c17e         4   func ,g         2
+  _r_Config_TAU_setMaxCount
+                                  0000c182         4   func ,g         1
+FILE=DefaultBuild\Pin.obj
+                                  0000c186  0000c238        b3
+  _R_Pins_Create
+                                  0000c186        b3   func ,g         0
+FILE=DefaultBuild\Config_UART.obj
+                                  0000c239  0000c376       13e
+  _R_Config_UART_Create
+                                  0000c239        9c   func ,g         1
+  _R_Config_UART_Start
+                                  0000c2d5        31   func ,g         1
+  _R_Config_UART_Stop
+                                  0000c306        27   func ,g         0
+  _R_Config_UART_Send
+                                  0000c32d        28   func ,g         2
+  _R_Config_UART_Receive
+                                  0000c355        18   func ,g         2
+  _R_Config_UART_Loopback_Enable
+                                  0000c36d         5   func ,g         0
+  _R_Config_UART_Loopback_Disable
+                                  0000c372         5   func ,g         0
+FILE=DefaultBuild\Config_UART_user.obj
+                                  0000c377  0000c385         f
+  _R_Config_UART_Create_UserInit
+                                  0000c377         1   func ,g         1
+  _r_Config_UART_callback_sendend@1
+                                  0000c378         4   func ,l         1
+  _r_Config_UART_callback_receiveend@1
+                                  0000c37c         4   func ,l         1
+  _r_Config_UART_callback_error@1
+                                  0000c380         1   func ,l         1
+  _r_Config_UART_callback_softwareoverrun@1
+                                  0000c381         1   func ,l         1
+  _R_Config_UART_GetReceiveCount
+                                  0000c382         4   func ,g         1
+FILE=r_dali207_api
+                                  0000c386  0000c479        f4
+  _R_DALI207_InitLibrary
+                                  0000c386         1   func ,g         1
+  _R_DALI207_InitLogicalUnit
+                                  0000c387        78   func ,g         1
+  _R_DALI207_SetNvm
+                                  0000c3ff         7   func ,g         1
+  _R_DALI207_GetNvm
+                                  0000c406         7   func ,g         2
+  _R_DALI207_NvmIsValid
+                                  0000c40d         7   func ,g         1
+  _R_DALI207_NvmIsChanged
+                                  0000c414         7   func ,g         1
+  _R_DALI207_GetStatus
+                                  0000c41b        23   func ,g         4
+  _R_DALI207_GetDimmingCurve
+                                  0000c43e         7   func ,g         1
+  _R_DALI207_SetFailureStatus
+                                  0000c445         7   func ,g         1
+  _R_DALI207_AddFailureStatus
+                                  0000c44c         7   func ,g         0
+  _R_DALI207_RemoveFailureStatus
+                                  0000c453         7   func ,g         0
+  _R_DALI207_SetOperatingMode
+                                  0000c45a         7   func ,g         0
+  _R_DALI207_AddOperatingMode
+                                  0000c461         7   func ,g         0
+  _R_DALI207_RemoveOperatingMode
+                                  0000c468         7   func ,g         0
+  _R_DALI207_FinishReferenceMeasurement
+                                  0000c46f         7   func ,g         1
+  _R_DALI207_GetLibraryVersion
+                                  0000c476         4   func ,g         0
+FILE=r_dali102_api
+                                  0000c47a  0000c88c       413
+  _R_DALI102_InitLibrary
+                                  0000c47a        51   func ,g         1
+  _R_DALI102_InitLogicalUnit
+                                  0000c4cb        c2   func ,g         1
+  _R_DALI102_NvmIsValid
+                                  0000c58d        25   func ,g         1
+  _R_DALI102_SetNvm
+                                  0000c5b2         7   func ,g         1
+  _R_DALI102_GetNvm
+                                  0000c5b9         7   func ,g         2
+  _R_DALI102_NvmIsChanged
+                                  0000c5c0         7   func ,g         1
+  _R_DALI102_NeedsToSaveNvm
+                                  0000c5c7         4   func ,g         1
+  _R_DALI102_NotifySaveNvm
+                                  0000c5cb         5   func ,g         1
+  _R_DALI102_StartPowerOnTimer
+                                  0000c5d0        a0   func ,g         1
+  __CommonCode@6
+                                  0000c670         8   func ,l         2
+  __CommonCode@1
+                                  0000c678         3   func ,l         a
+  _R_DALI102_GetOperatingMode
+                                  0000c67b         7   func ,g         1
+  _R_DALI102_Tick1ms
+                                  0000c682        64   func ,g         0
+  __CommonCode@5
+                                  0000c6e6        10   func ,l         2
+  __CommonCode@0
+                                  0000c6f6         9   func ,l         3
+  _R_DALI102_NotifyBeginStartup
+                                  0000c6ff         5   func ,g         1
+  _R_DALI102_NotifyEndStartup
+                                  0000c704         5   func ,g         1
+  _R_DALI102_SetLampOn
+                                  0000c709         7   func ,g         1
+  _R_DALI102_ClearLampOn
+                                  0000c710         7   func ,g         1
+  _R_DALI102_SetLampFailure
+                                  0000c717         7   func ,g         1
+  _R_DALI102_ClearLampFailure
+                                  0000c71e         7   func ,g         1
+  _R_DALI102_SetControlGearFailure
+                                  0000c725         7   func ,g         1
+  _R_DALI102_ClearControlGearFailure
+                                  0000c72c         7   func ,g         1
+  _R_DALI102_NotifySystemFailure
+                                  0000c733        64   func ,g         1
+  _R_DALI102_GetActualLevel
+                                  0000c797         f   func ,g         5
+  __CommonCode@4
+                                  0000c7a6         f   func ,l         2
+  _R_DALI102_GetActualLevelHighRes
+                                  0000c7b5        12   func ,g         0
+  _R_DALI102_IdentificationIsActive
+                                  0000c7c7         7   func ,g         1
+  __CommonCode@3
+                                  0000c7ce         6   func ,l         2
+  _R_DALI102_CreateCommand
+                                  0000c7d4        29   func ,g         1
+  _R_DALI102_ExecuteCommand
+                                  0000c7fd        82   func ,g         1
+  __CommonCode@2
+                                  0000c87f         a   func ,l         2
+  _R_DALI102_GetLibraryVersion
+                                  0000c889         4   func ,g         0
+FILE=r_dali209_api
+                                  0000c88d  0000cab8       22c
+  _R_DALI209_InitLibrary
+                                  0000c88d         d   func ,g         1
+  _R_DALI209_InitLogicalUnit
+                                  0000c89a       10f   func ,g         1
+  _R_DALI209_NvmIsValid
+                                  0000c9a9         7   func ,g         1
+  _R_DALI209_SetNvm
+                                  0000c9b0         f   func ,g         1
+  _R_DALI209_GetNvm
+                                  0000c9bf         7   func ,g         2
+  _R_DALI209_NvmIsChanged
+                                  0000c9c6         7   func ,g         1
+  _R_DALI209_GetActiveColourSpace
+                                  0000c9cd         5   func ,g         2
+  _R_DALI209_GetActualColourValueTc
+                                  0000c9d2        19   func ,g         2
+  __CommonCode@1
+                                  0000c9eb         b   func ,l         2
+  __CommonCode@0
+                                  0000c9f6         f   func ,l         2
+  _R_DALI209_GetActualColourValueXy
+                                  0000ca05        2c   func ,g         2
+  _R_DALI209_GetActualColourValueRgbwaf
+                                  0000ca31        84   func ,g         2
+  _R_DALI209_GetLibraryVersion
+                                  0000cab5         4   func ,g         0
+FILE=r_dali207
+                                  0000cab9  0000cb48        90
+  _R_DALI207_GetDeviceType
+                                  0000cab9         7   func ,g         2
+  _R_DALI207_GetExtendedVersionNumber
+                                  0000cac0         7   func ,g         2
+  _R_DALI207_IsReset
+                                  0000cac7         7   func ,g         2
+  _R_DALI207_ExecutePowerOnProcess
+                                  0000cace         1   func ,g         2
+  _R_DALI207_ExecuteSystemFailureProcess
+                                  0000cacf         1   func ,g         2
+  _R_DALI207_TickTimer
+                                  0000cad0         7   func ,g         2
+  _R_DALI207_GetFadeTime
+                                  0000cad7        48   func ,g         2
+  _R_DALI207_GetPhysicalMinimumLevel
+                                  0000cb1f        23   func ,g         2
+  _R_DALI207_ReferenceMeasurementIsRunning
+                                  0000cb42         7   func ,g         2
+FILE=r_dali207_cmd
+                                  0000cb49  0000cee1       399
+  _R_DALI207_StandardCommandIsIgnored
+                                  0000cb49        1c   func ,g         2
+  __CommonCode@11
+                                  0000cb65         6   func ,l         2
+  _R_DALI207_ApplicationExtendedCommandIsIgnored
+                                  0000cb6b        2e   func ,g         2
+  _R_DALI207_ExistsReplacementProcess
+                                  0000cb99         2   func ,g         2
+  _R_DALI207_ExecuteReplacementProcess
+                                  0000cb9b         3   func ,g         2
+  _R_DALI207_ExecuteAdditionalProcess
+                                  0000cb9e        1d   func ,g         2
+  _R_DALI207_ExecuteApplicationExtendedCommand
+                                  0000cbbb        28   func ,g         2
+  _cmd_reference_system_power@1
+                                  0000cbe3        3c   func ,l         2
+  __CommonCode@6
+                                  0000cc1f         5   func ,l         4
+  _cmd_enable_current_protector@1
+                                  0000cc24        16   func ,l         2
+  __CommonCode@10
+                                  0000cc3a        1a   func ,l         2
+  __CommonCode@14
+                                  0000cc54         8   func ,l         2
+  _cmd_disable_current_protector@1
+                                  0000cc5c        16   func ,l         2
+  _cmd_select_dimming_curve@1
+                                  0000cc72        b6   func ,l         2
+  __CommonCode@9
+                                  0000cd28         8   func ,l         2
+  __CommonCode@8
+                                  0000cd30         7   func ,l         5
+  __CommonCode@7
+                                  0000cd37         3   func ,l         5
+  __CommonCode@17
+                                  0000cd3a         8   func ,l         8
+  __CommonCode@5
+                                  0000cd42         8   func ,l         2
+  _cmd_store_dtr_as_fast_fade_time@1
+                                  0000cd4a        47   func ,l         2
+  __CommonCode@13
+                                  0000cd91         3   func ,l         2
+  __CommonCode@16
+                                  0000cd94         6   func ,l         3
+  _cmd_query_gear_type@1
+                                  0000cd9a         f   func ,l         2
+  _cmd_query_dimming_curve@1
+                                  0000cda9         f   func ,l         2
+  _cmd_query_possible_operating_modes@1
+                                  0000cdb8         f   func ,l         2
+  _cmd_query_features@1
+                                  0000cdc7         d   func ,l         2
+  __CommonCode@0
+                                  0000cdd4         5   func ,l         8
+  _cmd_query_failure_status@1
+                                  0000cdd9         f   func ,l         2
+  __CommonCode@1
+                                  0000cde8        10   func ,l         9
+  __CommonCode@12
+                                  0000cdf8         6   func ,l         3
+  _cmd_query_short_circuit@1
+                                  0000cdfe         d   func ,l         2
+  _cmd_query_open_circuit@1
+                                  0000ce0b         d   func ,l         2
+  _cmd_query_load_decrease@1
+                                  0000ce18         d   func ,l         2
+  _cmd_query_load_increase@1
+                                  0000ce25         b   func ,l         2
+  __CommonCode@3
+                                  0000ce30         8   func ,l         8
+  __CommonCode@4
+                                  0000ce38        13   func ,l         8
+  _cmd_query_current_protector_active@1
+                                  0000ce4b         d   func ,l         2
+  _cmd_query_thermal_shut_down@1
+                                  0000ce58         d   func ,l         2
+  _cmd_query_thermal_overload@1
+                                  0000ce65         d   func ,l         2
+  _cmd_query_reference_running@1
+                                  0000ce72        16   func ,l         2
+  __CommonCode@2
+                                  0000ce88         b   func ,l         2
+  _cmd_query_reference_measurement_failed@1
+                                  0000ce93         d   func ,l         2
+  _cmd_query_current_protector_enabled@1
+                                  0000cea0         f   func ,l         2
+  _cmd_query_operating_modes@1
+                                  0000ceaf        10   func ,l         2
+  _cmd_query_fast_fade_time@1
+                                  0000cebf        10   func ,l         2
+  _cmd_query_min_fast_fade_time@1
+                                  0000cecf        10   func ,l         2
+  _cmd_reserved@1
+                                  0000cedf         3   func ,l        10
+FILE=r_dali207_var
+                                  0000cee2  0000d03f       15e
+  _R_DALI207_VAR_Init
+                                  0000cee2        15   func ,g         1
+  _R_DALI207_VAR_Reset
+                                  0000cef7         c   func ,g         1
+  _R_DALI207_VAR_IsReset
+                                  0000cf03         f   func ,g         1
+  _R_DALI207_VAR_SetNvm
+                                  0000cf12        1a   func ,g         1
+  _R_DALI207_VAR_GetNvm
+                                  0000cf2c        1d   func ,g         1
+  _R_DALI207_VAR_NvmIsValid
+                                  0000cf49        27   func ,g         1
+  __CommonCode@1
+                                  0000cf70         d   func ,l         2
+  _R_DALI207_VAR_NvmIsChanged
+                                  0000cf7d         e   func ,g         1
+  _R_DALI207_VAR_GetMinFastFadeTime
+                                  0000cf8b         6   func ,g         2
+  _R_DALI207_VAR_SetFastFadeTime
+                                  0000cf91         7   func ,g         2
+  __CommonCode@0
+                                  0000cf98         8   func ,l         2
+  _R_DALI207_VAR_GetFastFadeTime
+                                  0000cfa0         3   func ,g         2
+  _R_DALI207_VAR_GetGearType
+                                  0000cfa3         7   func ,g         1
+  _R_DALI207_VAR_GetPossibleOperatingModes
+                                  0000cfaa         7   func ,g         1
+  _R_DALI207_VAR_GetFeatures
+                                  0000cfb1         7   func ,g         2
+  _R_DALI207_VAR_SetFailureStatus
+                                  0000cfb8         5   func ,g         1
+  _R_DALI207_VAR_GetFailureStatus
+                                  0000cfbd         4   func ,g         3
+  _R_DALI207_VAR_AddFailureStatus
+                                  0000cfc1         7   func ,g         2
+  _R_DALI207_VAR_RemoveFailureStatus
+                                  0000cfc8         9   func ,g         2
+  _R_DALI207_VAR_SetOperatingMode
+                                  0000cfd1         5   func ,g         1
+  _R_DALI207_VAR_AddOperatingMode
+                                  0000cfd6         7   func ,g         1
+  _R_DALI207_VAR_RemoveOperatingMode
+                                  0000cfdd         9   func ,g         1
+  _R_DALI207_VAR_GetOperatingMode
+                                  0000cfe6         c   func ,g         1
+  _R_DALI207_VAR_SetDimmingCurve
+                                  0000cff2         b   func ,g         2
+  _R_DALI207_VAR_GetDimmingCurve
+                                  0000cffd         4   func ,g         3
+  _R_DALI207_VAR_GetExtendedVersionNumber
+                                  0000d001         2   func ,g         1
+  _R_DALI207_VAR_GetDeviceType
+                                  0000d003         3   func ,g         1
+  _R_DALI207_VAR_EnableCurrentProtector
+                                  0000d006         f   func ,g         1
+  _R_DALI207_VAR_DisableCurrentProtector
+                                  0000d015        12   func ,g         1
+  _R_DALI207_VAR_CurrentProtectorIsEnabled
+                                  0000d027         8   func ,g         2
+  _R_DALI207_VAR_LampIsFailure
+                                  0000d02f         a   func ,g         0
+  _R_DALI207_VAR_GetPhm
+                                  0000d039         7   func ,g         1
+FILE=r_dali102
+                                  0000d040  0000d3d5       396
+  _R_DALI102_RegisterCallback
+                                  0000d040         4   func ,g         1
+  _R_DALI102_GetRandomAddress
+                                  0000d044         c   func ,g         1
+  _R_DALI102_GetFadeTimeMs
+                                  0000d050        2f   func ,g         4
+  _R_DALI102_CalcActualLevelDuringFade
+                                  0000d07f        4a   func ,g         2
+  __CommonCode@5
+                                  0000d0c9         6   func ,l         2
+  _R_DALI102_FadeTryStart
+                                  0000d0cf        48   func ,g         5
+  __CommonCode@4
+                                  0000d117         7   func ,l         2
+  _R_DALI102_Fading
+                                  0000d11e        5c   func ,g         1
+  __CommonCode@6
+                                  0000d17a         6   func ,l         4
+  __CommonCode@0
+                                  0000d180         6   func ,l         4
+  _R_DALI102_SetTargetLevelProcess
+                                  0000d186        2b   func ,g         b
+  _R_DALI102_FadeSetAbsoluteProcess
+                                  0000d1b1        5f   func ,g         2
+  _R_DALI102_FadeStopProcess
+                                  0000d210        3a   func ,g         3
+  _R_DALI102_SetLimitError
+                                  0000d24a         e   func ,g         5
+  __CommonCode@2
+                                  0000d258         5   func ,l         6
+  _R_DALI102_ClearLimitError
+                                  0000d25d         e   func ,g         6
+  _R_DALI102_EnableLimitError
+                                  0000d26b         5   func ,g         7
+  _R_DALI102_CalcTargetLevelDirectly
+                                  0000d270        5c   func ,g         5
+  _R_DALI102_GetDiscreteLevel
+                                  0000d2cc         4   func ,g         1
+  _R_DALI102_GetResetState
+                                  0000d2d0        36   func ,g         2
+  __CommonCode@3
+                                  0000d306        10   func ,l         2
+  _R_DALI102_IsEqualShortAddress
+                                  0000d316        19   func ,g         2
+  _R_DALI102_ListContains
+                                  0000d32f        1a   func ,g         3
+  _R_DALI102_PowerOnProcess
+                                  0000d349        5b   func ,g         2
+  _R_DALI102_GetPhysicalMinimumLevel
+                                  0000d3a4        10   func ,g         3
+  __CommonCode@1
+                                  0000d3b4         6   func ,l         3
+  _R_DALI102_ReferenceMeasurementIsRunning
+                                  0000d3ba         b   func ,g         1
+  _R_DALI102_FadeIsRunning
+                                  0000d3c5        11   func ,g         1
+FILE=r_dali102_cmd
+                                  0000d3d6  0000e529      1154
+  _R_DALI102_GetCommandNumber
+                                  0000d3d6        26   func ,g         1
+  _R_DALI102_GetCommandExecuteCondition
+                                  0000d3fc         8   func ,g         1
+  _R_DALI102_GetCommandFunction
+                                  0000d404         d   func ,g         1
+  _R_DALI102_IsAddressingTarget
+                                  0000d411        58   func ,g         1
+  __CommonCode@53
+                                  0000d469         9   func ,l         2
+  _R_DALI102_CommandIsIgnored
+                                  0000d472       141   func ,g         1
+  __CommonCode@78
+                                  0000d5b3         6   func ,l         4
+  __CommonCode@77
+                                  0000d5b9         6   func ,l         3
+  __CommonCode@52
+                                  0000d5bf         9   func ,l         2
+  __CommonCode@10
+                                  0000d5c8        1e   func ,l         2
+  __CommonCode@4
+                                  0000d5e6        10   func ,l         2
+  __CommonCode@66
+                                  0000d5f6         3   func ,l         2
+  __CommonCode@114
+                                  0000d5f9         2   func ,l         a
+  _R_DALI102_ExecuteCommandCommonProcess
+                                  0000d5fb        65   func ,g         8
+  _cmd_dapc@1
+                                  0000d660        87   func ,l         2
+  __CommonCode@72
+                                  0000d6e7         4   func ,l         2
+  __CommonCode@51
+                                  0000d6eb         6   func ,l         2
+  __CommonCode@34
+                                  0000d6f1         b   func ,l         2
+  _cmd_off@1
+                                  0000d6fc        23   func ,l         2
+  __CommonCode@31
+                                  0000d71f         7   func ,l         2
+  __CommonCode@30
+                                  0000d726         6   func ,l         2
+  _cmd_up@1
+                                  0000d72c        6e   func ,l         2
+  __CommonCode@42
+                                  0000d79a         b   func ,l         2
+  __CommonCode@50
+                                  0000d7a5        2e   func ,l         2
+  __CommonCode@49
+                                  0000d7d3         d   func ,l         2
+  __CommonCode@48
+                                  0000d7e0        18   func ,l         2
+  __CommonCode@75
+                                  0000d7f8         7   func ,l         2
+  __CommonCode@105
+                                  0000d7ff         a   func ,l         2
+  __CommonCode@47
+                                  0000d809         e   func ,l         2
+  __CommonCode@46
+                                  0000d817        10   func ,l         2
+  __CommonCode@45
+                                  0000d827         6   func ,l         4
+  __CommonCode@44
+                                  0000d82d         b   func ,l         2
+  __CommonCode@110
+                                  0000d838         6   func ,l         4
+  __CommonCode@43
+                                  0000d83e         b   func ,l         2
+  _cmd_down@1
+                                  0000d849        70   func ,l         2
+  _cmd_step_up@1
+                                  0000d8b9        48   func ,l         2
+  __CommonCode@41
+                                  0000d901         9   func ,l         2
+  __CommonCode@35
+                                  0000d90a        14   func ,l         2
+  __CommonCode@83
+                                  0000d91e         8   func ,l         4
+  __CommonCode@76
+                                  0000d926         e   func ,l         2
+  __CommonCode@91
+                                  0000d934         7   func ,l         6
+  _cmd_step_down@1
+                                  0000d93b        42   func ,l         2
+  __CommonCode@73
+                                  0000d97d         7   func ,l         2
+  __CommonCode@94
+                                  0000d984         4   func ,l         2
+  __CommonCode@36
+                                  0000d988         e   func ,l         2
+  __CommonCode@28
+                                  0000d996         8   func ,l         2
+  _cmd_recall_max_level@1
+                                  0000d99e        1c   func ,l         2
+  __CommonCode@37
+                                  0000d9ba         9   func ,l         2
+  __CommonCode@74
+                                  0000d9c3         a   func ,l         2
+  __CommonCode@92
+                                  0000d9cd         b   func ,l         2
+  __CommonCode@39
+                                  0000d9d8         e   func ,l         2
+  __CommonCode@89
+                                  0000d9e6         8   func ,l         2
+  __CommonCode@71
+                                  0000d9ee        10   func ,l         2
+  __CommonCode@38
+                                  0000d9fe         8   func ,l         2
+  __CommonCode@70
+                                  0000da06         a   func ,l         2
+  _cmd_recall_min_level@1
+                                  0000da10        1e   func ,l         2
+  _cmd_step_down_and_off@1
+                                  0000da2e        40   func ,l         2
+  __CommonCode@33
+                                  0000da6e         4   func ,l         2
+  __CommonCode@69
+                                  0000da72         6   func ,l         5
+  __CommonCode@90
+                                  0000da78         5   func ,l         3
+  __CommonCode@26
+                                  0000da7d         b   func ,l         2
+  __CommonCode@24
+                                  0000da88         6   func ,l         5
+  _cmd_on_and_step_up@1
+                                  0000da8e        43   func ,l         2
+  _cmd_enable_dapc_sequence@1
+                                  0000dad1        1a   func ,l         2
+  _cmd_go_to_last_active_level@1
+                                  0000daeb        19   func ,l         2
+  __CommonCode@32
+                                  0000db04        4a   func ,l         2
+  _cmd_go_to_scene@1
+                                  0000db4e        48   func ,l         2
+  _cmd_reset@1
+                                  0000db96        12   func ,l         2
+  _cmd_store_actual_level_in_dtr0@1
+                                  0000dba8        16   func ,l         2
+  __CommonCode@64
+                                  0000dbbe         9   func ,l         2
+  _cmd_save_persistent_variables@1
+                                  0000dbc7         f   func ,l         2
+  _cmd_set_operating_mode@1
+                                  0000dbd6        2e   func ,l         2
+  __CommonCode@20
+                                  0000dc04         7   func ,l         2
+  __CommonCode@63
+                                  0000dc0b         4   func ,l         3
+  __CommonCode@113
+                                  0000dc0f         6   func ,l         4
+  _cmd_reset_memory_bank@1
+                                  0000dc15        54   func ,l         2
+  __CommonCode@29
+                                  0000dc69         8   func ,l         2
+  _cmd_identify_device@1
+                                  0000dc71         f   func ,l         2
+  __CommonCode@87
+                                  0000dc80         b   func ,l         4
+  __CommonCode@95
+                                  0000dc8b         6   func ,l         3
+  _cmd_set_max_level@1
+                                  0000dc91        4b   func ,l         2
+  __CommonCode@27
+                                  0000dcdc         9   func ,l         2
+  __CommonCode@86
+                                  0000dce5         7   func ,l         2
+  __CommonCode@109
+                                  0000dcec         d   func ,l         2
+  __CommonCode@25
+                                  0000dcf9        16   func ,l         2
+  _cmd_set_min_level@1
+                                  0000dd0f        55   func ,l         2
+  _cmd_set_system_failure_level@1
+                                  0000dd64         d   func ,l         2
+  __CommonCode@58
+                                  0000dd71         5   func ,l         f
+  __CommonCode@23
+                                  0000dd76         7   func ,l         2
+  __CommonCode@68
+                                  0000dd7d         f   func ,l         2
+  __CommonCode@111
+                                  0000dd8c         8   func ,l         4
+  _cmd_set_power_on_level@1
+                                  0000dd94         f   func ,l         2
+  _cmd_set_fade_time@1
+                                  0000dda3        18   func ,l         2
+  __CommonCode@22
+                                  0000ddbb         6   func ,l         2
+  _cmd_set_fade_rate@1
+                                  0000ddc1        1a   func ,l         2
+  _cmd_set_extended_fade_time@1
+                                  0000dddb        1a   func ,l         2
+  _cmd_set_scene@1
+                                  0000ddf5        15   func ,l         2
+  __CommonCode@21
+                                  0000de0a         7   func ,l         2
+  __CommonCode@67
+                                  0000de11         7   func ,l         3
+  __CommonCode@82
+                                  0000de18         c   func ,l         2
+  _cmd_remove_from_scene@1
+                                  0000de24         e   func ,l         2
+  _cmd_add_to_group@1
+                                  0000de32        11   func ,l         2
+  __CommonCode@14
+                                  0000de43         5   func ,l         4
+  __CommonCode@54
+                                  0000de48         7   func ,l         2
+  __CommonCode@55
+                                  0000de4f         7   func ,l         2
+  __CommonCode@100
+                                  0000de56         4   func ,l         2
+  _cmd_remove_from_group@1
+                                  0000de5a        11   func ,l         2
+  _cmd_set_short_address@1
+                                  0000de6b        23   func ,l         2
+  _cmd_enable_write_memory@1
+                                  0000de8e        10   func ,l         2
+  _cmd_query_status@1
+                                  0000de9e        8c   func ,l         2
+  _cmd_query_control_gear_present@1
+                                  0000df2a         d   func ,l         2
+  __CommonCode@98
+                                  0000df37         a   func ,l         2
+  _cmd_query_lamp_failure@1
+                                  0000df41         f   func ,l         2
+  _cmd_query_lamp_power_on@1
+                                  0000df50         f   func ,l         2
+  _cmd_query_limit_error@1
+                                  0000df5f         d   func ,l         2
+  __CommonCode@15
+                                  0000df6c         1   func ,l         6
+  __CommonCode@65
+                                  0000df6d         6   func ,l         2
+  __CommonCode@19
+                                  0000df73         4   func ,l         a
+  __CommonCode@81
+                                  0000df77         8   func ,l         2
+  _cmd_query_reset_state@1
+                                  0000df7f         f   func ,l         2
+  _cmd_query_missing_short_address@1
+                                  0000df8e        10   func ,l         2
+  _cmd_query_version_number@1
+                                  0000df9e        14   func ,l         2
+  __CommonCode@61
+                                  0000dfb2         5   func ,l         3
+  __CommonCode@85
+                                  0000dfb7         4   func ,l         2
+  _cmd_query_content_dtr0@1
+                                  0000dfbb         f   func ,l         2
+  _cmd_query_device_type@1
+                                  0000dfca        34   func ,l         2
+  __CommonCode@56
+                                  0000dffe         3   func ,l         7
+  _cmd_query_physical_minimum@1
+                                  0000e001         f   func ,l         2
+  _cmd_query_power_failure@1
+                                  0000e010        10   func ,l         2
+  _cmd_query_content_dtr1@1
+                                  0000e020         f   func ,l         2
+  _cmd_query_content_dtr2@1
+                                  0000e02f         f   func ,l         2
+  _cmd_query_operating_mode@1
+                                  0000e03e         9   func ,l         2
+  __CommonCode@16
+                                  0000e047         5   func ,l         a
+  __CommonCode@17
+                                  0000e04c         7   func ,l         2
+  __CommonCode@62
+                                  0000e053         4   func ,l         4
+  _cmd_query_light_source_type@1
+                                  0000e057        4e   func ,l         2
+  __CommonCode@18
+                                  0000e0a5        13   func ,l         2
+  _cmd_query_actual_level@1
+                                  0000e0b8        37   func ,l         2
+  _cmd_query_max_level@1
+                                  0000e0ef        10   func ,l         2
+  _cmd_query_min_level@1
+                                  0000e0ff        10   func ,l         2
+  _cmd_query_power_on_level@1
+                                  0000e10f        10   func ,l         2
+  _cmd_query_system_failure_level@1
+                                  0000e11f        10   func ,l         2
+  __CommonCode@59
+                                  0000e12f         7   func ,l         8
+  _cmd_query_fade_time_fade_rate@1
+                                  0000e136        2d   func ,l         2
+  __CommonCode@5
+                                  0000e163         6   func ,l         2
+  _cmd_query_manufacturer_specific_mode@1
+                                  0000e169        17   func ,l         2
+  _cmd_query_next_device_type@1
+                                  0000e180        66   func ,l         2
+  __CommonCode@11
+                                  0000e1e6         7   func ,l         3
+  __CommonCode@97
+                                  0000e1ed         4   func ,l         3
+  _cmd_query_extended_fade_time@1
+                                  0000e1f1        10   func ,l         2
+  _cmd_query_control_gear_failure@1
+                                  0000e201        10   func ,l         2
+  _cmd_query_scene_level@1
+                                  0000e211        13   func ,l         2
+  _cmd_query_groups_0_7@1
+                                  0000e224         d   func ,l         2
+  __CommonCode@13
+                                  0000e231         7   func ,l         2
+  _cmd_query_groups_8_15@1
+                                  0000e238         e   func ,l         2
+  _cmd_query_random_address_h@1
+                                  0000e246         e   func ,l         2
+  _cmd_query_random_address_m@1
+                                  0000e254         e   func ,l         2
+  __CommonCode@12
+                                  0000e262         7   func ,l         3
+  _cmd_query_random_address_l@1
+                                  0000e269         d   func ,l         2
+  _cmd_read_memory_location@1
+                                  0000e276        2f   func ,l         2
+  __CommonCode@2
+                                  0000e2a5        20   func ,l         2
+  __CommonCode@1
+                                  0000e2c5         f   func ,l         2
+  __CommonCode@0
+                                  0000e2d4         a   func ,l         2
+  _cmd_application_extended_command@1
+                                  0000e2de         7   func ,l         2
+  _cmd_query_extended_version_number@1
+                                  0000e2e5        23   func ,l         2
+  _cmd_terminate@1
+                                  0000e308        1a   func ,l         2
+  _cmd_dtr0@1
+                                  0000e322         e   func ,l         2
+  __CommonCode@79
+                                  0000e330         5   func ,l         b
+  _cmd_initialise@1
+                                  0000e335        2e   func ,l         2
+  _cmd_randomise@1
+                                  0000e363        1c   func ,l         2
+  _cmd_compare@1
+                                  0000e37f        1a   func ,l         2
+  _cmd_withdraw@1
+                                  0000e399        12   func ,l         2
+  _cmd_ping@1
+                                  0000e3ab         3   func ,l         2
+  _cmd_searchaddrh@1
+                                  0000e3ae        13   func ,l         2
+  __CommonCode@57
+                                  0000e3c1         a   func ,l         2
+  __CommonCode@80
+                                  0000e3cb         7   func ,l         2
+  __CommonCode@96
+                                  0000e3d2         3   func ,l         2
+  __CommonCode@106
+                                  0000e3d5         4   func ,l         3
+  __CommonCode@8
+                                  0000e3d9         9   func ,l         2
+  _cmd_searchaddrm@1
+                                  0000e3e2        12   func ,l         2
+  __CommonCode@7
+                                  0000e3f4         6   func ,l         2
+  __CommonCode@9
+                                  0000e3fa         c   func ,l         2
+  _cmd_searchaddrl@1
+                                  0000e406        10   func ,l         2
+  _cmd_program_short_address@1
+                                  0000e416        2e   func ,l         2
+  __CommonCode@6
+                                  0000e444         7   func ,l         2
+  _cmd_verify_short_address@1
+                                  0000e44b        18   func ,l         2
+  _cmd_query_short_address@1
+                                  0000e463        1d   func ,l         2
+  _cmd_enable_device_type@1
+                                  0000e480        4c   func ,l         2
+  _cmd_dtr1@1
+                                  0000e4cc        11   func ,l         2
+  __CommonCode@3
+                                  0000e4dd         6   func ,l         3
+  _cmd_dtr2@1
+                                  0000e4e3        11   func ,l         2
+  _cmd_write_memory_location@1
+                                  0000e4f4        2d   func ,l         3
+  _cmd_write_memory_location_no_reply@1
+                                  0000e521         6   func ,l         2
+  _cmd_reserved@1
+                                  0000e527         3   func ,l         2
+FILE=r_dali102_dt6_if
+                                  0000e52a  0000e558        2f
+  _R_DALI102_DT6_IF_Init
+                                  0000e52a         7   func ,g         1
+  _R_DALI102_DT6_IF_GetFadeTime
+                                  0000e531         e   func ,g         1
+  _R_DALI102_DT6_IF_GetPhysicalMinimumLevel
+                                  0000e53f         9   func ,g         1
+  __CommonCode@0
+                                  0000e548         6   func ,l         2
+  _R_DALI102_DT6_IF_ReferenceMeasurementIsRunning
+                                  0000e54e         b   func ,g         1
+FILE=r_dali102_dt8_if
+                                  0000e559  0000e592        3a
+  _R_DALI102_DT8_IF_Init
+                                  0000e559         7   func ,g         1
+  _R_DALI102_DT8_IF_FadeTryStart
+                                  0000e560         a   func ,g         1
+  _R_DALI102_DT8_IF_FadeIsRunning
+                                  0000e56a         f   func ,g         1
+  _R_DALI102_DT8_IF_Fading
+                                  0000e579         9   func ,g         1
+  __CommonCode@0
+                                  0000e582         6   func ,l         3
+  _R_DALI102_DT8_IF_FadeStopProcess
+                                  0000e588         b   func ,g         1
+FILE=r_dali102_dtx_if
+                                  0000e593  0000e634        a2
+  _R_DALI102_DTX_IF_Init
+                                  0000e593         7   func ,g         2
+  _R_DALI102_DTX_IF_GetDeviceType
+                                  0000e59a         a   func ,g         4
+  _R_DALI102_DTX_IF_GetExtendedVersionNumber
+                                  0000e5a4         9   func ,g         1
+  __CommonCode@2
+                                  0000e5ad         6   func ,l         3
+  _R_DALI102_DTX_IF_IsReset
+                                  0000e5b3         b   func ,g         1
+  _R_DALI102_DTX_IF_ExecutePowerOnProcess
+                                  0000e5be         b   func ,g         1
+  _R_DALI102_DTX_IF_ExecuteSystemFailureProcess
+                                  0000e5c9         9   func ,g         1
+  __CommonCode@0
+                                  0000e5d2         6   func ,l         3
+  _R_DALI102_DTX_IF_StandardCommandIsIgnored
+                                  0000e5d8         b   func ,g         1
+  _R_DALI102_DTX_IF_ApplicationExtendedCommandIsIgnored
+                                  0000e5e3         9   func ,g         1
+  __CommonCode@1
+                                  0000e5ec         6   func ,l         3
+  _R_DALI102_DTX_IF_ExistsReplacementProcess
+                                  0000e5f2         b   func ,g         1
+  _R_DALI102_DTX_IF_ExecuteReplacementProcess
+                                  0000e5fd         f   func ,g         1
+  _R_DALI102_DTX_IF_ExecuteAdditionalProcess
+                                  0000e60c         f   func ,g         1
+  _R_DALI102_DTX_IF_ExecuteApplicationExtendedCommand
+                                  0000e61b         f   func ,g         1
+  _R_DALI102_DTX_IF_TickTimer
+                                  0000e62a         b   func ,g         1
+FILE=r_dali102_fade
+                                  0000e635  0000e841       20d
+  _R_DALI102_FADE_Init
+                                  0000e635        13   func ,g         1
+  _R_DALI102_FADE_Tick1ms
+                                  0000e648        36   func ,g         2
+  _R_DALI102_FADE_IsRunning
+                                  0000e67e         3   func ,g         6
+  _R_DALI102_FADE_IsRequested
+                                  0000e681        14   func ,g         7
+  _R_DALI102_FADE_Start
+                                  0000e695        36   func ,g         5
+  _R_DALI102_FADE_Stop
+                                  0000e6cb         6   func ,g         4
+  __CommonCode@2
+                                  0000e6d1         9   func ,l         2
+  _R_DALI102_FADE_Set
+                                  0000e6da        22   func ,g         3
+  __CommonCode@0
+                                  0000e6fc         4   func ,l         3
+  _R_DALI102_FADE_GetType
+                                  0000e700         4   func ,g         1
+  _R_DALI102_FADE_GetRelativeLevel
+                                  0000e704         8   func ,g         1
+  _R_DALI102_FADE_GetFadeTimeMs
+                                  0000e70c         c   func ,g         2
+  _R_DALI102_FADE_GetExFadeTimeMs
+                                  0000e718        22   func ,g         2
+  _R_DALI102_FADE_CalcActualLevel
+                                  0000e73a        af   func ,g         1
+  __CommonCode@1
+                                  0000e7e9         8   func ,l         2
+  _R_DALI102_FADE_InvalidFadeIsRunning
+                                  0000e7f1         4   func ,g         1
+  _division@1
+                                  0000e7f5        4d   func ,l         2
+FILE=r_dali102_list
+                                  0000e842  0000e8bd        7c
+  _R_DALI102_LIST_Init
+                                  0000e842         e   func ,g         1
+  _R_DALI102_LIST_Entry
+                                  0000e850         9   func ,g         7
+  __CommonCode@0
+                                  0000e859         5   func ,l         2
+  _R_DALI102_LIST_Next
+                                  0000e85e         7   func ,g         8
+  _R_DALI102_LIST_Add
+                                  0000e865        41   func ,g         2
+  _R_DALI102_LIST_GetSize
+                                  0000e8a6         4   func ,g         2
+  _get_cur_container@1
+                                  0000e8aa        14   func ,l         1
+FILE=r_dali102_mb_if
+                                  0000e8be  0000e92a        6d
+  _R_DALI102_MB_IF_Init
+                                  0000e8be         4   func ,g         1
+  _R_DALI102_MB_IF_Reset
+                                  0000e8c2        12   func ,g         1
+  _R_DALI102_MB_IF_Read
+                                  0000e8d4        11   func ,g         4
+  __CommonCode@1
+                                  0000e8e5         f   func ,l         2
+  _R_DALI102_MB_IF_Write
+                                  0000e8f4        13   func ,g         1
+  _R_DALI102_MB_IF_UnlatchRead
+                                  0000e907         9   func ,g         1
+  __CommonCode@0
+                                  0000e910        10   func ,l         2
+  _R_DALI102_MB_IF_CancelWrite
+                                  0000e920         b   func ,g         1
+FILE=r_dali102_timer
+                                  0000e92b  0000e9bc        92
+  _R_DALI102_TIMER8_Init
+                                  0000e92b         5   func ,g         1
+  _R_DALI102_TIMER8_Tick
+                                  0000e930         b   func ,g         1
+  _R_DALI102_TIMER8_Start
+                                  0000e93b         8   func ,g         2
+  _R_DALI102_TIMER8_Stop
+                                  0000e943         5   func ,g         1
+  _R_DALI102_TIMER8_IsRunning
+                                  0000e948         3   func ,g         1
+  __CommonCode@2
+                                  0000e94b         5   func ,l         2
+  _R_DALI102_TIMER16_Init
+                                  0000e950         4   func ,g         2
+  _R_DALI102_TIMER16_Tick
+                                  0000e954         c   func ,g         2
+  __CommonCode@1
+                                  0000e960         5   func ,l         3
+  _R_DALI102_TIMER16_Start
+                                  0000e965         9   func ,g         2
+  _R_DALI102_TIMER16_Stop
+                                  0000e96e         4   func ,g         5
+  _R_DALI102_TIMER16_IsRunning
+                                  0000e972         6   func ,g         2
+  _R_DALI102_TIMER32_Init
+                                  0000e978         0   func ,g         2
+  __CommonCode@0
+                                  0000e978         6   func ,l         2
+  _R_DALI102_TIMER32_Tick
+                                  0000e97e        22   func ,g         2
+  _R_DALI102_TIMER32_Start
+                                  0000e9a0         e   func ,g         2
+  _R_DALI102_TIMER32_Stop
+                                  0000e9ae         2   func ,g         4
+  _R_DALI102_TIMER32_IsRunning
+                                  0000e9b0         d   func ,g         4
+FILE=r_dali102_var
+                                  0000e9bd  0000ef61       5a5
+  _R_DALI102_VAR_Init
+                                  0000e9bd        74   func ,g         1
+  _R_DALI102_VAR_Reset
+                                  0000ea31        8c   func ,g         1
+  _R_DALI102_VAR_IsReset
+                                  0000eabd        63   func ,g         1
+  _R_DALI102_VAR_NvmIsValid
+                                  0000eb20        73   func ,g         1
+  _R_DALI102_VAR_SetNvm
+                                  0000eb93        66   func ,g         1
+  __CommonCode@10
+                                  0000ebf9         9   func ,l         3
+  __CommonCode@6
+                                  0000ec02        10   func ,l         2
+  _R_DALI102_VAR_GetNvm
+                                  0000ec12        68   func ,g         1
+  _R_DALI102_VAR_NvmIsChanged
+                                  0000ec7a         7   func ,g         1
+  _R_DALI102_VAR_SetActualLevel
+                                  0000ec81         5   func ,g        11
+  _R_DALI102_VAR_GetActualLevel
+                                  0000ec86         6   func ,g         8
+  _R_DALI102_VAR_SetActualLevelHighRes
+                                  0000ec8c         4   func ,g         2
+  _R_DALI102_VAR_GetActualLevelHighRes
+                                  0000ec90         3   func ,g         4
+  _R_DALI102_VAR_SetTargetLevel
+                                  0000ec93         5   func ,g         5
+  _R_DALI102_VAR_GetTargetLevel
+                                  0000ec98         4   func ,g         a
+  _R_DALI102_VAR_SetLastActiveLevel
+                                  0000ec9c         5   func ,g         3
+  _R_DALI102_VAR_GetLastActiveLevel
+                                  0000eca1         4   func ,g         2
+  _R_DALI102_VAR_SetLastLightLevel
+                                  0000eca5        13   func ,g         3
+  _R_DALI102_VAR_GetLastLightLevel
+                                  0000ecb8         4   func ,g         2
+  _R_DALI102_VAR_SetPowerOnLevel
+                                  0000ecbc        13   func ,g         2
+  _R_DALI102_VAR_GetPowerOnLevel
+                                  0000eccf         4   func ,g         2
+  _R_DALI102_VAR_SetSystemFailureLevel
+                                  0000ecd3        13   func ,g         2
+  _R_DALI102_VAR_GetSystemFailureLevel
+                                  0000ece6         4   func ,g         2
+  _R_DALI102_VAR_SetMinLevel
+                                  0000ecea        13   func ,g         3
+  _R_DALI102_VAR_GetMinLevel
+                                  0000ecfd         4   func ,g         c
+  _R_DALI102_VAR_SetMaxLevel
+                                  0000ed01        13   func ,g         3
+  __CommonCode@3
+                                  0000ed14         5   func ,l         9
+  _R_DALI102_VAR_GetMaxLevel
+                                  0000ed19         4   func ,g         d
+  _R_DALI102_VAR_SetFadeRate
+                                  0000ed1d        13   func ,g         2
+  _R_DALI102_VAR_GetFadeRate
+                                  0000ed30         4   func ,g         2
+  _R_DALI102_VAR_SetFadeTime
+                                  0000ed34        13   func ,g         2
+  _R_DALI102_VAR_GetFadeTime
+                                  0000ed47         4   func ,g         3
+  _R_DALI102_VAR_SetExtendedFadeTime
+                                  0000ed4b        2c   func ,g         2
+  __CommonCode@5
+                                  0000ed77         a   func ,l         2
+  _R_DALI102_VAR_GetExtendedFadeTime
+                                  0000ed81         6   func ,g         3
+  _R_DALI102_VAR_SetExtendedFadeTimeBase
+                                  0000ed87        14   func ,g         0
+  _R_DALI102_VAR_GetExtendedFadeTimeBase
+                                  0000ed9b         6   func ,g         0
+  _R_DALI102_VAR_SetExtendedFadeTimeMultiplier
+                                  0000eda1         f   func ,g         0
+  __CommonCode@4
+                                  0000edb0         a   func ,l         2
+  _R_DALI102_VAR_GetExtendedFadeTimeMultiplier
+                                  0000edba         8   func ,g         0
+  _R_DALI102_VAR_SetShortAddress
+                                  0000edc2        13   func ,g         2
+  _R_DALI102_VAR_GetShortAddress
+                                  0000edd5         4   func ,g         6
+  _R_DALI102_VAR_SetSearchAddress
+                                  0000edd9         8   func ,g         2
+  _R_DALI102_VAR_GetSearchAddress
+                                  0000ede1         7   func ,g         3
+  _R_DALI102_VAR_SetRandomAddress
+                                  0000ede8        22   func ,g         2
+  _R_DALI102_VAR_GetRandomAddress
+                                  0000ee0a         7   func ,g         2
+  _R_DALI102_VAR_SetOperatingMode
+                                  0000ee11        13   func ,g         1
+  _R_DALI102_VAR_GetOperatingMode
+                                  0000ee24         4   func ,g         3
+  _R_DALI102_VAR_GetDefaultOperatingMode
+                                  0000ee28         6   func ,g         0
+  _R_DALI102_VAR_SetInitialisationState
+                                  0000ee2e         5   func ,g         4
+  _R_DALI102_VAR_GetInitialisationState
+                                  0000ee33         4   func ,g         3
+  _R_DALI102_VAR_EnableWriteEnableState
+                                  0000ee37         5   func ,g         1
+  _R_DALI102_VAR_DisableWriteEnableState
+                                  0000ee3c         5   func ,g         2
+  _R_DALI102_VAR_WriteEnableStateIsEnabled
+                                  0000ee41         4   func ,g         1
+  _R_DALI102_VAR_SetControlGearFailure
+                                  0000ee45         6   func ,g         1
+  _R_DALI102_VAR_ClearControlGearFailure
+                                  0000ee4b         6   func ,g         2
+  _R_DALI102_VAR_ControlGearIsFailure
+                                  0000ee51         6   func ,g         2
+  _R_DALI102_VAR_SetLampFailure
+                                  0000ee57         6   func ,g         1
+  _R_DALI102_VAR_ClearLampFailure
+                                  0000ee5d         6   func ,g         1
+  _R_DALI102_VAR_LampIsFailure
+                                  0000ee63         8   func ,g         3
+  _R_DALI102_VAR_SetLampOn
+                                  0000ee6b         6   func ,g         1
+  __CommonCode@2
+                                  0000ee71         5   func ,l         a
+  _R_DALI102_VAR_ClearLampOn
+                                  0000ee76         6   func ,g         2
+  _R_DALI102_VAR_LampIsOn
+                                  0000ee7c         8   func ,g         5
+  _R_DALI102_VAR_SetLimitError
+                                  0000ee84         6   func ,g         1
+  _R_DALI102_VAR_ClearLimitError
+                                  0000ee8a         6   func ,g         3
+  _R_DALI102_VAR_LimitIsError
+                                  0000ee90         8   func ,g         2
+  _R_DALI102_VAR_SetPowerCycleSeen
+                                  0000ee98         6   func ,g         1
+  _R_DALI102_VAR_ClearPowerCycleSeen
+                                  0000ee9e         6   func ,g         2
+  _R_DALI102_VAR_PowerCycleIsSeen
+                                  0000eea4         8   func ,g         2
+  _R_DALI102_VAR_SetGearGroups
+                                  0000eeac        14   func ,g         1
+  _R_DALI102_VAR_GetGearGroups
+                                  0000eec0         4   func ,g         1
+  _R_DALI102_VAR_AddGearGroups
+                                  0000eec4        1e   func ,g         1
+  __CommonCode@1
+                                  0000eee2         5   func ,l         2
+  __CommonCode@9
+                                  0000eee7         9   func ,l         2
+  _R_DALI102_VAR_RemoveGearGroups
+                                  0000eef0        22   func ,g         1
+  _R_DALI102_VAR_GearGroupIsContained
+                                  0000ef12        11   func ,g         1
+  _R_DALI102_VAR_SetScene
+                                  0000ef23         e   func ,g         2
+  __CommonCode@0
+                                  0000ef31         2   func ,l         2
+  __CommonCode@8
+                                  0000ef33         7   func ,l         3
+  _R_DALI102_VAR_GetScene
+                                  0000ef3a         6   func ,g         3
+  _R_DALI102_VAR_SetDtr0
+                                  0000ef40         5   func ,g         8
+  _R_DALI102_VAR_GetDtr0
+                                  0000ef45         4   func ,g         b
+  _R_DALI102_VAR_SetDtr1
+                                  0000ef49         5   func ,g         4
+  _R_DALI102_VAR_GetDtr1
+                                  0000ef4e         4   func ,g         4
+  _R_DALI102_VAR_SetDtr2
+                                  0000ef52         5   func ,g         3
+  _R_DALI102_VAR_GetDtr2
+                                  0000ef57         4   func ,g         2
+  _R_DALI102_VAR_GetPhm
+                                  0000ef5b         7   func ,g         2
+FILE=r_dali209
+                                  0000ef62  00011c19      2cb8
+  _R_DALI209_RegisterCallback
+                                  0000ef62         4   func ,g         1
+  _R_DALI209_TranslateToLightOutput
+                                  0000ef66         e   func ,g         0
+  _R_DALI209_ColourIsAttainable
+                                  0000ef74        11   func ,g         0
+  _R_DALI209_TranslateColourValueTCtoRGB
+                                  0000ef85        11   func ,g         0
+  _R_DALI209_TranslateColourValueRGBtoTC
+                                  0000ef96        11   func ,g         0
+  _R_DALI209_TranslateColourValueTCtoXY
+                                  0000efa7        11   func ,g         0
+  _R_DALI209_TranslateColourValueXYtoTC
+                                  0000efb8        11   func ,g         0
+  _R_DALI209_TranslateColourValueXYtoRGB
+                                  0000efc9        11   func ,g         0
+  _R_DALI209_TranslateColourValueRGBtoXY
+                                  0000efda        11   func ,g         0
+  _R_DALI209_CanTranslateToLightOutput
+                                  0000efeb        14   func ,g         1
+  _R_DALI209_CanJudgeColourIsAttainable
+                                  0000efff        14   func ,g         1
+  _R_DALI209_CanTranslateColourValueTCtoRGB
+                                  0000f013        14   func ,g         0
+  _R_DALI209_CanTranslateColourValueRGBtoTC
+                                  0000f027        14   func ,g         0
+  _R_DALI209_CanTranslateColourValueTCtoXY
+                                  0000f03b        14   func ,g         0
+  _R_DALI209_CanTranslateColourValueXYtoTC
+                                  0000f04f        14   func ,g         0
+  _R_DALI209_CanTranslateColourValueXYtoRGB
+                                  0000f063        14   func ,g         0
+  _R_DALI209_CanTranslateColourValueRGBtoXY
+                                  0000f077        14   func ,g         0
+  _R_DALI209_CalcTriangleCenterPointForXy
+                                  0000f08b        8a   func ,g         1
+  _R_DALI209_SetPrimaryCoordinateForCrossJudge
+                                  0000f115       263   func ,g         1
+  _R_DALI209_CalcInRangeColour
+                                  0000f378       295   func ,g         2
+  _R_DALI209_CalcLightOutputRgbwaf
+                                  0000f60d       842   func ,g         2
+  _R_DALI209_CheckSupportedColourType
+                                  0000fe4f       340   func ,g         1
+  _R_DALI209_GetSupportedColourType
+                                  0001018f        22   func ,g         7
+  _R_DALI209_SetActiveColourType
+                                  000101b1        69   func ,g         7
+  _R_DALI209_GetActiveColourType
+                                  0001021a        54   func ,g         7
+  _R_DALI209_ActivateOnTcSpace
+                                  0001026e        ed   func ,g         8
+  _R_DALI209_ActivateOnXySpace
+                                  0001035b       1c3   func ,g         6
+  _R_DALI209_ActivateOnRgbwafSpace
+                                  0001051e       1be   func ,g         7
+  _R_DALI209_GetDeviceType
+                                  000106dc         3   func ,g         2
+  _R_DALI209_GetExtendedVersionNumber
+                                  000106df         3   func ,g         2
+  _R_DALI209_IsReset
+                                  000106e2         7   func ,g         2
+  _R_DALI209_ExecutePowerOnProcess
+                                  000106e9       250   func ,g         2
+  _R_DALI209_ExecuteSystemFailureProcess
+                                  00010939        bb   func ,g         2
+  _R_DALI209_TickTimer
+                                  000109f4         1   func ,g         2
+  _R_DALI209_FadeTryStart
+                                  000109f5        30   func ,g         2
+  _R_DALI209_FadeIsRunning
+                                  00010a25        22   func ,g         2
+  _R_DALI209_Fading
+                                  00010a47       123   func ,g         2
+  _R_DALI209_FadeStopProcess
+                                  00010b6a       152   func ,g         2
+  _R_DALI209_UpdateActualColourValue
+                                  00010cbc       282   func ,g         7
+  _R_DALI209_ColourTypeChangeToTc
+                                  00010f3e        c0   func ,g         4
+  _R_DALI209_ColourTypeChangeToXy
+                                  00010ffe        c1   func ,g         3
+  _R_DALI209_ColourTypeChangeToRgbwaf
+                                  000110bf       104   func ,g         3
+  _R_DALI209_ColourValueChangeFromTc
+                                  000111c3        e4   func ,g         3
+  _point_is_in_triangle@1
+                                  000112a7       3a8   func ,l         1
+  _lines_is_crossed@1
+                                  0001164f       281   func ,l         3
+  _get_crossed_point@1
+                                  000118d0       34a   func ,l         1
+FILE=r_dali209_cmd
+                                  00011c1a  00013b12      1ef9
+  _R_DALI209_StandardCommandIsIgnored
+                                  00011c1a         2   func ,g         2
+  _R_DALI209_ApplicationExtendedCommandIsIgnored
+                                  00011c1c        6c   func ,g         2
+  __CommonCode@115
+                                  00011c88         6   func ,l         3
+  __CommonCode@114
+                                  00011c8e         2   func ,l         2
+  __CommonCode@125
+                                  00011c90         7   func ,l         3
+  __CommonCode@7
+                                  00011c97         5   func ,l         9
+  _R_DALI209_ExistsReplacementProcess
+                                  00011c9c        1a   func ,g         2
+  _R_DALI209_ExecuteReplacementProcess
+                                  00011cb6        23   func ,g         2
+  __CommonCode@113
+                                  00011cd9        10   func ,l         2
+  _R_DALI209_ExecuteAdditionalProcess
+                                  00011ce9        21   func ,g         2
+  _R_DALI209_ExecuteApplicationExtendedCommand
+                                  00011d0a        30   func ,g         2
+  _cmd_add_dapc@1
+                                  00011d3a       111   func ,l         2
+  __CommonCode@185
+                                  00011e4b         9   func ,l         2
+  __CommonCode@148
+                                  00011e54         5   func ,l         2
+  __CommonCode@221
+                                  00011e59         c   func ,l         2
+  __CommonCode@238
+                                  00011e65         9   func ,l         2
+  __CommonCode@244
+                                  00011e6e         5   func ,l         3
+  __CommonCode@97
+                                  00011e73        13   func ,l         2
+  __CommonCode@96
+                                  00011e86         8   func ,l         2
+  __CommonCode@198
+                                  00011e8e         6   func ,l         4
+  __CommonCode@95
+                                  00011e94         a   func ,l         2
+  __CommonCode@94
+                                  00011e9e        11   func ,l         2
+  __CommonCode@233
+                                  00011eaf         6   func ,l         7
+  __CommonCode@93
+                                  00011eb5         7   func ,l         2
+  __CommonCode@188
+                                  00011ebc         c   func ,l         2
+  __CommonCode@92
+                                  00011ec8         7   func ,l         2
+  __CommonCode@91
+                                  00011ecf         6   func ,l         4
+  __CommonCode@90
+                                  00011ed5         7   func ,l         3
+  __CommonCode@89
+                                  00011edc         a   func ,l         2
+  __CommonCode@187
+                                  00011ee6         6   func ,l         2
+  __CommonCode@186
+                                  00011eec         e   func ,l         2
+  __CommonCode@88
+                                  00011efa         6   func ,l         2
+  __CommonCode@150
+                                  00011f00         6   func ,l         4
+  __CommonCode@87
+                                  00011f06         7   func ,l         2
+  __CommonCode@183
+                                  00011f0d         8   func ,l         2
+  __CommonCode@184
+                                  00011f15         8   func ,l         2
+  __CommonCode@86
+                                  00011f1d         6   func ,l         4
+  __CommonCode@85
+                                  00011f23         7   func ,l         2
+  __CommonCode@53
+                                  00011f2a         a   func ,l         2
+  __CommonCode@189
+                                  00011f34         c   func ,l         2
+  _cmd_add_off@1
+                                  00011f40         3   func ,l         2
+  _cmd_add_up@1
+                                  00011f43        d1   func ,l         2
+  __CommonCode@237
+                                  00012014         6   func ,l         4
+  __CommonCode@112
+                                  0001201a        10   func ,l         2
+  __CommonCode@111
+                                  0001202a         c   func ,l         2
+  __CommonCode@223
+                                  00012036         8   func ,l         6
+  __CommonCode@110
+                                  0001203e        11   func ,l         2
+  __CommonCode@181
+                                  0001204f         4   func ,l         6
+  __CommonCode@109
+                                  00012053         a   func ,l         2
+  __CommonCode@154
+                                  0001205d         6   func ,l         3
+  __CommonCode@108
+                                  00012063         7   func ,l         2
+  __CommonCode@107
+                                  0001206a         a   func ,l         2
+  __CommonCode@220
+                                  00012074         4   func ,l         4
+  __CommonCode@235
+                                  00012078         6   func ,l         5
+  __CommonCode@106
+                                  0001207e        15   func ,l         2
+  __CommonCode@182
+                                  00012093         8   func ,l         2
+  __CommonCode@105
+                                  0001209b         9   func ,l         2
+  __CommonCode@104
+                                  000120a4         4   func ,l         3
+  __CommonCode@103
+                                  000120a8         a   func ,l         2
+  __CommonCode@102
+                                  000120b2        23   func ,l         2
+  __CommonCode@219
+                                  000120d5         5   func ,l         2
+  __CommonCode@234
+                                  000120da         9   func ,l         2
+  __CommonCode@242
+                                  000120e3         2   func ,l         2
+  __CommonCode@243
+                                  000120e5         5   func ,l         5
+  __CommonCode@176
+                                  000120ea         8   func ,l         2
+  __CommonCode@101
+                                  000120f2         b   func ,l         2
+  __CommonCode@100
+                                  000120fd         6   func ,l         4
+  __CommonCode@99
+                                  00012103         7   func ,l         2
+  _cmd_add_down@1
+                                  0001210a        d1   func ,l         2
+  __CommonCode@145
+                                  000121db         5   func ,l         6
+  __CommonCode@75
+                                  000121e0         6   func ,l         4
+  __CommonCode@49
+                                  000121e6        1e   func ,l         5
+  _cmd_add_step_up@1
+                                  00012204         2   func ,l         2
+  _cmd_add_step_down@1
+                                  00012206         2   func ,l         2
+  __CommonCode@98
+                                  00012208        c0   func ,l         7
+  _cmd_add_recall_max_level@1
+                                  00012208         0   func ,l         2
+  __CommonCode@214
+                                  000122c8         7   func ,l         2
+  __CommonCode@180
+                                  000122cf         6   func ,l         2
+  __CommonCode@236
+                                  000122d5         7   func ,l         2
+  __CommonCode@239
+                                  000122dc         a   func ,l         4
+  __CommonCode@179
+                                  000122e6         8   func ,l         3
+  __CommonCode@178
+                                  000122ee         4   func ,l         3
+  __CommonCode@199
+                                  000122f2         9   func ,l         2
+  __CommonCode@170
+                                  000122fb         9   func ,l         2
+  __CommonCode@155
+                                  00012304         6   func ,l         4
+  __CommonCode@153
+                                  0001230a         7   func ,l         4
+  __CommonCode@152
+                                  00012311         e   func ,l         2
+  __CommonCode@149
+                                  0001231f         6   func ,l         4
+  __CommonCode@147
+                                  00012325         a   func ,l         3
+  __CommonCode@218
+                                  0001232f         7   func ,l         2
+  __CommonCode@146
+                                  00012336         6   func ,l         4
+  _cmd_add_recall_min_level@1
+                                  0001233c         3   func ,l         2
+  _cmd_add_step_down_and_off@1
+                                  0001233f         3   func ,l         2
+  _cmd_add_on_and_step_up@1
+                                  00012342         3   func ,l         2
+  _cmd_add_go_to_scene@1
+                                  00012345       185   func ,l         2
+  __CommonCode@217
+                                  000124ca         6   func ,l         2
+  __CommonCode@213
+                                  000124d0         6   func ,l         6
+  __CommonCode@177
+                                  000124d6         2   func ,l         3
+  __CommonCode@240
+                                  000124d8         5   func ,l         6
+  __CommonCode@123
+                                  000124dd         4   func ,l         6
+  __CommonCode@84
+                                  000124e1         7   func ,l         2
+  __CommonCode@83
+                                  000124e8         f   func ,l         2
+  __CommonCode@82
+                                  000124f7         7   func ,l         2
+  __CommonCode@163
+                                  000124fe         7   func ,l         3
+  __CommonCode@81
+                                  00012505         8   func ,l         2
+  __CommonCode@216
+                                  0001250d         8   func ,l         2
+  __CommonCode@63
+                                  00012515         f   func ,l         2
+  __CommonCode@52
+                                  00012524         7   func ,l         3
+  __CommonCode@25
+                                  0001252b         8   func ,l         2
+  __CommonCode@161
+                                  00012533         4   func ,l         7
+  __CommonCode@16
+                                  00012537         6   func ,l         2
+  __CommonCode@1
+                                  0001253d         4   func ,l         2
+  __CommonCode@210
+                                  00012541         8   func ,l         2
+  _cmd_add_reset@1
+                                  00012549         a   func ,l         2
+  _cmd_add_store_actual_level_in_the_dtr0@1
+                                  00012553        5e   func ,l         2
+  __CommonCode@80
+                                  000125b1         9   func ,l         2
+  _cmd_add_store_the_dtr_as_system_failure_level@1
+                                  000125ba        75   func ,l         2
+  __CommonCode@172
+                                  0001262f         6   func ,l         4
+  __CommonCode@225
+                                  00012635         6   func ,l         7
+  __CommonCode@171
+                                  0001263b         5   func ,l         2
+  __CommonCode@197
+                                  00012640         b   func ,l         5
+  __CommonCode@79
+                                  0001264b        15   func ,l         2
+  __CommonCode@78
+                                  00012660        25   func ,l         2
+  __CommonCode@175
+                                  00012685         7   func ,l         3
+  __CommonCode@174
+                                  0001268c         a   func ,l         2
+  __CommonCode@77
+                                  00012696        1f   func ,l         2
+  __CommonCode@169
+                                  000126b5         7   func ,l         2
+  __CommonCode@167
+                                  000126bc         5   func ,l         2
+  __CommonCode@76
+                                  000126c1         8   func ,l         2
+  __CommonCode@173
+                                  000126c9         c   func ,l         2
+  __CommonCode@74
+                                  000126d5        45   func ,l         2
+  __CommonCode@215
+                                  0001271a         8   func ,l         3
+  __CommonCode@212
+                                  00012722         8   func ,l         2
+  __CommonCode@166
+                                  0001272a         a   func ,l         2
+  __CommonCode@73
+                                  00012734         8   func ,l         2
+  __CommonCode@72
+                                  0001273c         8   func ,l         2
+  _cmd_add_store_the_dtr_as_power_on_level@1
+                                  00012744        74   func ,l         2
+  __CommonCode@168
+                                  000127b8         8   func ,l         3
+  __CommonCode@165
+                                  000127c0         4   func ,l         5
+  __CommonCode@164
+                                  000127c4         4   func ,l         3
+  __CommonCode@232
+                                  000127c8         8   func ,l         3
+  _cmd_add_store_the_dtr_as_scene@1
+                                  000127d0       114   func ,l         2
+  __CommonCode@159
+                                  000128e4         4   func ,l         2
+  __CommonCode@142
+                                  000128e8         6   func ,l         3
+  __CommonCode@132
+                                  000128ee         4   func ,l         2
+  __CommonCode@206
+                                  000128f2         7   func ,l         2
+  __CommonCode@116
+                                  000128f9         4   func ,l        17
+  __CommonCode@71
+                                  000128fd         9   func ,l         3
+  __CommonCode@70
+                                  00012906         c   func ,l         2
+  __CommonCode@69
+                                  00012912         c   func ,l         2
+  __CommonCode@68
+                                  0001291e         9   func ,l         2
+  __CommonCode@51
+                                  00012927         4   func ,l         2
+  __CommonCode@151
+                                  0001292b         9   func ,l         2
+  _cmd_add_remove_from_scene@1
+                                  00012934        15   func ,l         2
+  _cmd_add_query_power_on_level@1
+                                  00012949        53   func ,l         2
+  __CommonCode@67
+                                  0001299c         c   func ,l         2
+  __CommonCode@66
+                                  000129a8         6   func ,l         2
+  __CommonCode@160
+                                  000129ae         6   func ,l         3
+  __CommonCode@65
+                                  000129b4        12   func ,l         3
+  __CommonCode@231
+                                  000129c6         7   func ,l         3
+  __CommonCode@64
+                                  000129cd         e   func ,l         3
+  __CommonCode@230
+                                  000129db         4   func ,l         3
+  __CommonCode@208
+                                  000129df         4   func ,l         2
+  __CommonCode@209
+                                  000129e3         a   func ,l         2
+  __CommonCode@196
+                                  000129ed         6   func ,l         4
+  __CommonCode@60
+                                  000129f3         b   func ,l         4
+  _cmd_add_query_system_failure_level@1
+                                  000129fe        50   func ,l         2
+  __CommonCode@59
+                                  00012a4e         5   func ,l         3
+  __CommonCode@117
+                                  00012a53         4   func ,l         4
+  __CommonCode@195
+                                  00012a57         6   func ,l         4
+  __CommonCode@62
+                                  00012a5d         7   func ,l         3
+  _cmd_add_query_scene_level@1
+                                  00012a64        6d   func ,l         2
+  __CommonCode@157
+                                  00012ad1         d   func ,l         2
+  __CommonCode@61
+                                  00012ade         9   func ,l         2
+  __CommonCode@58
+                                  00012ae7         f   func ,l         2
+  _cmd_rep_query_actual_level@1
+                                  00012af6        b4   func ,l         2
+  __CommonCode@194
+                                  00012baa         9   func ,l         2
+  _cmd_set_temporary_x_coordinate@1
+                                  00012bb3        19   func ,l         2
+  __CommonCode@57
+                                  00012bcc         c   func ,l         2
+  __CommonCode@120
+                                  00012bd8         6   func ,l         2
+  __CommonCode@207
+                                  00012bde         5   func ,l         2
+  __CommonCode@241
+                                  00012be3         6   func ,l         8
+  __CommonCode@228
+                                  00012be9         6   func ,l         4
+  __CommonCode@56
+                                  00012bef         a   func ,l         2
+  __CommonCode@55
+                                  00012bf9         9   func ,l         2
+  __CommonCode@54
+                                  00012c02        1c   func ,l         2
+  __CommonCode@131
+                                  00012c1e         2   func ,l         2
+  __CommonCode@200
+                                  00012c20         7   func ,l         3
+  _cmd_set_temporary_y_coordinate@1
+                                  00012c27        19   func ,l         2
+  _cmd_activate@1
+                                  00012c40       18b   func ,l         2
+  __CommonCode@143
+                                  00012dcb         6   func ,l         3
+  __CommonCode@141
+                                  00012dd1         6   func ,l         3
+  __CommonCode@50
+                                  00012dd7         4   func ,l         3
+  __CommonCode@48
+                                  00012ddb         8   func ,l         2
+  _cmd_x_coordinate_step_up@1
+                                  00012de3        2a   func ,l         2
+  __CommonCode@47
+                                  00012e0d        34   func ,l         2
+  __CommonCode@140
+                                  00012e41         9   func ,l         2
+  __CommonCode@226
+                                  00012e4a         8   func ,l         3
+  __CommonCode@139
+                                  00012e52         9   func ,l         2
+  __CommonCode@138
+                                  00012e5b         c   func ,l         2
+  __CommonCode@46
+                                  00012e67         2   func ,l         2
+  __CommonCode@137
+                                  00012e69         f   func ,l         2
+  __CommonCode@45
+                                  00012e78        19   func ,l         2
+  __CommonCode@204
+                                  00012e91         2   func ,l         2
+  __CommonCode@229
+                                  00012e93         4   func ,l         2
+  __CommonCode@202
+                                  00012e97         4   func ,l         2
+  __CommonCode@136
+                                  00012e9b        11   func ,l         2
+  __CommonCode@203
+                                  00012eac         9   func ,l         3
+  __CommonCode@135
+                                  00012eb5         f   func ,l         2
+  __CommonCode@134
+                                  00012ec4         f   func ,l         2
+  _cmd_x_coordinate_step_down@1
+                                  00012ed3        2e   func ,l         2
+  __CommonCode@44
+                                  00012f01        11   func ,l         4
+  __CommonCode@192
+                                  00012f12         6   func ,l         4
+  __CommonCode@43
+                                  00012f18         5   func ,l         4
+  __CommonCode@39
+                                  00012f1d         e   func ,l         4
+  _cmd_y_coordinate_step_up@1
+                                  00012f2b        27   func ,l         2
+  __CommonCode@42
+                                  00012f52        2e   func ,l         2
+  __CommonCode@124
+                                  00012f80         6   func ,l         6
+  __CommonCode@41
+                                  00012f86         5   func ,l         2
+  __CommonCode@40
+                                  00012f8b        19   func ,l         2
+  _cmd_y_coordinate_step_down@1
+                                  00012fa4        2d   func ,l         2
+  _cmd_set_temporary_colour_temperature_tc@1
+                                  00012fd1        47   func ,l         2
+  __CommonCode@130
+                                  00013018         5   func ,l         2
+  __CommonCode@201
+                                  0001301d         6   func ,l         4
+  __CommonCode@119
+                                  00013023         b   func ,l         2
+  __CommonCode@17
+                                  0001302e         6   func ,l         2
+  _cmd_colour_temperature_tc_step_cooler@1
+                                  00013034        4e   func ,l         2
+  __CommonCode@38
+                                  00013082         5   func ,l         2
+  __CommonCode@127
+                                  00013087         7   func ,l         4
+  __CommonCode@128
+                                  0001308e         a   func ,l         2
+  __CommonCode@37
+                                  00013098        3c   func ,l         2
+  __CommonCode@36
+                                  000130d4         c   func ,l         2
+  __CommonCode@35
+                                  000130e0         d   func ,l         2
+  __CommonCode@34
+                                  000130ed         8   func ,l         2
+  __CommonCode@33
+                                  000130f5         c   func ,l         2
+  _cmd_colour_temperature_tc_step_warmer@1
+                                  00013101        5a   func ,l         2
+  _cmd_set_temporary_primary_n_dimlevel@1
+                                  0001315b         c   func ,l         2
+  __CommonCode@18
+                                  00013167         5   func ,l         4
+  _cmd_set_temporary_rgb_dimlevel@1
+                                  0001316c        46   func ,l         2
+  __CommonCode@32
+                                  000131b2        1e   func ,l         2
+  __CommonCode@121
+                                  000131d0         7   func ,l         3
+  __CommonCode@31
+                                  000131d7         8   func ,l         2
+  __CommonCode@30
+                                  000131df        1c   func ,l         2
+  __CommonCode@126
+                                  000131fb         6   func ,l         2
+  __CommonCode@224
+                                  00013201         6   func ,l         6
+  __CommonCode@29
+                                  00013207         a   func ,l         2
+  __CommonCode@28
+                                  00013211         a   func ,l         2
+  __CommonCode@27
+                                  0001321b         7   func ,l         4
+  __CommonCode@26
+                                  00013222         9   func ,l         2
+  _cmd_set_temporary_waf_dimlevel@1
+                                  0001322b        48   func ,l         2
+  _cmd_set_temporary_rgbwaf_control@1
+                                  00013273        44   func ,l         2
+  __CommonCode@193
+                                  000132b7         7   func ,l         7
+  __CommonCode@122
+                                  000132be         6   func ,l         4
+  _cmd_copy_report_to_temporary@1
+                                  000132c4        71   func ,l         2
+  __CommonCode@8
+                                  00013335         5   func ,l         8
+  __CommonCode@5
+                                  0001333a         5   func ,l        14
+  __CommonCode@2
+                                  0001333f         a   func ,l         2
+  __CommonCode@0
+                                  00013349         7   func ,l         3
+  _cmd_store_colour_temperature_tc_step_increment@1
+                                  00013350        2f   func ,l         2
+  __CommonCode@19
+                                  0001337f         d   func ,l         2
+  _cmd_store_colour_temperature_tc_limit@1
+                                  0001338c       12a   func ,l         2
+  __CommonCode@24
+                                  000134b6         6   func ,l         3
+  __CommonCode@23
+                                  000134bc        11   func ,l         2
+  __CommonCode@22
+                                  000134cd         8   func ,l         2
+  __CommonCode@21
+                                  000134d5         6   func ,l         3
+  __CommonCode@20
+                                  000134db        15   func ,l         2
+  _cmd_store_gear_features_status@1
+                                  000134f0        24   func ,l         2
+  _cmd_store_enabled_channels@1
+                                  00013514        96   func ,l         2
+  _cmd_query_gear_features_status@1
+                                  000135aa        1e   func ,l         2
+  __CommonCode@13
+                                  000135c8         7   func ,l         2
+  __CommonCode@15
+                                  000135cf         7   func ,l         3
+  __CommonCode@14
+                                  000135d6         a   func ,l         2
+  _cmd_query_colour_status@1
+                                  000135e0        4d   func ,l         2
+  _cmd_query_colour_type_features@1
+                                  0001362d        12   func ,l         2
+  __CommonCode@4
+                                  0001363f         7   func ,l         3
+  _cmd_query_colour_value@1
+                                  00013646       3e1   func ,l         2
+  __CommonCode@118
+                                  00013a27         6   func ,l        18
+  __CommonCode@12
+                                  00013a2d         a   func ,l         2
+  __CommonCode@11
+                                  00013a37         5   func ,l         3
+  __CommonCode@10
+                                  00013a3c         9   func ,l         2
+  __CommonCode@9
+                                  00013a45         a   func ,l         2
+  __CommonCode@6
+                                  00013a4f         a   func ,l         4
+  _cmd_query_rgbwaf_control@1
+                                  00013a59        12   func ,l         2
+  _cmd_reserved@1
+                                  00013a6b         3   func ,l         e
+  _clear_report_setting@1
+                                  00013a6e        55   func ,l         3
+  __CommonCode@3
+                                  00013ac3         7   func ,l         6
+  _clear_temporary_setting@1
+                                  00013aca        49   func ,l         6
+FILE=r_dali209_fade
+                                  00013b13  00014000       4ee
+  _R_DALI209_FADE_Init
+                                  00013b13        2c   func ,g         1
+  __CommonCode@15
+                                  00013b3f         f   func ,l         2
+  _R_DALI209_FADE_Tick1ms
+                                  00013b4e        36   func ,g         1
+  _R_DALI209_FADE_IsRunning
+                                  00013b84         3   func ,g         3
+  _R_DALI209_FADE_IsRequested
+                                  00013b87        14   func ,g         5
+  _R_DALI209_FADE_Start
+                                  00013b9b        36   func ,g         4
+  _R_DALI209_FADE_Stop
+                                  00013bd1         8   func ,g         2
+  _R_DALI209_FADE_Set
+                                  00013bd9        79   func ,g         3
+  __CommonCode@22
+                                  00013c52         8   func ,l         2
+  __CommonCode@23
+                                  00013c5a         4   func ,l         3
+  __CommonCode@14
+                                  00013c5e        1e   func ,l         2
+  __CommonCode@13
+                                  00013c7c         c   func ,l         2
+  __CommonCode@12
+                                  00013c88         6   func ,l         2
+  __CommonCode@16
+                                  00013c8e         7   func ,l         2
+  _R_DALI209_FADE_GetType
+                                  00013c95         4   func ,g         1
+  _R_DALI209_FADE_GetRgbwafControl
+                                  00013c99         4   func ,g         2
+  _R_DALI209_FADE_CalcActualColourValue
+                                  00013c9d       206   func ,g         1
+  __CommonCode@21
+                                  00013ea3         8   func ,l         2
+  __CommonCode@20
+                                  00013eab         8   func ,l         2
+  __CommonCode@11
+                                  00013eb3         a   func ,l         2
+  __CommonCode@10
+                                  00013ebd         9   func ,l         3
+  __CommonCode@9
+                                  00013ec6        14   func ,l         2
+  __CommonCode@8
+                                  00013eda         9   func ,l         2
+  __CommonCode@7
+                                  00013ee3         8   func ,l         3
+  __CommonCode@6
+                                  00013eeb         7   func ,l         3
+  __CommonCode@19
+                                  00013ef2         8   func ,l         2
+  __CommonCode@5
+                                  00013efa         d   func ,l         3
+  __CommonCode@4
+                                  00013f07         2   func ,l         2
+  __CommonCode@18
+                                  00013f09         4   func ,l         2
+  __CommonCode@3
+                                  00013f0d         a   func ,l         2
+  _R_DALI209_FADE_GetTargetColourValue
+                                  00013f17        5f   func ,g         2
+  __CommonCode@17
+                                  00013f76         4   func ,l         3
+  __CommonCode@2
+                                  00013f7a         9   func ,l         2
+  __CommonCode@1
+                                  00013f83        23   func ,l         2
+  __CommonCode@0
+                                  00013fa6         a   func ,l         2
+  _R_DALI209_FADE_InvalidFadeIsRunning
+                                  00013fb0         4   func ,g         1
+  _division@1
+                                  00013fb4        4d   func ,l         6
+FILE=r_dali209_var
+                                  00014001  000149a4       9a4
+  _R_DALI209_VAR_Init
+                                  00014001       158   func ,g         2
+  __CommonCode@35
+                                  00014159         8   func ,l         2
+  __CommonCode@34
+                                  00014161         6   func ,l         4
+  __CommonCode@33
+                                  00014167         8   func ,l         2
+  __CommonCode@32
+                                  0001416f        1b   func ,l         2
+  __CommonCode@27
+                                  0001418a         8   func ,l         2
+  __CommonCode@26
+                                  00014192         4   func ,l         2
+  __CommonCode@43
+                                  00014196         7   func ,l         5
+  __CommonCode@25
+                                  0001419d         3   func ,l         2
+  __CommonCode@39
+                                  000141a0         7   func ,l         2
+  __CommonCode@24
+                                  000141a7         4   func ,l         2
+  __CommonCode@41
+                                  000141ab         a   func ,l         2
+  _R_DALI209_VAR_Reset
+                                  000141b5       103   func ,g         1
+  __CommonCode@31
+                                  000142b8         9   func ,l         2
+  __CommonCode@30
+                                  000142c1         6   func ,l         6
+  __CommonCode@29
+                                  000142c7         6   func ,l         6
+  __CommonCode@28
+                                  000142cd         6   func ,l         6
+  _R_DALI209_VAR_IsReset
+                                  000142d3        97   func ,g         1
+  __CommonCode@40
+                                  0001436a         a   func ,l         3
+  _R_DALI209_VAR_NvmIsValid
+                                  00014374        b5   func ,g         1
+  _R_DALI209_VAR_SetNvm
+                                  00014429        7c   func ,g         1
+  __CommonCode@23
+                                  000144a5         a   func ,l         4
+  __CommonCode@22
+                                  000144af         e   func ,l         2
+  __CommonCode@21
+                                  000144bd         b   func ,l         2
+  _R_DALI209_VAR_GetNvm
+                                  000144c8        81   func ,g         1
+  _R_DALI209_VAR_NvmIsChanged
+                                  00014549         7   func ,g         1
+  _R_DALI209_VAR_SetTemporaryXyCoordinate
+                                  00014550         6   func ,g         5
+  _R_DALI209_VAR_GetTemporaryXyCoordinate
+                                  00014556         6   func ,g         4
+  _R_DALI209_VAR_SetReportXyCoordinate
+                                  0001455c         7   func ,g         5
+  __CommonCode@19
+                                  00014563         5   func ,l         3
+  __CommonCode@20
+                                  00014568         b   func ,l         3
+  _R_DALI209_VAR_GetReportXyCoordinate
+                                  00014573         9   func ,g         3
+  _R_DALI209_VAR_SetXyCoordinate
+                                  0001457c         9   func ,g         8
+  _R_DALI209_VAR_GetXyCoordinate
+                                  00014585         9   func ,g        11
+  __CommonCode@5
+                                  0001458e         7   func ,l         6
+  _R_DALI209_VAR_SetTemporaryColourTemperatureTc
+                                  00014595         5   func ,g         4
+  _R_DALI209_VAR_GetTemporaryColourTemperatureTc
+                                  0001459a         4   func ,g         4
+  _R_DALI209_VAR_SetReportColourTemperatureTc
+                                  0001459e         5   func ,g         4
+  _R_DALI209_VAR_GetReportColourTemperatureTc
+                                  000145a3         4   func ,g         2
+  _R_DALI209_VAR_SetColourTemperatureTc
+                                  000145a7         5   func ,g         4
+  _R_DALI209_VAR_GetColourTemperatureTc
+                                  000145ac         4   func ,g         d
+  _R_DALI209_VAR_SetColourTemperatureTcCoolest
+                                  000145b0        14   func ,g         2
+  _R_DALI209_VAR_GetColourTemperatureTcCoolest
+                                  000145c4         4   func ,g         6
+  _R_DALI209_VAR_SetColourTemperatureTcWarmest
+                                  000145c8        14   func ,g         2
+  _R_DALI209_VAR_GetColourTemperatureTcWarmest
+                                  000145dc         4   func ,g         6
+  _R_DALI209_VAR_SetColourTemperatureTcPhysicalCoolest
+                                  000145e0        14   func ,g         1
+  _R_DALI209_VAR_GetColourTemperatureTcPhysicalCoolest
+                                  000145f4         4   func ,g         2
+  _R_DALI209_VAR_SetColourTemperatureTcPhysicalWarmest
+                                  000145f8        14   func ,g         1
+  __CommonCode@9
+                                  0001460c         5   func ,l         7
+  _R_DALI209_VAR_GetColourTemperatureTcPhysicalWarmest
+                                  00014611         4   func ,g         2
+  _R_DALI209_VAR_SetColourTemperatureTcStepIncrement
+                                  00014615        13   func ,g         2
+  _R_DALI209_VAR_GetColourTemperatureTcStepIncrement
+                                  00014628         4   func ,g         2
+  _R_DALI209_VAR_SetTemporaryRgbwafDimlevel
+                                  0001462c         6   func ,g         8
+  __CommonCode@18
+                                  00014632         8   func ,l         2
+  _R_DALI209_VAR_GetTemporaryRgbwafDimlevel
+                                  0001463a         5   func ,g         5
+  _R_DALI209_VAR_SetReportRgbwafDimlevel
+                                  0001463f         6   func ,g         3
+  __CommonCode@17
+                                  00014645         8   func ,l         2
+  _R_DALI209_VAR_GetReportRgbwafDimlevel
+                                  0001464d         5   func ,g         3
+  _R_DALI209_VAR_SetRgbwafDimlevel
+                                  00014652         6   func ,g         6
+  __CommonCode@16
+                                  00014658         8   func ,l         2
+  _R_DALI209_VAR_GetRgbwafDimlevel
+                                  00014660         5   func ,g         b
+  _R_DALI209_VAR_SetTemporaryRgbwafControl
+                                  00014665         5   func ,g         3
+  _R_DALI209_VAR_GetTemporaryRgbwafControl
+                                  0001466a         4   func ,g         4
+  _R_DALI209_VAR_SetReportRgbwafControl
+                                  0001466e         5   func ,g         3
+  _R_DALI209_VAR_GetReportRgbwafControl
+                                  00014673         4   func ,g         2
+  _R_DALI209_VAR_SetRgbwafControl
+                                  00014677         5   func ,g         3
+  _R_DALI209_VAR_GetRgbwafControl
+                                  0001467c         4   func ,g         7
+  _R_DALI209_VAR_SetReportLightOutputRgbwaf
+                                  00014680         6   func ,g         3
+  __CommonCode@15
+                                  00014686         8   func ,l         2
+  __CommonCode@36
+                                  0001468e         6   func ,l         8
+  _R_DALI209_VAR_GetReportLightOutputRgbwaf
+                                  00014694         5   func ,g         2
+  _R_DALI209_VAR_SetDeratingFactor
+                                  00014699         5   func ,g         1
+  _R_DALI209_VAR_GetDeratingFactor
+                                  0001469e         4   func ,g         1
+  _R_DALI209_VAR_SetEnabledChannels
+                                  000146a2        13   func ,g         1
+  _R_DALI209_VAR_GetEnabledChannels
+                                  000146b5         4   func ,g         7
+  _R_DALI209_VAR_SetTemporaryColourType
+                                  000146b9         5   func ,g         8
+  _R_DALI209_VAR_GetTemporaryColourType
+                                  000146be         4   func ,g         4
+  _R_DALI209_VAR_SetReportColourType
+                                  000146c2         5   func ,g         6
+  _R_DALI209_VAR_GetReportColourType
+                                  000146c7         4   func ,g         2
+  _R_DALI209_VAR_SetLastActiveColourType
+                                  000146cb        13   func ,g         4
+  _R_DALI209_VAR_GetLastActiveColourType
+                                  000146de         4   func ,g         2
+  _R_DALI209_VAR_SetLastActiveColourValueTc
+                                  000146e2        14   func ,g         2
+  _R_DALI209_VAR_GetLastActiveColourValueTc
+                                  000146f6         4   func ,g         3
+  _R_DALI209_VAR_SetLastActiveColourValueXy
+                                  000146fa        13   func ,g         2
+  _R_DALI209_VAR_GetLastActiveColourValueXy
+                                  0001470d         9   func ,g         2
+  _R_DALI209_VAR_SetLastActiveColourValueRgbwaf
+                                  00014716         6   func ,g         3
+  __CommonCode@14
+                                  0001471c         7   func ,l         2
+  _R_DALI209_VAR_GetLastActiveColourValueRgbwaf
+                                  00014723         6   func ,g         3
+  _R_DALI209_VAR_SetLastActiveColourRgbwafControl
+                                  00014729         7   func ,g         2
+  _R_DALI209_VAR_GetLastActiveColourRgbwafControl
+                                  00014730         6   func ,g         3
+  _R_DALI209_VAR_SetSceneColourType
+                                  00014736         6   func ,g         3
+  __CommonCode@13
+                                  0001473c         7   func ,l         2
+  _R_DALI209_VAR_GetSceneColourType
+                                  00014743         6   func ,g         2
+  _R_DALI209_VAR_SetSceneColourValueTc
+                                  00014749        16   func ,g         1
+  __CommonCode@7
+                                  0001475f         6   func ,l         4
+  __CommonCode@6
+                                  00014765         8   func ,l         4
+  _R_DALI209_VAR_GetSceneColourValueTc
+                                  0001476d         5   func ,g         3
+  __CommonCode@11
+                                  00014772         5   func ,l         2
+  __CommonCode@38
+                                  00014777         a   func ,l         2
+  _R_DALI209_VAR_SetSceneColourValueXy
+                                  00014781        19   func ,g         1
+  __CommonCode@12
+                                  0001479a        10   func ,l         2
+  _R_DALI209_VAR_GetSceneColourValueXy
+                                  000147aa         6   func ,g         2
+  _R_DALI209_VAR_SetSceneColourValueRgbwaf
+                                  000147b0        24   func ,g         1
+  _R_DALI209_VAR_GetSceneColourValueRgbwaf
+                                  000147d4        19   func ,g         2
+  _R_DALI209_VAR_SetSceneColourRgbwafControl
+                                  000147ed         3   func ,g         1
+  __CommonCode@4
+                                  000147f0         2   func ,l         5
+  __CommonCode@37
+                                  000147f2         9   func ,l         2
+  _R_DALI209_VAR_GetSceneColourRgbwafControl
+                                  000147fb         5   func ,g         3
+  _R_DALI209_VAR_SetPowerOnColourType
+                                  00014800        13   func ,g         3
+  _R_DALI209_VAR_GetPowerOnColourType
+                                  00014813         4   func ,g         3
+  _R_DALI209_VAR_SetPowerOnColourValueTc
+                                  00014817        14   func ,g         1
+  _R_DALI209_VAR_GetPowerOnColourValueTc
+                                  0001482b         4   func ,g         4
+  _R_DALI209_VAR_SetPowerOnColourValueXy
+                                  0001482f        13   func ,g         1
+  __CommonCode@8
+                                  00014842         7   func ,l         3
+  _R_DALI209_VAR_GetPowerOnColourValueXy
+                                  00014849         9   func ,g         3
+  _R_DALI209_VAR_SetPowerOnColourValueRgbwaf
+                                  00014852         5   func ,g         1
+  __CommonCode@10
+                                  00014857         7   func ,l         2
+  _R_DALI209_VAR_GetPowerOnColourValueRgbwaf
+                                  0001485e         6   func ,g         4
+  _R_DALI209_VAR_SetPowerOnColourRgbwafControl
+                                  00014864         4   func ,g         1
+  __CommonCode@2
+                                  00014868         4   func ,l         3
+  _R_DALI209_VAR_GetPowerOnColourRgbwafControl
+                                  0001486c         6   func ,g         4
+  _R_DALI209_VAR_SetSystemFailureColourType
+                                  00014872        13   func ,g         3
+  _R_DALI209_VAR_GetSystemFailureColourType
+                                  00014885         4   func ,g         2
+  _R_DALI209_VAR_SetSystemFailureColourValueTc
+                                  00014889        14   func ,g         1
+  _R_DALI209_VAR_GetSystemFailureColourValueTc
+                                  0001489d         4   func ,g         2
+  _R_DALI209_VAR_SetSystemFailureColourValueXy
+                                  000148a1        13   func ,g         1
+  _R_DALI209_VAR_GetSystemFailureColourValueXy
+                                  000148b4         9   func ,g         2
+  _R_DALI209_VAR_SetSystemFailureColourValueRgbwaf
+                                  000148bd         6   func ,g         1
+  __CommonCode@3
+                                  000148c3         7   func ,l         2
+  _R_DALI209_VAR_GetSystemFailureColourValueRgbwaf
+                                  000148ca         6   func ,g         2
+  _R_DALI209_VAR_SetSystemFailureColourRgbwafControl
+                                  000148d0         6   func ,g         1
+  _R_DALI209_VAR_GetSystemFailureColourRgbwafControl
+                                  000148d6         6   func ,g         2
+  _R_DALI209_VAR_SetAutomaticActivation
+                                  000148dc         7   func ,g         2
+  _R_DALI209_VAR_ClearAutomaticActivation
+                                  000148e3         7   func ,g         1
+  _R_DALI209_VAR_AutomaticActivationIsActive
+                                  000148ea         6   func ,g         4
+  _R_DALI209_VAR_SetTcPhysicalLimitReadOnly
+                                  000148f0         7   func ,g         0
+  _R_DALI209_VAR_ClearTcPhysicalLimitReadOnly
+                                  000148f7         7   func ,g         0
+  _R_DALI209_VAR_TcPhysicalLimitIsReadOnly
+                                  000148fe         8   func ,g         3
+  _R_DALI209_VAR_SetXyOutOfRange
+                                  00014906         6   func ,g         3
+  _R_DALI209_VAR_ClearXyOutOfRange
+                                  0001490c         6   func ,g         9
+  _R_DALI209_VAR_XyIsOutOfRange
+                                  00014912         6   func ,g         1
+  _R_DALI209_VAR_SetTcOutOfRange
+                                  00014918         6   func ,g         5
+  _R_DALI209_VAR_ClearTcOutOfRange
+                                  0001491e         6   func ,g         c
+  _R_DALI209_VAR_TcIsOutOfRange
+                                  00014924         8   func ,g         1
+  _R_DALI209_VAR_SetColourTypeXyActive
+                                  0001492c         6   func ,g         4
+  __CommonCode@1
+                                  00014932         5   func ,l         a
+  _R_DALI209_VAR_ClearColourTypeXyActive
+                                  00014937         6   func ,g         8
+  _R_DALI209_VAR_ColourTypeXyIsActive
+                                  0001493d         8   func ,g         7
+  _R_DALI209_VAR_SetColourTypeTcActive
+                                  00014945         6   func ,g         4
+  _R_DALI209_VAR_ClearColourTypeTcActive
+                                  0001494b         6   func ,g         8
+  _R_DALI209_VAR_ColourTypeTcIsActive
+                                  00014951         8   func ,g         7
+  _R_DALI209_VAR_SetColourTypeRgbwafActive
+                                  00014959         6   func ,g         4
+  _R_DALI209_VAR_ClearColourTypeRgbwafActive
+                                  0001495f         6   func ,g         8
+  _R_DALI209_VAR_ColourTypeRgbwafIsActive
+                                  00014965         8   func ,g         7
+  _R_DALI209_VAR_GetPowerRatio
+                                  0001496d         7   func ,g         2
+  _R_DALI209_VAR_GetColourTypeFeatures
+                                  00014974         6   func ,g         3
+  _R_DALI209_VAR_GetRgbwafChannelsPresent
+                                  0001497a         7   func ,g         1
+  _R_DALI209_VAR_GetPrimaryRedXyCoordinate
+                                  00014981         9   func ,g         6
+  _R_DALI209_VAR_GetPrimaryGreenXyCoordinate
+                                  0001498a         9   func ,g         6
+  __CommonCode@0
+                                  00014993         9   func ,l         3
+  _R_DALI209_VAR_GetPrimaryBlueXyCoordinate
+                                  0001499c         9   func ,g         6
+
+SECTION=.constf
+FILE=_REL_print
+                                  000149a6  000149b9        14
+
+SECTION=.data
+FILE=DefaultBuild\r_cg.obj
+                                  000149ba  00014c87       2ce
+FILE=DefaultBuild\r_main.obj
+                                  00014c88  00014e9b       214
+FILE=DefaultBuild\r_dali101_rx.obj
+                                  00014e9c  00014ea6         b
+FILE=DefaultBuild\r_led.obj
+                                  00014ea8  00014eb0         9
+FILE=DefaultBuild\r_led1.obj
+                                  00014eb2  00014eb5         4
+FILE=DefaultBuild\r_led2.obj
+                                  00014eb6  00014eb9         4
+FILE=DefaultBuild\r_led3.obj
+                                  00014eba  00014ebd         4
+FILE=DefaultBuild\Config_TAU_user.obj
+                                  00014ebe  00014ec2         5
+FILE=DefaultBuild\Config_UART_user.obj
+                                  00014ec4  00014ec5         2
+FILE=r_dali102
+                                  00014ec6  00014ec7         2
+FILE=r_dali102_mb_if
+                                  00014ec8  00014ec9         2
+FILE=r_dali209
+                                  00014eca  00014ecb         2
+
+SECTION=.sdata
+FILE=DefaultBuild\r_led.obj
+                                  00014ecc  00014ecd         2
+FILE=DefaultBuild\r_led1.obj
+                                  00014ece  00014edd        10
+FILE=DefaultBuild\r_led2.obj
+                                  00014ede  00014eed        10
+FILE=DefaultBuild\r_led3.obj
+                                  00014eee  00014efd        10
+
+SECTION=RFD_DATA_n
+FILE=DefaultBuild\r_rfd_common_api.obj
+                                  00014efe  00014f00         3
+FILE=DefaultBuild\r_rfd_common_userown.obj
+                                  00014f02  00014f02         1
+
+SECTION=RFD_CMN_f
+FILE=DefaultBuild\r_rfd_common_extension_api.obj
+                                  00014f03  00014f14        12
+  _R_RFD_SetBootAreaImmediately
+                                  00014f03        12   func ,g         0
+FILE=DefaultBuild\r_rfd_common_get_api.obj
+                                  00014f15  00014f4f        3b
+  _R_RFD_GetSecurityAndBootFlags
+                                  00014f15         8   func ,g         0
+  _R_RFD_GetFSW
+                                  00014f1d        33   func ,g         0
+FILE=DefaultBuild\r_rfd_common_api.obj
+                                  00014f50  0001508a       13b
+  _R_RFD_Init
+                                  00014f50        24   func ,g         1
+  _R_RFD_SetDataFlashAccessMode
+                                  00014f74         d   func ,g         4
+  _R_RFD_ChangeInterruptVector
+                                  00014f81        2c   func ,g         0
+  _R_RFD_RestoreInterruptVector
+                                  00014fad        1f   func ,g         0
+  _R_RFD_SetFlashMemoryMode
+                                  00014fcc        8d   func ,g         8
+  _R_RFD_CheckFlashMemoryMode
+                                  00015059        1f   func ,g         0
+  _r_rfd_wait_count
+                                  00015078        13   func ,g         0
+FILE=DefaultBuild\r_rfd_common_control_api.obj
+                                  0001508b  000150cb        41
+  _R_RFD_CheckCFDFSeqEndStep1
+                                  0001508b         d   func ,g         3
+  _R_RFD_CheckExtraSeqEndStep1
+                                  00015098         d   func ,g         0
+  _R_RFD_CheckCFDFSeqEndStep2
+                                  000150a5         8   func ,g         3
+  _R_RFD_CheckExtraSeqEndStep2
+                                  000150ad         6   func ,g         0
+  _R_RFD_GetSeqErrorStatus
+                                  000150b3         a   func ,g         3
+  _R_RFD_ClearSeqRegister
+                                  000150bd         8   func ,g         3
+  _R_RFD_ForceStopSeq
+                                  000150c5         5   func ,g         0
+  _R_RFD_ForceReset
+                                  000150ca         2   func ,g         0
+FILE=DefaultBuild\r_rfd_common_userown.obj
+                                  000150cc  000150e0        15
+  _R_RFD_HOOK_EnterCriticalSection
+                                  000150cc         9   func ,g         3
+  _R_RFD_HOOK_ExitCriticalSection
+                                  000150d5         c   func ,g         3
+
+SECTION=RFD_DF_f
+FILE=DefaultBuild\r_rfd_data_flash_api.obj
+                                  000150e1  0001512d        4d
+  _R_RFD_EraseDataFlashReq
+                                  000150e1        1c   func ,g         2
+  _R_RFD_WriteDataFlashReq
+                                  000150fd        15   func ,g         4
+  _R_RFD_BlankCheckDataFlashReq
+                                  00015112        1c   func ,g         2
+
+SECTION=NVM_f
+FILE=DefaultBuild\r_nvm.obj
+                                  0001512e  00015b7e       a51
+  _R_NVM_Init
+                                  0001512e       265   func ,g         1
+  _R_NVM_Open
+                                  00015393         5   func ,g         1
+  _R_NVM_Close
+                                  00015398         5   func ,g         0
+  _R_NVM_Task
+                                  0001539d       2f6   func ,g         1
+  _R_NVM_Read
+                                  00015693       1b2   func ,g         2
+  _R_NVM_Write
+                                  00015845        33   func ,g         5
+  _erase_task@1
+                                  00015878       18d   func ,l         2
+  _write_task_s2_sor_write_handler@1
+                                  00015a05        15   func ,l         1
+  _write_task_s4_data_write_handler@1
+                                  00015a1a        15   func ,l         1
+  _write_task_s6_eor_write_handler@1
+                                  00015a2f        15   func ,l         1
+  _search_last_valid_record@1
+                                  00015a44        95   func ,l         1
+  _df_write_start@1
+                                  00015ad9        44   func ,l         2
+  _df_write_handler@1
+                                  00015b1d        62   func ,l         4
+
+SECTION=.monitor2
+FILE=rlink_generates_02
+                                  0001fe00  0001ffff       200
+
+SECTION=.dataR
+FILE=DefaultBuild\r_cg.obj
+                                  000fcf00  000fd1cd       2ce
+  _gs_unit@6
+                                  000fcf00       2ca   data ,l        7d
+    struct  {
+                                                 2ca
+      _gs_unit@6.dali102
+                                  000fcf00        6c
+    struct  {
+                                                  6c
+      _gs_unit@6.dali102.logical_unit_index
+                                  000fcf00         1   unsigned char
+      _gs_unit@6.dali102.reported_device_types_num
+                                  000fcf01         1   unsigned char
+      _gs_unit@6.dali102.pre_command_num
+                                  000fcf02         1   enum
+      _gs_unit@6.dali102.limit_error_is_enabled
+                                  000fcf03         1   _Bool
+      _gs_unit@6.dali102.needs_to_save_nvm
+                                  000fcf04         1   _Bool
+      _gs_unit@6.dali102.lamp_is_startup
+                                  000fcf05         1   _Bool
+      _gs_unit@6.dali102.var
+                                  000fcf06        34
+    struct  {
+                                                  34
+      _gs_unit@6.dali102.var.actual_level
+                                  000fcf06         2   unsigned short
+      _gs_unit@6.dali102.var.target_level
+                                  000fcf08         1   unsigned char
+      _gs_unit@6.dali102.var.last_active_level
+                                  000fcf09         1   unsigned char
+      _gs_unit@6.dali102.var.last_light_level
+                                  000fcf0a         1   unsigned char
+      _gs_unit@6.dali102.var.power_on_level
+                                  000fcf0b         1   unsigned char
+      _gs_unit@6.dali102.var.system_failure_level
+                                  000fcf0c         1   unsigned char
+      _gs_unit@6.dali102.var.min_level
+                                  000fcf0d         1   unsigned char
+      _gs_unit@6.dali102.var.max_level
+                                  000fcf0e         1   unsigned char
+      _gs_unit@6.dali102.var.fade_rate
+                                  000fcf0f         1   unsigned char
+      _gs_unit@6.dali102.var.fade_time
+                                  000fcf10         1   unsigned char
+      _gs_unit@6.dali102.var.extended_fade_time
+                                  000fcf11         1
+    struct  {
+                                                   1
+      _gs_unit@6.dali102.var.extended_fade_time.base
+                                  000fcf11         1   unsigned char:4(4)
+      _gs_unit@6.dali102.var.extended_fade_time.multiplier
+                                  000fcf11         1   unsigned char:3(1)
+    }
+      _gs_unit@6.dali102.var.short_address
+                                  000fcf12         1   unsigned char
+      _gs_unit@6.dali102.var.search_address
+                                  000fcf14         4   unsigned long
+      _gs_unit@6.dali102.var.random_address
+                                  000fcf18         4   unsigned long
+      _gs_unit@6.dali102.var.operating_mode
+                                  000fcf1c         1   unsigned char
+      _gs_unit@6.dali102.var.initialisation_state
+                                  000fcf1d         1   enum
+      _gs_unit@6.dali102.var.write_enable_state
+                                  000fcf1e         1   _Bool
+      _gs_unit@6.dali102.var.status
+                                  000fcf1f         1
+    struct  {
+                                                   1
+      _gs_unit@6.dali102.var.status.control_gear_failure
+                                  000fcf1f         1   _Bool:1(7)
+      _gs_unit@6.dali102.var.status.lamp_failure
+                                  000fcf1f         1   _Bool:1(6)
+      _gs_unit@6.dali102.var.status.lamp_on
+                                  000fcf1f         1   _Bool:1(5)
+      _gs_unit@6.dali102.var.status.limit_error
+                                  000fcf1f         1   _Bool:1(4)
+      _gs_unit@6.dali102.var.status.power_cycle_seen
+                                  000fcf1f         1   _Bool:1(3)
+    }
+      _gs_unit@6.dali102.var.gear_groups
+                                  000fcf20         2   unsigned short
+      _gs_unit@6.dali102.var.scene
+                                  000fcf22        10   unsigned char
+      _gs_unit@6.dali102.var.dtr0
+                                  000fcf32         1   unsigned char
+      _gs_unit@6.dali102.var.dtr1
+                                  000fcf33         1   unsigned char
+      _gs_unit@6.dali102.var.dtr2
+                                  000fcf34         1   unsigned char
+      _gs_unit@6.dali102.var.p_default_value
+                                  000fcf36         4   [near pointer]
+      _gs_unit@6.dali102.var.nvm_is_changed
+                                  000fcf38         1   _Bool
+    }
+      _gs_unit@6.dali102.fade
+                                  000fcf3a        14
+    struct  {
+                                                  14
+      _gs_unit@6.dali102.fade.is_running
+                                  000fcf3a         1   _Bool
+      _gs_unit@6.dali102.fade.invalid_fade_is_running
+                                  000fcf3b         1   _Bool
+      _gs_unit@6.dali102.fade.phm_fade_time_ms
+                                  000fcf3c         2   unsigned short
+      _gs_unit@6.dali102.fade.type
+                                  000fcf3e         1   enum
+      _gs_unit@6.dali102.fade.start_level
+                                  000fcf40         2   unsigned short
+      _gs_unit@6.dali102.fade.delta_level
+                                  000fcf42         4   signed long
+      _gs_unit@6.dali102.fade.fade_time_ms
+                                  000fcf46         4   unsigned long
+      _gs_unit@6.dali102.fade.counter
+                                  000fcf4a         4   unsigned long
+    }
+      _gs_unit@6.dali102.dtx_if_list
+                                  000fcf4e         a
+    struct  {
+                                                   a
+      _gs_unit@6.dali102.dtx_if_list.p_head
+                                  000fcf4e         4   [near pointer]
+      _gs_unit@6.dali102.dtx_if_list.p_cur
+                                  000fcf50         4   [near pointer]
+      _gs_unit@6.dali102.dtx_if_list.p_tail
+                                  000fcf52         4   [near pointer]
+      _gs_unit@6.dali102.dtx_if_list.offset
+                                  000fcf54         2   unsigned int
+      _gs_unit@6.dali102.dtx_if_list.size
+                                  000fcf56         1   unsigned char
+    }
+      _gs_unit@6.dali102.p_dtx_if
+                                  000fcf58         4   [near pointer]
+      _gs_unit@6.dali102.p_dt6_if
+                                  000fcf5a         4   [near pointer]
+      _gs_unit@6.dali102.p_dt8_if
+                                  000fcf5c         4   [near pointer]
+      _gs_unit@6.dali102.p_operating_mode_list
+                                  000fcf5e         4   [near pointer]
+      _gs_unit@6.dali102.p_light_source_list
+                                  000fcf60         4   [near pointer]
+      _gs_unit@6.dali102.initialise_timer
+                                  000fcf62         4
+    struct  {
+                                                   4
+      _gs_unit@6.dali102.initialise_timer.counter
+                                  000fcf62         4   unsigned long
+    }
+      _gs_unit@6.dali102.power_on_timer
+                                  000fcf66         2
+    struct  {
+                                                   2
+      _gs_unit@6.dali102.power_on_timer.counter
+                                  000fcf66         2   unsigned short
+    }
+      _gs_unit@6.dali102.identification_timer
+                                  000fcf68         2
+    struct  {
+                                                   2
+      _gs_unit@6.dali102.identification_timer.counter
+                                  000fcf68         2   unsigned short
+    }
+      _gs_unit@6.dali102.dapc_sequence_timer
+                                  000fcf6a         1
+    struct  {
+                                                   1
+      _gs_unit@6.dali102.dapc_sequence_timer.counter
+                                  000fcf6a         1   unsigned char
+    }
+    }
+      _gs_unit@6.dali207
+                                  000fcf6c        18
+    struct  {
+                                                  18
+      _gs_unit@6.dali207.p_dali102
+                                  000fcf6c         4   [near pointer]
+      _gs_unit@6.dali207.dtx_if
+                                  000fcf6e         6
+    struct  {
+                                                   6
+      _gs_unit@6.dali207.dtx_if.p_sc
+                                  000fcf6e         4   [near pointer]
+      _gs_unit@6.dali207.dtx_if.p_obj
+                                  000fcf70         4   [near pointer]
+      _gs_unit@6.dali207.dtx_if.list_item
+                                  000fcf72         2
+    struct dali102_list_item_t_ {
+                                                   2
+      _gs_unit@6.dali207.dtx_if.list_item.p_next
+                                  000fcf72         4   [near pointer]
+    }
+    }
+      _gs_unit@6.dali207.dt6_if
+                                  000fcf74         4
+    struct  {
+                                                   4
+      _gs_unit@6.dali207.dt6_if.p_sc
+                                  000fcf74         4   [near pointer]
+      _gs_unit@6.dali207.dt6_if.p_obj
+                                  000fcf76         4   [near pointer]
+    }
+      _gs_unit@6.dali207.var
+                                  000fcf78         8
+    struct  {
+                                                   8
+      _gs_unit@6.dali207.var.fast_fade_time
+                                  000fcf78         1   unsigned char
+      _gs_unit@6.dali207.var.failure_status
+                                  000fcf79         1   unsigned char
+      _gs_unit@6.dali207.var.operating_mode
+                                  000fcf7a         1   unsigned char
+      _gs_unit@6.dali207.var.dimming_curve
+                                  000fcf7b         1   unsigned char
+      _gs_unit@6.dali207.var.p_default_value
+                                  000fcf7c         4   [near pointer]
+      _gs_unit@6.dali207.var.reference_measurement_failed
+                                  000fcf7e         1   _Bool:1(7)
+      _gs_unit@6.dali207.var.current_protector_enabled
+                                  000fcf7e         1   _Bool:1(6)
+      _gs_unit@6.dali207.var.nvm_is_changed
+                                  000fcf7e         1   _Bool:1(5)
+    }
+      _gs_unit@6.dali207.measurement_timer
+                                  000fcf80         4
+    struct  {
+                                                   4
+      _gs_unit@6.dali207.measurement_timer.counter
+                                  000fcf80         4   unsigned long
+    }
+    }
+      _gs_unit@6.dali209
+                                  000fcf84       144
+    struct  {
+                                                 144
+      _gs_unit@6.dali209.p_dali102
+                                  000fcf84         4   [near pointer]
+      _gs_unit@6.dali209.dtx_if
+                                  000fcf86         6
+    struct  {
+                                                   6
+      _gs_unit@6.dali209.dtx_if.p_sc
+                                  000fcf86         4   [near pointer]
+      _gs_unit@6.dali209.dtx_if.p_obj
+                                  000fcf88         4   [near pointer]
+      _gs_unit@6.dali209.dtx_if.list_item
+                                  000fcf8a         2
+    struct dali102_list_item_t_ {
+                                                   2
+      _gs_unit@6.dali209.dtx_if.list_item.p_next
+                                  000fcf8a         4   [near pointer]
+    }
+    }
+      _gs_unit@6.dali209.dt8_if
+                                  000fcf8c         4
+    struct  {
+                                                   4
+      _gs_unit@6.dali209.dt8_if.p_sc
+                                  000fcf8c         4   [near pointer]
+      _gs_unit@6.dali209.dt8_if.p_obj
+                                  000fcf8e         4   [near pointer]
+    }
+      _gs_unit@6.dali209.var
+                                  000fcf90        ee
+    struct  {
+                                                  ee
+      _gs_unit@6.dali209.var.temporary_xy_coordinate
+                                  000fcf90         4   unsigned short
+      _gs_unit@6.dali209.var.report_xy_coordinate
+                                  000fcf94         4   unsigned short
+      _gs_unit@6.dali209.var.xy_coordinate
+                                  000fcf98         4   unsigned short
+      _gs_unit@6.dali209.var.temporary_colour_temperature_tc
+                                  000fcf9c         2   unsigned short
+      _gs_unit@6.dali209.var.report_colour_temperature_tc
+                                  000fcf9e         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc
+                                  000fcfa0         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc_coolest
+                                  000fcfa2         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc_warmest
+                                  000fcfa4         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc_physical_coolest
+                                  000fcfa6         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc_physical_warmest
+                                  000fcfa8         2   unsigned short
+      _gs_unit@6.dali209.var.colour_temperature_tc_step_increment
+                                  000fcfaa         1   unsigned char
+      _gs_unit@6.dali209.var.temporary_rgbwaf_dimlevel
+                                  000fcfab         6   unsigned char
+      _gs_unit@6.dali209.var.report_rgbwaf_dimlevel
+                                  000fcfb1         6   unsigned char
+      _gs_unit@6.dali209.var.rgbwaf_dimlevel
+                                  000fcfb7         6   unsigned char
+      _gs_unit@6.dali209.var.temporary_rgbwaf_control
+                                  000fcfbd         1   unsigned char
+      _gs_unit@6.dali209.var.report_rgbwaf_control
+                                  000fcfbe         1   unsigned char
+      _gs_unit@6.dali209.var.rgbwaf_control
+                                  000fcfbf         1   unsigned char
+      _gs_unit@6.dali209.var.derating_factor
+                                  000fcfc0         1   unsigned char
+      _gs_unit@6.dali209.var.enabled_channels
+                                  000fcfc1         1   unsigned char
+      _gs_unit@6.dali209.var.report_lightoutput_rgbwaf
+                                  000fcfc2         6   unsigned char
+      _gs_unit@6.dali209.var.temporary_colour_type
+                                  000fcfc8         1   unsigned char
+      _gs_unit@6.dali209.var.report_colour_type
+                                  000fcfc9         1   unsigned char
+      _gs_unit@6.dali209.var.last_active_colour_type
+                                  000fcfca         1   unsigned char
+      _gs_unit@6.dali209.var.last_active_colour_value
+                                  000fcfcc         8
+    union   {
+                                                   8
+      _gs_unit@6.dali209.var.last_active_colour_value.tc
+                                  000fcfcc         2   unsigned short
+      _gs_unit@6.dali209.var.last_active_colour_value.xy
+                                  000fcfcc         4   unsigned short
+      _gs_unit@6.dali209.var.last_active_colour_value.rgbwaf
+                                  000fcfcc         7
+    struct  {
+                                                   7
+      _gs_unit@6.dali209.var.last_active_colour_value.rgbwaf.control
+                                  000fcfcc         1   unsigned char
+      _gs_unit@6.dali209.var.last_active_colour_value.rgbwaf.value
+                                  000fcfcd         6   unsigned char
+    }
+    }
+      _gs_unit@6.dali209.var.scene_colour_type
+                                  000fcfd4        10   unsigned char
+      _gs_unit@6.dali209.var.scene_colour_value
+                                  000fcfe4        80
+    union   {
+                                                   8
+      _gs_unit@6.dali209.var.scene_colour_value.tc
+                                  000fcfe4         2   unsigned short
+      _gs_unit@6.dali209.var.scene_colour_value.xy
+                                  000fcfe4         4   unsigned short
+      _gs_unit@6.dali209.var.scene_colour_value.rgbwaf
+                                  000fcfe4         7
+    struct  {
+                                                   7
+      _gs_unit@6.dali209.var.scene_colour_value.rgbwaf.control
+                                  000fcfe4         1   unsigned char
+      _gs_unit@6.dali209.var.scene_colour_value.rgbwaf.value
+                                  000fcfe5         6   unsigned char
+    }
+    }
+      _gs_unit@6.dali209.var.power_on_colour_type
+                                  000fd064         1   unsigned char
+      _gs_unit@6.dali209.var.power_on_colour_value
+                                  000fd066         8
+    union   {
+                                                   8
+      _gs_unit@6.dali209.var.power_on_colour_value.tc
+                                  000fd066         2   unsigned short
+      _gs_unit@6.dali209.var.power_on_colour_value.xy
+                                  000fd066         4   unsigned short
+      _gs_unit@6.dali209.var.power_on_colour_value.rgbwaf
+                                  000fd066         7
+    struct  {
+                                                   7
+      _gs_unit@6.dali209.var.power_on_colour_value.rgbwaf.control
+                                  000fd066         1   unsigned char
+      _gs_unit@6.dali209.var.power_on_colour_value.rgbwaf.value
+                                  000fd067         6   unsigned char
+    }
+    }
+      _gs_unit@6.dali209.var.system_failure_colour_type
+                                  000fd06e         1   unsigned char
+      _gs_unit@6.dali209.var.system_failure_colour_value
+                                  000fd070         8
+    union   {
+                                                   8
+      _gs_unit@6.dali209.var.system_failure_colour_value.tc
+                                  000fd070         2   unsigned short
+      _gs_unit@6.dali209.var.system_failure_colour_value.xy
+                                  000fd070         4   unsigned short
+      _gs_unit@6.dali209.var.system_failure_colour_value.rgbwaf
+                                  000fd070         7
+    struct  {
+                                                   7
+      _gs_unit@6.dali209.var.system_failure_colour_value.rgbwaf.control
+                                  000fd070         1   unsigned char
+      _gs_unit@6.dali209.var.system_failure_colour_value.rgbwaf.value
+                                  000fd071         6   unsigned char
+    }
+    }
+      _gs_unit@6.dali209.var.gear_features_status
+                                  000fd078         1
+    struct  {
+                                                   1
+      _gs_unit@6.dali209.var.gear_features_status.automatic_activation
+                                  000fd078         1   _Bool:1(7)
+      _gs_unit@6.dali209.var.gear_features_status.tc_physical_limit_read_only
+                                  000fd078         1   _Bool:1(6)
+    }
+      _gs_unit@6.dali209.var.colour_status
+                                  000fd079         1
+    struct  {
+                                                   1
+      _gs_unit@6.dali209.var.colour_status.xy_out_of_range
+                                  000fd079         1   _Bool:1(7)
+      _gs_unit@6.dali209.var.colour_status.tc_out_of_range
+                                  000fd079         1   _Bool:1(6)
+      _gs_unit@6.dali209.var.colour_status.colour_type_xy_active
+                                  000fd079         1   _Bool:1(5)
+      _gs_unit@6.dali209.var.colour_status.colour_type_tc_active
+                                  000fd079         1   _Bool:1(4)
+      _gs_unit@6.dali209.var.colour_status.colour_type_rgbwaf_active
+                                  000fd079         1   _Bool:1(3)
+    }
+      _gs_unit@6.dali209.var.p_default_value
+                                  000fd07a         4   [near pointer]
+      _gs_unit@6.dali209.var.nvm_is_changed
+                                  000fd07c         1   _Bool
+    }
+      _gs_unit@6.dali209.fade
+                                  000fd07e        36
+    struct  {
+                                                  36
+      _gs_unit@6.dali209.fade.is_running
+                                  000fd07e         1   _Bool
+      _gs_unit@6.dali209.fade.invalid_fade_is_running
+                                  000fd07f         1   _Bool
+      _gs_unit@6.dali209.fade.phm_fade_time_ms
+                                  000fd080         2   unsigned short
+      _gs_unit@6.dali209.fade.level_fade_type
+                                  000fd082         1   enum
+      _gs_unit@6.dali209.fade.colour_fade_type
+                                  000fd083         1   enum
+      _gs_unit@6.dali209.fade.fade_time_ms
+                                  000fd084         4   unsigned long
+      _gs_unit@6.dali209.fade.counter
+                                  000fd088         4   unsigned long
+      _gs_unit@6.dali209.fade.rgbwaf_control
+                                  000fd08c         1   unsigned char
+      _gs_unit@6.dali209.fade.start
+                                  000fd08e         c
+    union   {
+                                                   c
+      _gs_unit@6.dali209.fade.start.tc
+                                  000fd08e         2   unsigned short
+      _gs_unit@6.dali209.fade.start.xy
+                                  000fd08e         4   unsigned short
+      _gs_unit@6.dali209.fade.start.rgbwaf
+                                  000fd08e         c   unsigned short
+    }
+      _gs_unit@6.dali209.fade.delta
+                                  000fd09a        1a
+    union   {
+                                                  1a
+      _gs_unit@6.dali209.fade.delta.tc
+                                  000fd09a         4   signed long
+      _gs_unit@6.dali209.fade.delta.xy
+                                  000fd09a         8   signed long
+      _gs_unit@6.dali209.fade.delta.rgbwaf
+                                  000fd09a        1a
+    struct  {
+                                                  1a
+      _gs_unit@6.dali209.fade.delta.rgbwaf.control
+                                  000fd09a         1   unsigned char
+      _gs_unit@6.dali209.fade.delta.rgbwaf.value
+                                  000fd09c        18   signed long
+    }
+    }
+    }
+      _gs_unit@6.dali209.supported_colour_type
+                                  000fd0b4         1   unsigned char
+      _gs_unit@6.dali209.active_colour_space
+                                  000fd0b5         1   unsigned char
+      _gs_unit@6.dali209.xy_target_colour_is_out_of_range
+                                  000fd0b6         1   _Bool
+      _gs_unit@6.dali209.center_point_xy_coordinate
+                                  000fd0b8         4   unsigned short
+      _gs_unit@6.dali209.red_xy_coordinate_for_cross_judge
+                                  000fd0bc         4   unsigned short
+      _gs_unit@6.dali209.green_xy_coordinate_for_cross_judge
+                                  000fd0c0         4   unsigned short
+      _gs_unit@6.dali209.blue_xy_coordinate_for_cross_judge
+                                  000fd0c4         4   unsigned short
+    }
+      _gs_unit@6.nvm
+                                  000fd0c8        e0
+    struct  {
+                                                  e0
+      _gs_unit@6.nvm.dali102
+                                  000fd0c8        22
+    struct  {
+                                                  22
+      _gs_unit@6.nvm.dali102.last_light_level
+                                  000fd0c8         1   unsigned char
+      _gs_unit@6.nvm.dali102.power_on_level
+                                  000fd0c9         1   unsigned char
+      _gs_unit@6.nvm.dali102.system_failure_level
+                                  000fd0ca         1   unsigned char
+      _gs_unit@6.nvm.dali102.min_level
+                                  000fd0cb         1   unsigned char
+      _gs_unit@6.nvm.dali102.max_level
+                                  000fd0cc         1   unsigned char
+      _gs_unit@6.nvm.dali102.fade_rate
+                                  000fd0cd         1   unsigned char
+      _gs_unit@6.nvm.dali102.fade_time
+                                  000fd0ce         1   unsigned char
+      _gs_unit@6.nvm.dali102.extended_fade_time
+                                  000fd0cf         1
+    struct  {
+                                                   1
+      _gs_unit@6.nvm.dali102.extended_fade_time.base
+                                  000fd0cf         1   unsigned char:4(4)
+      _gs_unit@6.nvm.dali102.extended_fade_time.multiplier
+                                  000fd0cf         1   unsigned char:3(1)
+    }
+      _gs_unit@6.nvm.dali102.short_address
+                                  000fd0d0         1   unsigned char
+      _gs_unit@6.nvm.dali102.random_address
+                                  000fd0d2         4   unsigned long
+      _gs_unit@6.nvm.dali102.operating_mode
+                                  000fd0d6         1   unsigned char
+      _gs_unit@6.nvm.dali102.gear_groups
+                                  000fd0d8         2   unsigned short
+      _gs_unit@6.nvm.dali102.scene
+                                  000fd0da        10   unsigned char
+    }
+      _gs_unit@6.nvm.dali207
+                                  000fd0ea         3
+    struct  {
+                                                   3
+      _gs_unit@6.nvm.dali207.fast_fade_time
+                                  000fd0ea         1   unsigned char
+      _gs_unit@6.nvm.dali207.dimming_curve
+                                  000fd0eb         1   unsigned char
+      _gs_unit@6.nvm.dali207.reference_measurement_failed
+                                  000fd0ec         1   _Bool:1(7)
+      _gs_unit@6.nvm.dali207.current_protector_enabled
+                                  000fd0ec         1   _Bool:1(6)
+    }
+      _gs_unit@6.nvm.dali209
+                                  000fd0ee        b8
+    struct  {
+                                                  b8
+      _gs_unit@6.nvm.dali209.last_active_colour_type
+                                  000fd0ee         1   unsigned char
+      _gs_unit@6.nvm.dali209.last_active_colour_value
+                                  000fd0f0         8
+    union   {
+                                                   8
+      _gs_unit@6.nvm.dali209.last_active_colour_value.tc
+                                  000fd0f0         2   unsigned short
+      _gs_unit@6.nvm.dali209.last_active_colour_value.xy
+                                  000fd0f0         4   unsigned short
+      _gs_unit@6.nvm.dali209.last_active_colour_value.rgbwaf
+                                  000fd0f0         7
+    struct  {
+                                                   7
+      _gs_unit@6.nvm.dali209.last_active_colour_value.rgbwaf.control
+                                  000fd0f0         1   unsigned char
+      _gs_unit@6.nvm.dali209.last_active_colour_value.rgbwaf.value
+                                  000fd0f1         6   unsigned char
+    }
+    }
+      _gs_unit@6.nvm.dali209.scene_colour_type
+                                  000fd0f8        10   unsigned char
+      _gs_unit@6.nvm.dali209.scene_colour_value
+                                  000fd108        80
+    union   {
+                                                   8
+      _gs_unit@6.nvm.dali209.scene_colour_value.tc
+                                  000fd108         2   unsigned short
+      _gs_unit@6.nvm.dali209.scene_colour_value.xy
+                                  000fd108         4   unsigned short
+      _gs_unit@6.nvm.dali209.scene_colour_value.rgbwaf
+                                  000fd108         7
+    struct  {
+                                                   7
+      _gs_unit@6.nvm.dali209.scene_colour_value.rgbwaf.control
+                                  000fd108         1   unsigned char
+      _gs_unit@6.nvm.dali209.scene_colour_value.rgbwaf.value
+                                  000fd109         6   unsigned char
+    }
+    }
+      _gs_unit@6.nvm.dali209.power_on_colour_type
+                                  000fd188         1   unsigned char
+      _gs_unit@6.nvm.dali209.power_on_colour_value
+                                  000fd18a         8
+    union   {
+                                                   8
+      _gs_unit@6.nvm.dali209.power_on_colour_value.tc
+                                  000fd18a         2   unsigned short
+      _gs_unit@6.nvm.dali209.power_on_colour_value.xy
+                                  000fd18a         4   unsigned short
+      _gs_unit@6.nvm.dali209.power_on_colour_value.rgbwaf
+                                  000fd18a         7
+    struct  {
+                                                   7
+      _gs_unit@6.nvm.dali209.power_on_colour_value.rgbwaf.control
+                                  000fd18a         1   unsigned char
+      _gs_unit@6.nvm.dali209.power_on_colour_value.rgbwaf.value
+                                  000fd18b         6   unsigned char
+    }
+    }
+      _gs_unit@6.nvm.dali209.system_failure_colour_type
+                                  000fd192         1   unsigned char
+      _gs_unit@6.nvm.dali209.system_failure_colour_value
+                                  000fd194         8
+    union   {
+                                                   8
+      _gs_unit@6.nvm.dali209.system_failure_colour_value.tc
+                                  000fd194         2   unsigned short
+      _gs_unit@6.nvm.dali209.system_failure_colour_value.xy
+                                  000fd194         4   unsigned short
+      _gs_unit@6.nvm.dali209.system_failure_colour_value.rgbwaf
+                                  000fd194         7
+    struct  {
+                                                   7
+      _gs_unit@6.nvm.dali209.system_failure_colour_value.rgbwaf.control
+                                  000fd194         1   unsigned char
+      _gs_unit@6.nvm.dali209.system_failure_colour_value.rgbwaf.value
+                                  000fd195         6   unsigned char
+    }
+    }
+      _gs_unit@6.nvm.dali209.colour_temperature_tc_coolest
+                                  000fd19c         2   unsigned short
+      _gs_unit@6.nvm.dali209.colour_temperature_tc_warmest
+                                  000fd19e         2   unsigned short
+      _gs_unit@6.nvm.dali209.colour_temperature_tc_physical_coolest
+                                  000fd1a0         2   unsigned short
+      _gs_unit@6.nvm.dali209.colour_temperature_tc_physical_warmest
+                                  000fd1a2         2   unsigned short
+      _gs_unit@6.nvm.dali209.colour_temperature_tc_step_increment
+                                  000fd1a4         1   unsigned char
+      _gs_unit@6.nvm.dali209.enabled_channels
+                                  000fd1a5         1   unsigned char
+    }
+      _gs_unit@6.nvm.debug
+                                  000fd1a6         2
+    struct  {
+                                                   2
+      _gs_unit@6.nvm.debug.failure_procedure
+                                  000fd1a6         2   unsigned short
+    }
+    }
+      _gs_unit@6.banks
+                                  000fd1a8        14
+    struct  {
+                                                  14
+      _gs_unit@6.banks.bank
+                                  000fd1a8         4
+    struct memory_bank_t_ {
+                                                   4
+      _gs_unit@6.banks.bank.p_location
+                                  000fd1a8         4   [near pointer]
+      _gs_unit@6.banks.bank.nvm_is_changed
+                                  000fd1aa         1   _Bool
+    }
+      _gs_unit@6.banks.buf_data
+                                  000fd1ac         8   unsigned char
+      _gs_unit@6.banks.buf_status
+                                  000fd1b4         1   enum
+      _gs_unit@6.banks.buf_bank_num
+                                  000fd1b6         2   signed short
+      _gs_unit@6.banks.buf_address
+                                  000fd1b8         2   signed short
+      _gs_unit@6.banks.buf_index
+                                  000fd1ba         1   unsigned char
+    }
+      _gs_unit@6.phm_fade_time_ms
+                                  000fd1bc         2   unsigned short
+      _gs_unit@6.p_dali102_default
+                                  000fd1be         4   [near pointer]
+      _gs_unit@6.p_dali207_default
+                                  000fd1c0         4   [near pointer]
+      _gs_unit@6.p_dali209_default
+                                  000fd1c2         4   [near pointer]
+      _gs_unit@6.p_light_source_type
+                                  000fd1c4         4   [near pointer]
+      _gs_unit@6.p_operating_mode_list
+                                  000fd1c6         4   [near pointer]
+      _gs_unit@6.p_bank_info_list
+                                  000fd1c8         4   [near pointer]
+    }
+  _pre_level@14@colour_report@1
+                                  000fd1ca         1   data ,l         4
+  _pre_tc@15@colour_report@1
+                                  000fd1cc         2   data ,l         2
+FILE=DefaultBuild\r_main.obj
+                                  000fd1ce  000fd3e1       214
+  _s_recv_buf@1
+                                  000fd1ce       204   data ,l         5
+  _s_serial_num@4
+                                  000fd3d2         4   data ,l         c
+  _variable_number@5
+                                  000fd3d6         1   data ,l         2
+  _g_send_busy_flg
+                                  000fd3d7         1   data ,g         3
+  _g_run_ack_flg
+                                  000fd3d8         1   data ,g         3
+  _g_variable_flg
+                                  000fd3d9         1   data ,g         2
+  _request_flag
+                                  000fd3da         1   data ,g         3
+  _sp_analysis_rtn@9@negotiation_cmd_packet@1
+                                  000fd3dc         2   data ,l         1
+  _sp_analysis_rtn@11@registVariable_cmd_packet@1
+                                  000fd3de         2   data ,l         1
+  _sp_analysis_rtn@13@run_stop_cmd_packet@1
+                                  000fd3e0         2   data ,l         1
+FILE=DefaultBuild\r_dali101_rx.obj
+                                  000fd3e2  000fd3ec         b
+  _gs_bus_timer_mode@1
+                                  000fd3e2         1   data ,l         c
+  _gs_idle_time_us@2
+                                  000fd3e4         4   data ,l        10
+  _gs_active_time_us@3
+                                  000fd3e8         4   data ,l         c
+  _gs_system_failure_is_detected@4
+                                  000fd3ec         1   data ,l         4
+FILE=DefaultBuild\r_led.obj
+                                  000fd3ee  000fd3f6         9
+  _A1
+                                  000fd3ee         4   data ,g         3
+  _A2
+                                  000fd3f2         4   data ,g         3
+  _gs_feedback@2
+                                  000fd3f6         1   data ,l         4
+FILE=DefaultBuild\r_led1.obj
+                                  000fd3f8  000fd3fb         4
+  _g_led1_feedback_is_enabled
+                                  000fd3f8         1   data ,g         5
+  _gs_led_current_level@1
+                                  000fd3fa         2   data ,l         2
+FILE=DefaultBuild\r_led2.obj
+                                  000fd3fc  000fd3ff         4
+  _g_led2_feedback_is_enabled
+                                  000fd3fc         1   data ,g         5
+  _gs_led_current_level@1
+                                  000fd3fe         2   data ,l         2
+FILE=DefaultBuild\r_led3.obj
+                                  000fd400  000fd403         4
+  _g_led3_feedback_is_enabled
+                                  000fd400         1   data ,g         5
+  _gs_led_current_level@1
+                                  000fd402         2   data ,l         2
+FILE=DefaultBuild\Config_TAU_user.obj
+                                  000fd404  000fd408         5
+  _count
+                                  000fd404         2   data ,g         3
+  _maxCount
+                                  000fd406         2   data ,g         2
+  _timer_flag
+                                  000fd408         1   data ,g         3
+FILE=DefaultBuild\Config_UART_user.obj
+                                  000fd40a  000fd40b         2
+  _g_tx_end_flag
+                                  000fd40a         1   data ,g         0
+  _g_rx_end_flag
+                                  000fd40b         1   data ,g         1
+FILE=r_dali102
+                                  000fd40c  000fd40d         2
+  _gsp_gen_callback@1
+                                  000fd40c         2   data ,l         2
+FILE=r_dali102_mb_if
+                                  000fd40e  000fd40f         2
+  _gsp_callback@1
+                                  000fd40e         2   data ,l         6
+FILE=r_dali209
+                                  000fd410  000fd411         2
+  _gsp_gen_callback@1
+                                  000fd410         2   data ,l        21
+
+SECTION=.stack_bss
+FILE=DefaultBuild\cstart.obj
+                                  000fd412  000fd611       200
+  _stackend
+                                  000fd412         0   none ,l         0
+  _stacktop
+                                  000fd612         0   none ,l         0
+
+SECTION=.bss
+FILE=DefaultBuild\r_nvm.obj
+                                  000fd612  000fd73f       12e
+  _gs_task@1
+                                  000fd612       106   data ,l        2d
+    struct  {
+                                                 106
+      _gs_task@1.name
+                                  000fd612         1   enum
+      _gs_task@1.p_storage
+                                  000fd614         4   [near pointer]
+      _gs_task@1.state
+                                  000fd616         2   unsigned short
+      _gs_task@1.buf
+                                  000fd618       100   unsigned char
+    }
+  _gs_storage@2
+                                  000fd718        1c   data ,l        41
+    struct  {
+                                                   e
+      _gs_storage@2.writable
+                                  000fd718         2   _Bool
+      _gs_storage@2.block
+                                  000fd71a         2   unsigned char
+      _gs_storage@2.valid_index
+                                  000fd71c         1   signed char
+      _gs_storage@2.id
+                                  000fd71d         1   unsigned char
+      _gs_storage@2.request
+                                  000fd71e         1   unsigned char
+      _gs_storage@2.p_data
+                                  000fd720         4   [near pointer]
+      _gs_storage@2.write_data_num
+                                  000fd722         2   unsigned short
+      _gs_storage@2.data_size
+                                  000fd724         2   unsigned short
+    }
+  _gs_df@3
+                                  000fd734         c   data ,l        37
+    struct  {
+                                                   c
+      _gs_df@3.address
+                                  000fd734         4   unsigned long
+      _gs_df@3.p_data
+                                  000fd738         4   [near pointer]
+      _gs_df@3.i
+                                  000fd73a         2   unsigned short
+      _gs_df@3.size
+                                  000fd73c         2   unsigned short
+      _gs_df@3.phy_block
+                                  000fd73e         1   unsigned char
+    }
+FILE=DefaultBuild\r_random.obj
+                                  000fd740  000fd743         4
+  _gs_seed@1
+                                  000fd740         4   data ,l         f
+FILE=DefaultBuild\r_cg.obj
+                                  000fd744  000fd93b       1f8
+  _gs_storage0@7
+                                  000fd744         c   data ,l         d
+    struct  {
+                                                   c
+      _gs_storage0@7.dali102
+                                  000fd744         1
+    struct  {
+                                                   1
+      _gs_storage0@7.dali102.last_light_level
+                                  000fd744         1   unsigned char
+    }
+      _gs_storage0@7.dali209
+                                  000fd746         a
+    struct  {
+                                                   a
+      _gs_storage0@7.dali209.last_active_colour_type
+                                  000fd746         1   unsigned char
+      _gs_storage0@7.dali209.last_active_colour_value
+                                  000fd748         8
+    union   {
+                                                   8
+      _gs_storage0@7.dali209.last_active_colour_value.tc
+                                  000fd748         2   unsigned short
+      _gs_storage0@7.dali209.last_active_colour_value.xy
+                                  000fd748         4   unsigned short
+      _gs_storage0@7.dali209.last_active_colour_value.rgbwaf
+                                  000fd748         7
+    struct  {
+                                                   7
+      _gs_storage0@7.dali209.last_active_colour_value.rgbwaf.control
+                                  000fd748         1   unsigned char
+      _gs_storage0@7.dali209.last_active_colour_value.rgbwaf.value
+                                  000fd749         6   unsigned char
+    }
+    }
+    }
+    }
+  _gs_storage1@8
+                                  000fd750        d4   data ,l        54
+    struct  {
+                                                  d4
+      _gs_storage1@8.dali102
+                                  000fd750        20
+    struct  {
+                                                  20
+      _gs_storage1@8.dali102.power_on_level
+                                  000fd750         1   unsigned char
+      _gs_storage1@8.dali102.system_failure_level
+                                  000fd751         1   unsigned char
+      _gs_storage1@8.dali102.min_level
+                                  000fd752         1   unsigned char
+      _gs_storage1@8.dali102.max_level
+                                  000fd753         1   unsigned char
+      _gs_storage1@8.dali102.fade_rate
+                                  000fd754         1   unsigned char
+      _gs_storage1@8.dali102.fade_time
+                                  000fd755         1   unsigned char
+      _gs_storage1@8.dali102.extended_fade_time
+                                  000fd756         1
+    struct  {
+                                                   1
+      _gs_storage1@8.dali102.extended_fade_time.base
+                                  000fd756         1   unsigned char:4(4)
+      _gs_storage1@8.dali102.extended_fade_time.multiplier
+                                  000fd756         1   unsigned char:3(1)
+    }
+      _gs_storage1@8.dali102.short_address
+                                  000fd757         1   unsigned char
+      _gs_storage1@8.dali102.random_address
+                                  000fd758         4   unsigned long
+      _gs_storage1@8.dali102.operating_mode
+                                  000fd75c         1   unsigned char
+      _gs_storage1@8.dali102.gear_groups
+                                  000fd75e         2   unsigned short
+      _gs_storage1@8.dali102.scene
+                                  000fd760        10   unsigned char
+    }
+      _gs_storage1@8.dali207
+                                  000fd770         3
+    struct  {
+                                                   3
+      _gs_storage1@8.dali207.fast_fade_time
+                                  000fd770         1   unsigned char
+      _gs_storage1@8.dali207.dimming_curve
+                                  000fd771         1   unsigned char
+      _gs_storage1@8.dali207.reference_measurement_failed
+                                  000fd772         1   _Bool:1(7)
+      _gs_storage1@8.dali207.current_protector_enabled
+                                  000fd772         1   _Bool:1(6)
+    }
+      _gs_storage1@8.dali209
+                                  000fd774        ae
+    struct  {
+                                                  ae
+      _gs_storage1@8.dali209.scene_colour_type
+                                  000fd774        10   unsigned char
+      _gs_storage1@8.dali209.scene_colour_value
+                                  000fd784        80
+    union   {
+                                                   8
+      _gs_storage1@8.dali209.scene_colour_value.tc
+                                  000fd784         2   unsigned short
+      _gs_storage1@8.dali209.scene_colour_value.xy
+                                  000fd784         4   unsigned short
+      _gs_storage1@8.dali209.scene_colour_value.rgbwaf
+                                  000fd784         7
+    struct  {
+                                                   7
+      _gs_storage1@8.dali209.scene_colour_value.rgbwaf.control
+                                  000fd784         1   unsigned char
+      _gs_storage1@8.dali209.scene_colour_value.rgbwaf.value
+                                  000fd785         6   unsigned char
+    }
+    }
+      _gs_storage1@8.dali209.power_on_colour_type
+                                  000fd804         1   unsigned char
+      _gs_storage1@8.dali209.power_on_colour_value
+                                  000fd806         8
+    union   {
+                                                   8
+      _gs_storage1@8.dali209.power_on_colour_value.tc
+                                  000fd806         2   unsigned short
+      _gs_storage1@8.dali209.power_on_colour_value.xy
+                                  000fd806         4   unsigned short
+      _gs_storage1@8.dali209.power_on_colour_value.rgbwaf
+                                  000fd806         7
+    struct  {
+                                                   7
+      _gs_storage1@8.dali209.power_on_colour_value.rgbwaf.control
+                                  000fd806         1   unsigned char
+      _gs_storage1@8.dali209.power_on_colour_value.rgbwaf.value
+                                  000fd807         6   unsigned char
+    }
+    }
+      _gs_storage1@8.dali209.system_failure_colour_type
+                                  000fd80e         1   unsigned char
+      _gs_storage1@8.dali209.system_failure_colour_value
+                                  000fd810         8
+    union   {
+                                                   8
+      _gs_storage1@8.dali209.system_failure_colour_value.tc
+                                  000fd810         2   unsigned short
+      _gs_storage1@8.dali209.system_failure_colour_value.xy
+                                  000fd810         4   unsigned short
+      _gs_storage1@8.dali209.system_failure_colour_value.rgbwaf
+                                  000fd810         7
+    struct  {
+                                                   7
+      _gs_storage1@8.dali209.system_failure_colour_value.rgbwaf.control
+                                  000fd810         1   unsigned char
+      _gs_storage1@8.dali209.system_failure_colour_value.rgbwaf.value
+                                  000fd811         6   unsigned char
+    }
+    }
+      _gs_storage1@8.dali209.colour_temperature_tc_coolest
+                                  000fd818         2   unsigned short
+      _gs_storage1@8.dali209.colour_temperature_tc_warmest
+                                  000fd81a         2   unsigned short
+      _gs_storage1@8.dali209.colour_temperature_tc_physical_coolest
+                                  000fd81c         2   unsigned short
+      _gs_storage1@8.dali209.colour_temperature_tc_physical_warmest
+                                  000fd81e         2   unsigned short
+      _gs_storage1@8.dali209.colour_temperature_tc_step_increment
+                                  000fd820         1   unsigned char
+      _gs_storage1@8.dali209.enabled_channels
+                                  000fd821         1   unsigned char
+    }
+      _gs_storage1@8.debug
+                                  000fd822         2
+    struct  {
+                                                   2
+      _gs_storage1@8.debug.failure_procedure
+                                  000fd822         2   unsigned short
+    }
+    }
+  _gs_auto_save_timer@9
+                                  000fd824         2   data ,l         4
+    struct  {
+                                                   2
+      _gs_auto_save_timer@9.counter
+                                  000fd824         2   signed short
+    }
+  _gs_system_failure@10
+                                  000fd826         1   data ,l         3
+  _gs_colour_report_timer@11
+                                  000fd828         2   data ,l         4
+    struct  {
+                                                   2
+      _gs_colour_report_timer@11.counter
+                                  000fd828         2   signed short
+    }
+  _pre_xy@16@colour_report@1
+                                  000fd82a         4   data ,l         4
+    struct  {
+                                                   4
+      _pre_xy@16@colour_report@1.coordinate_x
+                                  000fd82a         2   unsigned short
+      _pre_xy@16@colour_report@1.coordinate_y
+                                  000fd82c         2   unsigned short
+    }
+  _pre_rgbwaf@17@colour_report@1
+                                  000fd82e         e   data ,l         a
+    struct  {
+                                                   e
+      _pre_rgbwaf@17@colour_report@1.colour_value_rgbwaf
+                                  000fd82e         c   unsigned short
+      _pre_rgbwaf@17@colour_report@1.enabled_channels
+                                  000fd83a         1   unsigned char
+    }
+  _msg@18@colour_report@1
+                                  000fd83c       100   data ,l         8
+FILE=DefaultBuild\r_debug.obj
+                                  000fd93c  000fd941         6
+  _gs_debug@1
+                                  000fd93c         6   data ,l        41
+    struct  {
+                                                   6
+      _gs_debug@1.lamp
+                                  000fd93c         1   enum
+      _gs_debug@1.control_gear
+                                  000fd93d         1   enum
+      _gs_debug@1.failure_procedure
+                                  000fd93e         2   unsigned short
+      _gs_debug@1.measurement_is_finished
+                                  000fd940         1   _Bool
+      _gs_debug@1.nvm_is_changed
+                                  000fd941         1   _Bool
+    }
+FILE=DefaultBuild\r_main.obj
+                                  000fd942  000fdd5b       41a
+  _s_variable_pkt@2
+                                  000fd942       204   data ,l         a
+  _s_send_pkt@3
+                                  000fdb46       204   data ,l         b
+  _s_analysis_rtn@6@QE4LigHTHING_COMM_AnalysisPacket
+                                  000fdd4a         4   data ,l         3
+    struct  {
+                                                   4
+      _s_analysis_rtn@6@QE4LigHTHING_COMM_AnalysisPacket.lighting_err
+                                  000fdd4a         1   enum
+      _s_analysis_rtn@6@QE4LigHTHING_COMM_AnalysisPacket.resp_len
+                                  000fdd4c         2   unsigned int
+    }
+  _sp_analysis_rtn@7@QE4LigHTHING_COMM_AnalysisPacket
+                                  000fdd4e         2   data ,l         2
+  _s_analysis_rtn@8@negotiation_cmd_packet@1
+                                  000fdd50         4   data ,l         3
+    struct  {
+                                                   4
+      _s_analysis_rtn@8@negotiation_cmd_packet@1.lighting_err
+                                  000fdd50         1   enum
+      _s_analysis_rtn@8@negotiation_cmd_packet@1.resp_len
+                                  000fdd52         2   unsigned int
+    }
+  _s_analysis_rtn@10@registVariable_cmd_packet@1
+                                  000fdd54         4   data ,l         3
+    struct  {
+                                                   4
+      _s_analysis_rtn@10@registVariable_cmd_packet@1.lighting_err
+                                  000fdd54         1   enum
+      _s_analysis_rtn@10@registVariable_cmd_packet@1.resp_len
+                                  000fdd56         2   unsigned int
+    }
+  _s_analysis_rtn@12@run_stop_cmd_packet@1
+                                  000fdd58         4   data ,l         5
+    struct  {
+                                                   4
+      _s_analysis_rtn@12@run_stop_cmd_packet@1.lighting_err
+                                  000fdd58         1   enum
+      _s_analysis_rtn@12@run_stop_cmd_packet@1.resp_len
+                                  000fdd5a         2   unsigned int
+    }
+FILE=DefaultBuild\r_dali101_bft.obj
+                                  000fdd5c  000fdd5f         4
+  _gs_backward@1
+                                  000fdd5c         2   data ,l         e
+    struct  {
+                                                   2
+      _gs_backward@1.data
+                                  000fdd5c         1   unsigned char
+      _gs_backward@1.is_corrupted
+                                  000fdd5d         1   _Bool:1(7)
+      _gs_backward@1.exists
+                                  000fdd5d         1   _Bool:1(6)
+    }
+  _gs_send_timer@2
+                                  000fdd5e         2   data ,l         5
+    struct  {
+                                                   2
+      _gs_send_timer@2.counter
+                                  000fdd5e         2   signed short
+    }
+FILE=DefaultBuild\r_dali101_rx.obj
+                                  000fdd60  000fdd73        14
+  _gs_frame@5
+                                  000fdd60         a   data ,l        1b
+    struct  {
+                                                   a
+      _gs_frame@5.data
+                                  000fdd60         4   unsigned long
+      _gs_frame@5.settling_time_us
+                                  000fdd64         4   unsigned long
+      _gs_frame@5.length
+                                  000fdd68         1   signed char
+      _gs_frame@5.is_twice
+                                  000fdd69         1   _Bool
+    }
+  _gs_last_frame@6
+                                  000fdd6a         a   data ,l         d
+    struct  {
+                                                   a
+      _gs_last_frame@6.data
+                                  000fdd6a         4   unsigned long
+      _gs_last_frame@6.settling_time_us
+                                  000fdd6e         4   unsigned long
+      _gs_last_frame@6.length
+                                  000fdd72         1   signed char
+      _gs_last_frame@6.is_twice
+                                  000fdd73         1   _Bool
+    }
+FILE=DefaultBuild\r_lamp_tc.obj
+                                  000fdd74  000fdd77         4
+  _gs_cooler_level@1
+                                  000fdd74         2   data ,l         5
+  _gs_warmer_level@2
+                                  000fdd76         2   data ,l         5
+FILE=DefaultBuild\r_lamp.obj
+                                  000fdd78  000fdd8f        18
+  _gs_lamp@2
+                                  000fdd78        18   data ,l        38
+    struct  {
+                                                  18
+      _gs_lamp@2.startup_timer
+                                  000fdd78         2
+    struct  {
+                                                   2
+      _gs_lamp@2.startup_timer.counter
+                                  000fdd78         2   signed short
+    }
+      _gs_lamp@2.flashing_timer
+                                  000fdd7a         2
+    struct  {
+                                                   2
+      _gs_lamp@2.flashing_timer.counter
+                                  000fdd7a         2   signed short
+    }
+      _gs_lamp@2.dimming_level
+                                  000fdd7c         1   unsigned char
+      _gs_lamp@2.dimming_curve
+                                  000fdd7d         1   unsigned char
+      _gs_lamp@2.phm
+                                  000fdd7e         1   unsigned char
+      _gs_lamp@2.colour_space
+                                  000fdd7f         1   unsigned char
+      _gs_lamp@2.tc
+                                  000fdd80         2   unsigned short
+      _gs_lamp@2.coordinate_x
+                                  000fdd82         2   unsigned short
+      _gs_lamp@2.coordinate_y
+                                  000fdd84         2   unsigned short
+      _gs_lamp@2.light_output
+                                  000fdd86         6   unsigned short
+      _gs_lamp@2.enable_channel
+                                  000fdd8c         1   unsigned char
+      _gs_lamp@2.flashing_state_is_on
+                                  000fdd8d         1   _Bool
+      _gs_lamp@2.current_protector_is_enabled
+                                  000fdd8e         1   _Bool
+    }
+FILE=DefaultBuild\r_lamp_rgbwaf.obj
+                                  000fdd90  000fdd95         6
+  _gs_red_level@1
+                                  000fdd90         2   data ,l         5
+  _gs_green_level@2
+                                  000fdd92         2   data ,l         5
+  _gs_blue_level@3
+                                  000fdd94         2   data ,l         5
+FILE=DefaultBuild\r_lamp_xy.obj
+                                  000fdd96  000fdd9b         6
+  _gs_xy_red_level@1
+                                  000fdd96         2   data ,l         5
+  _gs_xy_green_level@2
+                                  000fdd98         2   data ,l         5
+  _gs_xy_blue_level@3
+                                  000fdd9a         2   data ,l         5
+FILE=DefaultBuild\Config_DALI.obj
+                                  000fdd9c  000fdda1         6
+  _g_rx_frame_data
+                                  000fdd9c         4   data ,g         6
+  _g_rx_frame_length
+                                  000fdda0         1   data ,g         4
+  _g_rx_frame_exists
+                                  000fdda1         1   data ,g         4
+FILE=DefaultBuild\Config_UART.obj
+                                  000fdda2  000fddab         a
+  _gp_uart1_tx_address
+                                  000fdda2         2   data ,g         5
+  _g_uart1_tx_count
+                                  000fdda4         2   data ,g         4
+  _gp_uart1_rx_address
+                                  000fdda6         2   data ,g         4
+  _g_uart1_rx_count
+                                  000fdda8         2   data ,g         5
+  _g_uart1_rx_length
+                                  000fddaa         2   data ,g         3
+FILE=sprintf
+                                  000fddac  000fddaf         4
+  __REL_pointer@1
+                                  000fddac         4   data ,l        10
+FILE=_REL_print
+                                  000fddb0  000fde2f        80
+  _qt@1@_REL_inmod@1
+                                  000fddb0        80   data ,l         3
+
+SECTION=RFD_DATA_nR
+FILE=DefaultBuild\r_rfd_common_api.obj
+                                  000fde30  000fde32         3
+  _g_u08_change_interrupt_vector_flag
+                                  000fde30         1   data ,g         4
+  _g_u08_cpu_frequency
+                                  000fde31         1   data ,g         4
+  _g_u08_fset_cpu_frequency
+                                  000fde32         1   data ,g         4
+FILE=DefaultBuild\r_rfd_common_userown.obj
+                                  000fde34  000fde34         1
+  _sg_u08_psw_ie_state@1
+                                  000fde34         1   data ,l         2
+
+SECTION=.sdataR
+FILE=DefaultBuild\r_led.obj
+                                  000ffe20  000ffe21         2
+  _gs_get_value@1
+                                  000ffe20         2   data ,l         4
+FILE=DefaultBuild\r_led1.obj
+                                  000ffe22  000ffe31        10
+  _g_led1_vr
+                                  000ffe22         2   data ,g         5
+  _g_led1_fb_ad
+                                  000ffe24         2   data ,g         4
+  _g_led1_fb_ad_old
+                                  000ffe26         2   data ,g         4
+  _g_led1_offset
+                                  000ffe28         2   data ,g         3
+  _g_led1_duty
+                                  000ffe2a         4   data ,g         f
+  _g_led1_err
+                                  000ffe2e         4   data ,g         8
+FILE=DefaultBuild\r_led2.obj
+                                  000ffe32  000ffe41        10
+  _g_led2_vr
+                                  000ffe32         2   data ,g         5
+  _g_led2_fb_ad
+                                  000ffe34         2   data ,g         4
+  _g_led2_fb_ad_old
+                                  000ffe36         2   data ,g         4
+  _g_led2_offset
+                                  000ffe38         2   data ,g         3
+  _g_led2_duty
+                                  000ffe3a         4   data ,g         f
+  _g_led2_err
+                                  000ffe3e         4   data ,g         8
+FILE=DefaultBuild\r_led3.obj
+                                  000ffe42  000ffe51        10
+  _g_led3_vr
+                                  000ffe42         2   data ,g         5
+  _g_led3_fb_ad
+                                  000ffe44         2   data ,g         4
+  _g_led3_fb_ad_old
+                                  000ffe46         2   data ,g         4
+  _g_led3_offset
+                                  000ffe48         2   data ,g         3
+  _g_led3_duty
+                                  000ffe4a         4   data ,g         f
+  _g_led3_err
+                                  000ffe4e         4   data ,g         8
+
+Absolute value symbols
+FILE=DefaultBuild\r_nvm.obj
+  @$IMM_14
+                                  00000014         0   none ,l         1
+FILE=DefaultBuild\r_debug.obj
+  @$IMM_96
+                                  00000096         0   none ,l         1
+FILE=DefaultBuild\r_main.obj
+  @$IMM_2
+                                  00000002         0   none ,l         1
+FILE=rlink_generates_05
+  __s.textf
+                                  00006eda         0   none ,g         0
+  __e.textf
+                                  000149a5         0   none ,g         0
+  __s.const
+                                  00002000         0   none ,g         0
+  __e.const
+                                  000043bd         0   none ,g         0
+  __s.bss
+                                  000fd612         0   none ,g         0
+  __e.bss
+                                  000fde30         0   none ,g         0
+  __sNVM_f
+                                  0001512e         0   none ,g         0
+  __eNVM_f
+                                  00015b7f         0   none ,g         0
+  __s.data
+                                  000149ba         0   none ,g         0
+  __e.data
+                                  00014ecc         0   none ,g         0
+  __s.text
+                                  000043bd         0   none ,g         0
+  __e.text
+                                  000045ee         0   none ,g         0
+  __s.sdata
+                                  00014ecc         0   none ,g         0
+  __e.sdata
+                                  00014efe         0   none ,g         0
+  __sRFD_DF_f
+                                  000150e1         0   none ,g         0
+  __eRFD_DF_f
+                                  0001512e         0   none ,g         0
+  __sRFD_CMN_f
+                                  00014f03         0   none ,g         0
+  __eRFD_CMN_f
+                                  000150e1         0   none ,g         0
+  __sRFD_DATA_n
+                                  00014efe         0   none ,g         0
+  __eRFD_DATA_n
+                                  00014f03         0   none ,g         0
+  __sRFD_DATA_nR
+                                  000fde30         0   none ,g         0
+  __eRFD_DATA_nR
+                                  000fde35         0   none ,g         0
+  __s.constf
+                                  000149a6         0   none ,g         0
+  __e.constf
+                                  000149ba         0   none ,g         0
+  __s.sbss
+                                  000ffe52         0   none ,g         0
+  __e.sbss
+                                  000ffe52         0   none ,g         0
+  __s.dataR
+                                  000fcf00         0   none ,g         0
+  __e.dataR
+                                  000fd412         0   none ,g         0
+  __s.sdataR
+                                  000ffe20         0   none ,g         0
+  __e.sdataR
+                                  000ffe52         0   none ,g         0
+  __s.stack_bss
+                                  000fd412         0   none ,g         0
+  __e.stack_bss
+                                  000fd612         0   none ,g         0
+  __s.init_array
+                                  00000080         0   none ,g         0
+  __e.init_array
+                                  00000080         0   none ,g         0
+  __s.RLIB
+                                  000045ee         0   none ,g         0
+  __e.RLIB
+                                  000051bd         0   none ,g         0
+  __s.SLIB
+                                  000051bd         0   none ,g         0
+  __e.SLIB
+                                  00006eda         0   none ,g         0
+  __s.option_byte
+                                  000000c0         0   none ,g         0
+  __e.option_byte
+                                  000000c4         0   none ,g         0
+  __s.monitor1
+                                  000000ce         0   none ,g         0
+  __e.monitor1
+                                  000000d8         0   none ,g         0
+  __s.monitor2
+                                  0001fe00         0   none ,g         0
+  __e.monitor2
+                                  00020000         0   none ,g         0
+  __s.security_id
+                                  000000c4         0   none ,g         0
+  __e.security_id
+                                  000000ce         0   none ,g         0
+  __s.vect
+                                  00000000         0   none ,g         0
+  __e.vect
+                                  00000080         0   none ,g         0
+  __RAM_ADDR_START
+                                  000fcf00         0   none ,g         0
+  __RAM_ADDR_END
+                                  000ffee0         0   none ,g         0
+  __STACK_ADDR_START
+                                  000ffe20         0   none ,g         1
+  __STACK_ADDR_END
+                                  000fde36         0   none ,g         1
+
+*** Unfilled Areas ***
+
+AREA                                START    END
+
+*** Delete Symbols ***
+
+SYMBOL                                SIZE    INFO
+
+*** Variable Vector Table List ***
+
+ADDRESS  SYMBOL/ADDRESS
+00       _start
+02       ffff
+04       
+06       
+08       
+0a       
+0c       
+0e       
+10       
+12       
+14       
+16       
+18       
+1a       
+1c       
+1e       
+20       _r_Config_TAU_interrupt@1
+22       
+24       _r_Config_UART_interrupt_send@1
+26       _r_Config_UART_interrupt_receive@1
+28       _r_Config_UART_interrupt_error@1
+2a       
+2c       
+2e       _r_tau0_channel1_isr@1
+30       _r_Config_TAU0_2_interrupt@1
+32       _r_Config_TAU0_3_interrupt@1
+34       
+36       
+38       
+3a       
+3c       
+3e       
+40       
+42       
+44       _r_Config_DALI_interrupt_power_down_detection@1
+46       
+48       
+4a       
+4c       
+4e       
+50       
+52       
+54       
+56       
+58       
+5a       
+5c       
+5e       
+60       
+62       
+64       _r_Config_DALI_interrupt_stop_bit_detection@1
+66       _r_Config_DALI_interrupt_falling_edge_detection@1
+68       
+6a       
+6c       
+6e       
+70       
+72       
+74       
+76       
+78       
+7a       
+7c       
+7e       
+
+*** Cross Reference List ***
+
+No   Unit Name   Global.Symbol   Location External Infomation
+---- ----------- --------------- -------- ---------------------
+0001 r_memory_banks
+     SECTION=.textf
+                 _R_MemoryBanks_Init
+                                 00006eda 0007(0000742e:.textf)
+                 _R_MemoryBanks_NvmIsChanged
+                                 00006f41
+                 _R_MemoryBanks_Reset
+                                 00006f7a 0007(00008266:.textf)
+                 _R_MemoryBanks_Read
+                                 00006f96 0007(00008281:.textf)
+                 _R_MemoryBanks_Write
+                                 000070fb 0007(000082a4:.textf)
+                 _R_MemoryBanks_UnlatchRead
+                                 00007274 0001(000070f3:.textf)
+                                          0007(000082b3:.textf)
+                 _R_MemoryBanks_CancelWrite
+                                 0000728d 0001(0000726c:.textf)
+                                          0007(000082c2:.textf)
+0002 r_nvm
+     SECTION=NVM_f
+                 _R_NVM_Init
+                                 0001512e 0007(00007379:.textf)
+                 _R_NVM_Open
+                                 00015393 0007(0000737d:.textf)
+                 _R_NVM_Close
+                                 00015398
+                 _R_NVM_Task
+                                 0001539d 0007(00007b49:.textf)
+                 _R_NVM_Read
+                                 00015693 0007(0000744a:.textf)
+                                          0007(00007454:.textf)
+                 _R_NVM_Write
+                                 00015845 0007(000074fd:.textf)
+                                          0007(00007acf:.textf)
+                                          0007(00007adf:.textf)
+                                          0007(00007b38:.textf)
+                                          0007(00007b45:.textf)
+     SECTION=.const
+     SECTION=.bss
+0003 r_random
+     SECTION=.textf
+                 _R_RANDOM_Init
+                                 000072ba 0007(0000736f:.textf)
+                 _R_RANDOM_Generate
+                                 000072d9 0007(00002386:.const)
+                                          0007(00002388:.const)
+                 _R_RANDOM_IncrementSeed
+                                 00007327 0007(000077f2:.textf)
+     SECTION=.bss
+0004 r_unit0_memory_bank
+     SECTION=.const
+                 _g_unit0_memory_bank_info_list
+                                 00002130 0007(000fd1c8:.dataR)
+0005 r_unit1_memory_bank
+     SECTION=.const
+                 _g_unit1_memory_bank_info_list
+                                 00002240
+0006 r_unit2_memory_bank
+     SECTION=.const
+                 _g_unit2_memory_bank_info_list
+                                 00002350
+0007 r_cg
+     SECTION=.textf
+                 _R_CG_Init
+                                 00007345 0009(00008449:.textf)
+                 _R_CG_Load
+                                 00007443 0009(00008450:.textf)
+                 _R_CG_Start
+                                 000077c9 0009(00008454:.textf)
+                 _R_CG_Task
+                                 000077ef 0009(0000846f:.textf)
+     SECTION=.const
+     SECTION=.data
+     SECTION=.bss
+     SECTION=.dataR
+0008 r_debug
+     SECTION=.textf
+                 _R_DEBUG_Init
+                                 000082c5
+                 _R_DEBUG_NvmIsValid
+                                 000082d0 0007(00007782:.textf)
+                 _R_DEBUG_NvmIsChanged
+                                 000082d2 0007(00007a55:.textf)
+                 _R_DEBUG_ClearChangeFlag
+                                 000082d6 0007(00007ac2:.textf)
+                 _R_DEBUG_SetNvm
+                                 000082da 0007(000077c3:.textf)
+                 _R_DEBUG_GetNvm
+                                 000082e2 0007(00007a99:.textf)
+                                          0007(00007b15:.textf)
+                 _R_DEBUG_ChangeStatus
+                                 000082ea
+                 _R_DEBUG_GetLampStatus
+                                 0000842f
+                 _R_DEBUG_GetControlGearStatus
+                                 00008433 0007(000077f6:.textf)
+                 _R_DEBUG_GetFailureProcedure
+                                 00008437 0007(0000786b:.textf)
+                                          0070(0000a9c5:.textf)
+                                          0070(0000aa14:.textf)
+                                          0070(0000aa61:.textf)
+                 _R_DEBUG_ReferenceMeasurementIsFinished
+                                 0000843b 0007(00007ca4:.textf)
+     SECTION=.const
+     SECTION=.bss
+0009 r_main
+     SECTION=.textf
+                 _main
+                                 00008448 0062(00004496:.text)
+                 _send_main
+                                 00008479 0009(0000846c:.textf)
+                 _QE4LigHTHING_COMM_AnalysisPacket
+                                 000084b2 0009(00008b32:.textf)
+                 _getVariableData
+                                 000087fe 0009(0000848a:.textf)
+                 _QE4LIGHTING_COMMON_GetSerialNum
+                                 00008ac4
+                 _QE4LIGHTING_COMMON_ClearSerialNum
+                                 00008af1
+                 _receive_main
+                                 00008af9 0009(00008469:.textf)
+     SECTION=.dataR
+                 _g_send_busy_flg
+                                 000fd3d7 0009(00008497:.textf)
+                                          0009(0000849c:.textf)
+                                          0079(0000c379:.textf)
+                 _g_run_ack_flg
+                                 000fd3d8 0009(00008575:.textf)
+                                          0009(000085bb:.textf)
+                                          0009(000085e2:.textf)
+                 _g_variable_flg
+                                 000fd3d9 0009(00008674:.textf)
+                                          0009(000087dd:.textf)
+                 _request_flag
+                                 000fd3da 0009(0000847f:.textf)
+                                          0009(000084a8:.textf)
+                                          0009(000087e7:.textf)
+     SECTION=.const
+     SECTION=.data
+     SECTION=.bss
+0010 r_memory_bank
+     SECTION=.textf
+                 _R_MemoryBank_Init
+                                 00008b47 0001(00006f0e:.textf)
+                                          0001(00006f2c:.textf)
+                 _R_MemoryBank_NvmIsChanged
+                                 00008b8b 0001(00006f64:.textf)
+                 _R_MemoryBank_Reset
+                                 00008b99 0001(00006f93:.textf)
+                 _R_MemoryBank_Read
+                                 00008bff 0001(00007028:.textf)
+                                          0001(0000704c:.textf)
+                 _R_MemoryBank_Write
+                                 00008c46 0001(00007194:.textf)
+                                          0001(00007220:.textf)
+                 _R_MemoryBank_IsImplemented
+                                 00008ce0 0001(00006fb4:.textf)
+                                          0001(0000711a:.textf)
+                                          0001(000072b7:.textf)
+                 _R_MemoryBank_GetLastAccessibleLocation
+                                 00008ceb 0001(00006fc0:.textf)
+                                          0001(00007126:.textf)
+0011 r_dali101
+     SECTION=.textf
+                 _R_DALI101_Init
+                                 00008cf3 0007(00007365:.textf)
+                 _R_DALI101_Start
+                                 00008cfb 0007(000077ca:.textf)
+                 _R_DALI101_Tick1ms
+                                 00008d14
+                 _R_DALI101_Task
+                                 00008d18 0007(00007905:.textf)
+                 _R_DALI101_GetReceivedFrame
+                                 00008d20 0007(00007912:.textf)
+                 _R_DALI101_SystemFailureIsDetected
+                                 00008d24 0007(000078ea:.textf)
+                 _R_DALI101_SendBackwardFrame
+                                 00008d28 0007(00007952:.textf)
+0012 r_dali101_bft
+     SECTION=.textf
+                 _R_Config_TAU0_3_Isr
+                                 00008d2c 0045(00004417:.text)
+                 _R_DALI101_BFT_Init
+                                 00008d34 0011(00008cf8:.textf)
+                 _R_DALI101_BFT_Start
+                                 00008d3e 0011(00008d11:.textf)
+                 _R_DALI101_BFT_Tick1ms
+                                 00008d3f 0011(00008d15:.textf)
+                 _R_DALI101_BFT_Task
+                                 00008d46 0011(00008d1d:.textf)
+                 _R_DALI101_BFT_Send
+                                 00008d7a 0011(00008d29:.textf)
+     SECTION=.bss
+0013 r_dali101_rx
+     SECTION=.textf
+                 _R_Config_TAU0_2_Isr
+                                 00008dac 0043(000043fd:.text)
+                 _R_Config_DALI_FED_ISR
+                                 00008dfa 0074(000044d7:.text)
+                 _R_Config_DALI_BPD_ISR
+                                 00008e15 0074(000044c7:.text)
+                 _R_Config_DALI_SDD_ISR
+                                 00008e27 0074(0000451b:.text)
+                 _R_DALI101_RX_Init
+                                 00008e38 0011(00008cf4:.textf)
+                 _R_DALI101_RX_Start
+                                 00008e6a 0011(00008d0c:.textf)
+                 _R_DALI101_RX_Task
+                                 00008e7c 0011(00008d19:.textf)
+                 _R_DALI101_RX_GetReceivedFrame
+                                 00008f01 0011(00008d21:.textf)
+                 _R_DALI101_RX_SystemFailureIsDetected
+                                 00008f43 0011(00008d25:.textf)
+     SECTION=.data
+     SECTION=.bss
+     SECTION=.dataR
+0014 r_led
+     SECTION=.textf
+                 _R_LED_Init
+                                 00008f50 0070(0000a8ad:.textf)
+                 _R_LED_Start
+                                 00008fc9 0070(0000a8db:.textf)
+                 _R_LED_SetLevel
+                                 00008fe5 0066(0000a74b:.textf)
+                                          0066(0000a75e:.textf)
+                                          0066(0000a81e:.textf)
+                                          0066(0000a83f:.textf)
+                                          0066(0000a84d:.textf)
+                                          0071(0000b46b:.textf)
+                                          0071(0000b47e:.textf)
+                                          0071(0000b491:.textf)
+                                          0071(0000b868:.textf)
+                                          0071(0000b889:.textf)
+                                          0071(0000b8ac:.textf)
+                                          0072(0000b937:.textf)
+                                          0072(0000b94a:.textf)
+                                          0072(0000b95d:.textf)
+                                          0072(0000bd07:.textf)
+                                          0072(0000bd28:.textf)
+                                          0072(0000bd4b:.textf)
+                 _R_LED_IsOn
+                                 00008ffe 0066(0000a80f:.textf)
+                                          0066(0000a831:.textf)
+                                          0066(0000a844:.textf)
+                                          0070(0000a9f5:.textf)
+                                          0070(0000aa00:.textf)
+                                          0070(0000aa09:.textf)
+                                          0071(0000b85a:.textf)
+                                          0071(0000b87b:.textf)
+                                          0071(0000b89d:.textf)
+                                          0072(0000bcf9:.textf)
+                                          0072(0000bd1a:.textf)
+                                          0072(0000bd3c:.textf)
+                 _R_LED_IsFailed
+                                 00009015 0070(0000aa3f:.textf)
+                                          0070(0000aa4a:.textf)
+                                          0070(0000aa53:.textf)
+     SECTION=.dataR
+                 _A1
+                                 000fd3ee 0014(000090b8:.textf)
+                                          0014(00009228:.textf)
+                                          0014(00009399:.textf)
+                 _A2
+                                 000fd3f2 0014(00009085:.textf)
+                                          0014(000091f5:.textf)
+                                          0014(00009366:.textf)
+     SECTION=.text
+     SECTION=.const
+     SECTION=.data
+     SECTION=.sdata
+     SECTION=.sdataR
+0015 r_led1
+     SECTION=.textf
+                 _R_LED1_Init
+                                 0000947d 0014(00008fbc:.textf)
+                 _R_LED1_SetLevel
+                                 000094a3 0014(00008ff1:.textf)
+                 _R_LED1_IsFailed
+                                 000094ea 0014(00009021:.textf)
+     SECTION=.dataR
+                 _g_led1_feedback_is_enabled
+                                 000fd3f8 0014(0000900a:.textf)
+                                          0014(0000902f:.textf)
+                                          0015(0000948c:.textf)
+                                          0015(000094c7:.textf)
+                                          0015(000094e4:.textf)
+     SECTION=.sdataR
+                 _g_led1_vr
+                                 000ffe22 0014(0000907e:.textf)
+                                          0014(000090b1:.textf)
+                                          0014(00009142:.textf)
+                                          0015(0000947e:.textf)
+                                          0015(000094b9:.textf)
+                 _g_led1_fb_ad
+                                 000ffe24 0014(00009079:.textf)
+                                          0014(000090a1:.textf)
+                                          0014(00009161:.textf)
+                                          0015(000094de:.textf)
+                 _g_led1_fb_ad_old
+                                 000ffe26 0014(00009080:.textf)
+                                          0014(00009163:.textf)
+                                          0015(0000949f:.textf)
+                                          0015(000094da:.textf)
+                 _g_led1_offset
+                                 000ffe28 0014(00008fab:.textf)
+                                          0014(00009082:.textf)
+                                          0014(00009099:.textf)
+                 _g_led1_duty
+                                 000ffe2a 0014(000090df:.textf)
+                                          0014(000090e3:.textf)
+                                          0014(000090fe:.textf)
+                                          0014(0000911d:.textf)
+                                          0014(00009121:.textf)
+                                          0014(0000912c:.textf)
+                                          0014(00009135:.textf)
+                                          0014(00009148:.textf)
+                                          0014(0000914c:.textf)
+                                          0014(00009150:.textf)
+                                          0014(00009155:.textf)
+                                          0015(0000948f:.textf)
+                                          0015(00009493:.textf)
+                                          0015(000094ca:.textf)
+                                          0015(000094ce:.textf)
+                 _g_led1_err
+                                 000ffe2e 0014(00009093:.textf)
+                                          0014(00009097:.textf)
+                                          0014(000090cb:.textf)
+                                          0014(000090cf:.textf)
+                                          0015(00009497:.textf)
+                                          0015(0000949b:.textf)
+                                          0015(000094d2:.textf)
+                                          0015(000094d6:.textf)
+     SECTION=.data
+     SECTION=.sdata
+0016 r_led2
+     SECTION=.textf
+                 _R_LED2_Init
+                                 000094f2 0014(00008fc0:.textf)
+                 _R_LED2_SetLevel
+                                 00009518 0014(00008ff6:.textf)
+                 _R_LED2_IsFailed
+                                 0000955f 0014(00009025:.textf)
+     SECTION=.dataR
+                 _g_led2_feedback_is_enabled
+                                 000fd3fc 0014(0000900e:.textf)
+                                          0014(0000919f:.textf)
+                                          0016(00009501:.textf)
+                                          0016(0000953c:.textf)
+                                          0016(00009559:.textf)
+     SECTION=.sdataR
+                 _g_led2_vr
+                                 000ffe32 0014(000091ee:.textf)
+                                          0014(00009221:.textf)
+                                          0014(000092b2:.textf)
+                                          0016(000094f3:.textf)
+                                          0016(0000952e:.textf)
+                 _g_led2_fb_ad
+                                 000ffe34 0014(000091e9:.textf)
+                                          0014(00009211:.textf)
+                                          0014(000092d1:.textf)
+                                          0016(00009553:.textf)
+                 _g_led2_fb_ad_old
+                                 000ffe36 0014(000091f0:.textf)
+                                          0014(000092d3:.textf)
+                                          0016(00009514:.textf)
+                                          0016(0000954f:.textf)
+                 _g_led2_offset
+                                 000ffe38 0014(00008fb0:.textf)
+                                          0014(000091f2:.textf)
+                                          0014(00009209:.textf)
+                 _g_led2_duty
+                                 000ffe3a 0014(0000924f:.textf)
+                                          0014(00009253:.textf)
+                                          0014(0000926e:.textf)
+                                          0014(0000928d:.textf)
+                                          0014(00009291:.textf)
+                                          0014(0000929c:.textf)
+                                          0014(000092a5:.textf)
+                                          0014(000092b8:.textf)
+                                          0014(000092bc:.textf)
+                                          0014(000092c0:.textf)
+                                          0014(000092c5:.textf)
+                                          0016(00009504:.textf)
+                                          0016(00009508:.textf)
+                                          0016(0000953f:.textf)
+                                          0016(00009543:.textf)
+                 _g_led2_err
+                                 000ffe3e 0014(00009203:.textf)
+                                          0014(00009207:.textf)
+                                          0014(0000923b:.textf)
+                                          0014(0000923f:.textf)
+                                          0016(0000950c:.textf)
+                                          0016(00009510:.textf)
+                                          0016(00009547:.textf)
+                                          0016(0000954b:.textf)
+     SECTION=.data
+     SECTION=.sdata
+0017 r_led3
+     SECTION=.textf
+                 _R_LED3_Init
+                                 00009567 0014(00008fc4:.textf)
+                 _R_LED3_SetLevel
+                                 0000958d 0014(00008ffb:.textf)
+                 _R_LED3_IsFailed
+                                 000095d4 0014(00009029:.textf)
+     SECTION=.dataR
+                 _g_led3_feedback_is_enabled
+                                 000fd400 0014(00009012:.textf)
+                                          0014(0000930f:.textf)
+                                          0017(00009576:.textf)
+                                          0017(000095b1:.textf)
+                                          0017(000095ce:.textf)
+     SECTION=.sdataR
+                 _g_led3_vr
+                                 000ffe42 0014(0000935f:.textf)
+                                          0014(00009392:.textf)
+                                          0014(00009423:.textf)
+                                          0017(00009568:.textf)
+                                          0017(000095a3:.textf)
+                 _g_led3_fb_ad
+                                 000ffe44 0014(0000935a:.textf)
+                                          0014(00009382:.textf)
+                                          0014(00009442:.textf)
+                                          0017(000095c8:.textf)
+                 _g_led3_fb_ad_old
+                                 000ffe46 0014(00009361:.textf)
+                                          0014(00009444:.textf)
+                                          0017(00009589:.textf)
+                                          0017(000095c4:.textf)
+                 _g_led3_offset
+                                 000ffe48 0014(00008fa7:.textf)
+                                          0014(00009363:.textf)
+                                          0014(0000937a:.textf)
+                 _g_led3_duty
+                                 000ffe4a 0014(000093c0:.textf)
+                                          0014(000093c4:.textf)
+                                          0014(000093df:.textf)
+                                          0014(000093fe:.textf)
+                                          0014(00009402:.textf)
+                                          0014(0000940d:.textf)
+                                          0014(00009416:.textf)
+                                          0014(00009429:.textf)
+                                          0014(0000942d:.textf)
+                                          0014(00009431:.textf)
+                                          0014(00009436:.textf)
+                                          0017(00009579:.textf)
+                                          0017(0000957d:.textf)
+                                          0017(000095b4:.textf)
+                                          0017(000095b8:.textf)
+                 _g_led3_err
+                                 000ffe4e 0014(00009374:.textf)
+                                          0014(00009378:.textf)
+                                          0014(000093ac:.textf)
+                                          0014(000093b0:.textf)
+                                          0017(00009581:.textf)
+                                          0017(00009585:.textf)
+                                          0017(000095bc:.textf)
+                                          0017(000095c0:.textf)
+     SECTION=.data
+     SECTION=.sdata
+0018 r_port
+     SECTION=.textf
+                 _R_PORT_PinWrite
+                                 000095dc
+                 _R_PORT_PinRead
+                                 00009618 0011(00008d00:.textf)
+     SECTION=.const
+0019 r_timer16
+     SECTION=.textf
+                 _R_TIMER16_Init
+                                 00009649 0007(00007384:.textf)
+                                          0007(0000738b:.textf)
+                                          0012(00008d3b:.textf)
+                                          0070(0000a8b4:.textf)
+                                          0070(0000a8bb:.textf)
+                 _R_TIMER16_Tick
+                                 00009651 0012(00008d43:.textf)
+                                          0070(0000a8e2:.textf)
+                                          0070(0000a8e9:.textf)
+                 _R_TIMER16_Start
+                                 00009660 0007(000077d8:.textf)
+                                          0007(000077e2:.textf)
+                                          0007(00007a36:.textf)
+                                          0007(00007b60:.textf)
+                                          0012(00008d92:.textf)
+                                          0070(0000a8fe:.textf)
+                                          0070(0000aadd:.textf)
+                                          0070(0000b3d8:.textf)
+                 _R_TIMER16_Stop
+                                 00009664 0012(00008d54:.textf)
+                                          0070(0000a91a:.textf)
+                                          0070(0000aafd:.textf)
+                                          0070(0000b3e0:.textf)
+                 _R_TIMER16_IsRunning
+                                 0000966c 0070(0000a921:.textf)
+                                          0070(0000aaa2:.textf)
+                                          0070(0000b3cb:.textf)
+                 _R_TIMER16_Expires
+                                 00009676 0007(00007a23:.textf)
+                                          0007(00007b50:.textf)
+                                          0012(00008d4a:.textf)
+                                          0070(0000a8f1:.textf)
+                                          0070(0000a910:.textf)
+0020 r_rfd_data_flash_api
+     SECTION=RFD_DF_f
+                 _R_RFD_EraseDataFlashReq
+                                 000150e1 0002(000159a1:NVM_f)
+                                          0002(000159f0:NVM_f)
+                 _R_RFD_WriteDataFlashReq
+                                 000150fd 0002(00015543:NVM_f)
+                                          0002(00015629:NVM_f)
+                                          0002(00015b1a:NVM_f)
+                                          0002(00015b79:NVM_f)
+                 _R_RFD_BlankCheckDataFlashReq
+                                 00015112 0002(00015901:NVM_f)
+                                          0002(0001594c:NVM_f)
+0021 r_rfd_common_extension_api
+     SECTION=RFD_CMN_f
+                 _R_RFD_SetBootAreaImmediately
+                                 00014f03
+0022 r_rfd_common_get_api
+     SECTION=RFD_CMN_f
+                 _R_RFD_GetSecurityAndBootFlags
+                                 00014f15
+                 _R_RFD_GetFSW
+                                 00014f1d
+0023 r_rfd_common_api
+     SECTION=RFD_CMN_f
+                 _R_RFD_Init
+                                 00014f50 0002(000151e4:NVM_f)
+                 _R_RFD_SetDataFlashAccessMode
+                                 00014f74 0002(00015218:NVM_f)
+                                          0002(0001538b:NVM_f)
+                                          0002(00015395:NVM_f)
+                                          0002(0001539a:NVM_f)
+                 _R_RFD_ChangeInterruptVector
+                                 00014f81
+                 _R_RFD_RestoreInterruptVector
+                                 00014fad
+                 _R_RFD_SetFlashMemoryMode
+                                 00014fcc 0002(00015532:NVM_f)
+                                          0002(00015618:NVM_f)
+                                          0002(000158d0:NVM_f)
+                                          0002(000158fa:NVM_f)
+                                          0002(0001595f:NVM_f)
+                                          0002(000159e9:NVM_f)
+                                          0002(00015b08:NVM_f)
+                                          0002(00015b45:NVM_f)
+                 _R_RFD_CheckFlashMemoryMode
+                                 00015059
+                 _r_rfd_wait_count
+                                 00015078
+     SECTION=RFD_DATA_nR
+                 _g_u08_change_interrupt_vector_flag
+                                 000fde30 0023(00014f53:RFD_CMN_f)
+                                          0023(00014fa7:RFD_CMN_f)
+                                          0023(00014fc9:RFD_CMN_f)
+                                          0023(00014fe1:RFD_CMN_f)
+                 _g_u08_cpu_frequency
+                                 000fde31 0023(00014f5c:RFD_CMN_f)
+                                          0023(00014f68:RFD_CMN_f)
+                                          0023(0001500d:RFD_CMN_f)
+                                          0023(0001507a:RFD_CMN_f)
+                 _g_u08_fset_cpu_frequency
+                                 000fde32 0021(00014f05:RFD_CMN_f)
+                                          0023(00014f5f:RFD_CMN_f)
+                                          0023(00014f6c:RFD_CMN_f)
+                                          0023(00015050:RFD_CMN_f)
+     SECTION=RFD_DATA_n
+0024 r_rfd_common_control_api
+     SECTION=RFD_CMN_f
+                 _R_RFD_CheckCFDFSeqEndStep1
+                                 0001508b 0002(0001589f:NVM_f)
+                                          0002(00015909:NVM_f)
+                                          0002(00015b1f:NVM_f)
+                 _R_RFD_CheckExtraSeqEndStep1
+                                 00015098
+                 _R_RFD_CheckCFDFSeqEndStep2
+                                 000150a5 0002(000158a9:NVM_f)
+                                          0002(00015910:NVM_f)
+                                          0002(00015b26:NVM_f)
+                 _R_RFD_CheckExtraSeqEndStep2
+                                 000150ad
+                 _R_RFD_GetSeqErrorStatus
+                                 000150b3 0002(000158b8:NVM_f)
+                                          0002(0001591c:NVM_f)
+                                          0002(00015b30:NVM_f)
+                 _R_RFD_ClearSeqRegister
+                                 000150bd 0002(000158bc:NVM_f)
+                                          0002(00015920:NVM_f)
+                                          0002(00015b34:NVM_f)
+                 _R_RFD_ForceStopSeq
+                                 000150c5
+                 _R_RFD_ForceReset
+                                 000150ca
+0025 r_rfd_common_userown
+     SECTION=RFD_CMN_f
+                 _R_RFD_HOOK_EnterCriticalSection
+                                 000150cc 0023(00014f84:RFD_CMN_f)
+                                          0023(00014fae:RFD_CMN_f)
+                                          0023(00014fef:RFD_CMN_f)
+                 _R_RFD_HOOK_ExitCriticalSection
+                                 000150d5 0023(00014fa3:RFD_CMN_f)
+                                          0023(00014fc5:RFD_CMN_f)
+                                          0023(00015006:RFD_CMN_f)
+     SECTION=RFD_DATA_n
+     SECTION=RFD_DATA_nR
+0026 Config_ADC
+     SECTION=.textf
+                 _R_Config_ADC_Create
+                                 00009681 0056(00009d91:.textf)
+                 _R_Config_ADC_ADS0_Execute
+                                 00009720
+0027 Config_ADC_user
+     SECTION=.textf
+                 _R_Config_ADC_Create_UserInit
+                                 00009742 0026(0000971b:.textf)
+0028 Config_COMP0
+     SECTION=.textf
+                 _R_Config_COMP0_Create
+                                 00009743 0054(00009cf5:.textf)
+                 _R_Config_COMP0_Start
+                                 00009779 0014(00008fce:.textf)
+                 _R_Config_COMP0_Stop
+                                 00009797
+0029 Config_COMP0_user
+     SECTION=.textf
+                 _R_Config_COMP0_Create_UserInit
+                                 0000979c 0028(00009776:.textf)
+0030 Config_COMP1
+     SECTION=.textf
+                 _R_Config_COMP1_Create
+                                 0000979d 0054(00009cf9:.textf)
+                 _R_Config_COMP1_Start
+                                 000097d3 0014(00008fd2:.textf)
+                 _R_Config_COMP1_Stop
+                                 000097f1
+0031 Config_COMP1_user
+     SECTION=.textf
+                 _R_Config_COMP1_Create_UserInit
+                                 000097f6 0030(000097d0:.textf)
+0032 Config_COMP2
+     SECTION=.textf
+                 _R_Config_COMP2_Create
+                                 000097f7 0054(00009cfd:.textf)
+                 _R_Config_COMP2_Start
+                                 0000982f 0014(00008fd6:.textf)
+                 _R_Config_COMP2_Stop
+                                 0000984d
+0033 Config_COMP2_user
+     SECTION=.textf
+                 _R_Config_COMP2_Create_UserInit
+                                 00009852 0032(0000982c:.textf)
+0034 Config_DAC0
+     SECTION=.textf
+                 _R_Config_DAC0_Create
+                                 00009853 0053(00009cd5:.textf)
+                 _R_Config_DAC0_Start
+                                 00009879 0014(00008fca:.textf)
+                 _R_Config_DAC0_Stop
+                                 0000987e
+                 _R_Config_DAC0_Set_ConversionValue_10bit
+                                 00009883
+0035 Config_DAC0_user
+     SECTION=.textf
+                 _R_Config_DAC0_Create_UserInit
+                                 00009889 0034(00009876:.textf)
+0036 Config_PGA
+     SECTION=.textf
+                 _R_Config_PGA_Create
+                                 0000988a 0054(00009cf1:.textf)
+                 _R_Config_PGA_Start
+                                 000098b5
+                 _R_Config_PGA_Stop
+                                 000098d3
+0037 Config_PGA_user
+     SECTION=.textf
+                 _R_Config_PGA_Create_UserInit
+                                 000098d8 0036(000098b2:.textf)
+0038 Config_PORT
+     SECTION=.textf
+                 _R_Config_PORT_Create
+                                 000098d9 0056(00009d75:.textf)
+0039 Config_PORT_user
+     SECTION=.textf
+                 _R_Config_PORT_Create_UserInit
+                                 0000996a 0038(00009965:.textf)
+0040 Config_TAU0_1
+     SECTION=.textf
+                 _R_Config_TAU0_1_Create
+                                 0000996b 0057(00009d99:.textf)
+                 _R_Config_TAU0_1_Start
+                                 000099c5 0014(00008fe2:.textf)
+                 _R_Config_TAU0_1_Stop
+                                 000099d6
+0041 Config_TAU0_1_user
+     SECTION=.textf
+                 _R_Config_TAU0_1_Create_UserInit
+                                 000099e7 0040(000099c2:.textf)
+0042 Config_TAU0_2
+     SECTION=.textf
+                 _R_Config_TAU0_2_Create
+                                 000099e8 0057(00009d9d:.textf)
+                 _R_Config_TAU0_2_Start
+                                 00009a42 0013(00008e24:.textf)
+                                          0013(00008e35:.textf)
+                                          0013(00008e78:.textf)
+                 _R_Config_TAU0_2_Stop
+                                 00009a53 0013(00008dec:.textf)
+                                          0013(00008e07:.textf)
+                                          0013(00008ed9:.textf)
+                                          0013(00008ef7:.textf)
+0043 Config_TAU0_2_user
+     SECTION=.textf
+                 _R_Config_TAU0_2_Create_UserInit
+                                 00009a64 0042(00009a3f:.textf)
+     SECTION=.text
+0044 Config_TAU0_3
+     SECTION=.textf
+                 _R_Config_TAU0_3_Create
+                                 00009a65 0057(00009da1:.textf)
+                 _R_Config_TAU0_3_Start
+                                 00009ac5 0012(00008d6b:.textf)
+                 _R_Config_TAU0_3_Stop
+                                 00009ad6 0012(00008d2d:.textf)
+0045 Config_TAU0_3_user
+     SECTION=.textf
+                 _R_Config_TAU0_3_Create_UserInit
+                                 00009ae7 0044(00009ac2:.textf)
+     SECTION=.text
+0046 Config_TKB0
+     SECTION=.textf
+                 _R_Config_TKB0_Create
+                                 00009ae8 0058(00009dc1:.textf)
+                 _R_Config_TKB0_Start
+                                 00009b98 0014(00008fda:.textf)
+                 _R_Config_TKB0_Stop
+                                 00009ba5
+                 _R_Config_TKB0_TKBO00_DitheringFunction_Start
+                                 00009bae
+                 _R_Config_TKB0_TKBO00_DitheringFunction_Stop
+                                 00009bb7
+                 _R_Config_TKB0_TKBO01_DitheringFunction_Start
+                                 00009bc1
+                 _R_Config_TKB0_TKBO01_DitheringFunction_Stop
+                                 00009bca
+                 _R_Config_TKB0_Set_BatchOverwriteRequestOn
+                                 00009bd4 0015(00009488:.textf)
+                                          0015(000094c3:.textf)
+                                          0016(000094fd:.textf)
+                                          0016(00009538:.textf)
+                 _R_Config_TKB0_TKBO00_Forced_Output_Stop_Function1_Start
+                                 00009bd9
+                 _R_Config_TKB0_TKBO00_Forced_Output_Stop_Function1_Stop
+                                 00009bdd
+                 _R_Config_TKB0_TKBO01_Forced_Output_Stop_Function1_Start
+                                 00009be1
+                 _R_Config_TKB0_TKBO01_Forced_Output_Stop_Function1_Stop
+                                 00009be6
+0047 Config_TKB0_user
+     SECTION=.textf
+                 _R_Config_TKB0_Create_UserInit
+                                 00009beb 0046(00009b95:.textf)
+0048 Config_TKB1
+     SECTION=.textf
+                 _R_Config_TKB1_Create
+                                 00009bec 0058(00009dc5:.textf)
+                 _R_Config_TKB1_Start
+                                 00009c77 0014(00008fde:.textf)
+                 _R_Config_TKB1_Stop
+                                 00009c83
+                 _R_Config_TKB1_TKBO10_DitheringFunction_Start
+                                 00009c8c
+                 _R_Config_TKB1_TKBO10_DitheringFunction_Stop
+                                 00009c95
+                 _R_Config_TKB1_Set_BatchOverwriteRequestOn
+                                 00009c9f 0017(00009572:.textf)
+                                          0017(000095ad:.textf)
+                 _R_Config_TKB1_TKBO10_Forced_Output_Stop_Function1_Start
+                                 00009ca4
+                 _R_Config_TKB1_TKBO10_Forced_Output_Stop_Function1_Stop
+                                 00009ca8
+0049 Config_TKB1_user
+     SECTION=.textf
+                 _R_Config_TKB1_Create_UserInit
+                                 00009cac 0048(00009c74:.textf)
+0050 Config_WDT
+     SECTION=.textf
+                 _R_Config_WDT_Create
+                                 00009cad 0056(00009d8d:.textf)
+                 _R_Config_WDT_Restart
+                                 00009cb7 0009(00008473:.textf)
+0051 Config_WDT_user
+     SECTION=.textf
+                 _R_Config_WDT_Create_UserInit
+                                 00009cbb 0050(00009cb4:.textf)
+0052 r_cg_ad_common
+     SECTION=.textf
+                 _R_ADC_Set_PowerOn
+                                 00009cbc
+                 _R_ADC_Set_PowerOff
+                                 00009cc1
+                 _R_ADC_Set_Reset
+                                 00009cc6
+                 _R_ADC_Release_Reset
+                                 00009ccb
+0053 r_cg_da_common
+     SECTION=.textf
+                 _R_DAC_Create
+                                 00009cd0 0056(00009d85:.textf)
+                 _R_DAC_Set_PowerOn
+                                 00009cd8
+                 _R_DAC_Set_PowerOff
+                                 00009cdd
+                 _R_DAC_Set_Reset
+                                 00009ce2
+                 _R_DAC_Release_Reset
+                                 00009ce7
+0054 r_cg_pgacomp_common
+     SECTION=.textf
+                 _R_PGACOMP_Create
+                                 00009cec 0056(00009d81:.textf)
+                 _R_PGACOMP_Set_PowerOn
+                                 00009d00
+                 _R_PGACOMP_Set_PowerOff
+                                 00009d05
+                 _R_PGACOMP_Set_Reset
+                                 00009d0a
+                 _R_PGACOMP_Release_Reset
+                                 00009d0f
+0055 r_cg_sau_common
+     SECTION=.textf
+                 _R_SAU0_Create
+                                 00009d14 0056(00009d7d:.textf)
+                 _R_SAU1_Create
+                                 00009d1c
+                 _R_SAU0_Set_PowerOn
+                                 00009d21
+                 _R_SAU0_Set_PowerOff
+                                 00009d26
+                 _R_SAU1_Set_PowerOn
+                                 00009d2b
+                 _R_SAU1_Set_PowerOff
+                                 00009d30
+                 _R_SAU0_Set_Reset
+                                 00009d35
+                 _R_SAU0_Release_Reset
+                                 00009d3a
+                 _R_SAU1_Set_Reset
+                                 00009d3f
+                 _R_SAU1_Release_Reset
+                                 00009d44
+                 _R_SAU0_Set_SnoozeOn
+                                 00009d49
+                 _R_SAU0_Set_SnoozeOff
+                                 00009d54
+0056 r_cg_systeminit
+     SECTION=.textf
+                 _R_Systeminit
+                                 00009d5f 0059(00009ddf:.textf)
+0057 r_cg_tau_common
+     SECTION=.textf
+                 _R_TAU0_Create
+                                 00009d94 0056(00009d79:.textf)
+                 _R_TAU0_Set_PowerOn
+                                 00009da8
+                 _R_TAU0_Set_PowerOff
+                                 00009dad
+                 _R_TAU0_Set_Reset
+                                 00009db2
+                 _R_TAU0_Release_Reset
+                                 00009db7
+0058 r_cg_tkb_common
+     SECTION=.textf
+                 _R_TKB_Create
+                                 00009dbc 0056(00009d89:.textf)
+                 _R_TKB_Set_PowerOn
+                                 00009dc8
+                 _R_TKB_Set_PowerOff
+                                 00009dcd
+                 _R_TKB_Set_Reset
+                                 00009dd2
+                 _R_TKB_Release_Reset
+                                 00009dd7
+0059 hdwinit
+     SECTION=.textf
+                 _hdwinit
+                                 00009ddc 0060(00009df9:.textf)
+0060 r_bsp_init
+     SECTION=.textf
+                 _bsp_init_system
+                                 00009de6 0062(00004432:.text)
+                 _bsp_init_hardware
+                                 00009df8 0062(00004492:.text)
+0061 stkinit
+     SECTION=.textf
+                 _stkinit
+                                 00009dfc 0062(0000442e:.text)
+0062 cstart
+     SECTION=.text
+                 _start
+                                 00004426
+                 _exit
+                                 0000449a 0062(0000449b:.text)
+                 _atexit
+                                 0000449c
+     SECTION=.textf
+     SECTION=.const
+     SECTION=.constf
+     SECTION=.data
+     SECTION=.sdata
+     SECTION=.bss
+     SECTION=.sbss
+     SECTION=.dataR
+     SECTION=.sdataR
+     SECTION=.stack_bss
+     SECTION=.init_array
+     SECTION=.RLIB
+     SECTION=.SLIB
+     SECTION=.dataR
+     SECTION=.sdataR
+0063 r_bsp_common
+     SECTION=.const
+                 _g_bsp_delay_time
+                                 0000295a 0063(00009e9a:.textf)
+                                          0063(00009f6e:.textf)
+     SECTION=.textf
+                 _R_BSP_StartClock
+                                 00009e40
+                 _R_BSP_StopClock
+                                 00009e44
+                 _R_BSP_SetClockSource
+                                 00009e48
+                 _R_BSP_GetFclkFreqHz
+                                 00009e4c
+                 _R_BSP_ChangeClockSetting
+                                 00009e50
+                 _R_BSP_SoftwareDelay
+                                 00009e54
+0064 r_bsp_common_ccrl
+     SECTION=.text
+                 _delay_wait
+                                 0000449d 0063(0000a070:.textf)
+0065 mcu_clocks
+     SECTION=.const
+                 _g_fih_hz
+                                 00002972 0065(0000a36f:.textf)
+                 _g_fim_hz
+                                 00002a72 0065(0000a37b:.textf)
+     SECTION=.textf
+                 _start_clock
+                                 0000a077 0063(00009e41:.textf)
+                 _stop_clock
+                                 0000a183 0063(00009e45:.textf)
+                 _set_fclk_clock_source
+                                 0000a1b3 0063(00009e49:.textf)
+                 _get_fclk_freq_hz
+                                 0000a339 0063(00009e4d:.textf)
+                                          0063(00009e5a:.textf)
+                 _change_clock_setting
+                                 0000a44c 0063(00009e51:.textf)
+                 _mcu_clock_setup
+                                 0000a619 0060(00009df5:.textf)
+0066 r_lamp_tc
+     SECTION=.textf
+                 _R_LAMP_InitColourTypeTc
+                                 0000a6f5 0070(0000a8ce:.textf)
+                                          0070(0000a99b:.textf)
+                                          0070(0000a9ba:.textf)
+                 _R_LAMP_DimmingFlashTc
+                                 0000a6fd 0070(0000a93c:.textf)
+                 _R_LAMP_DimmingTc
+                                 0000a778 0070(0000a975:.textf)
+     SECTION=.bss
+0067 r_trng
+     SECTION=.textf
+                 _R_TRNG_Create
+                                 0000a867 0007(00007348:.textf)
+                 _R_TRNG_GenerateRandomNumber
+                                 0000a86c 0007(0000734c:.textf)
+                 _R_TRNG_WaitCompletion
+                                 0000a875 0007(00007350:.textf)
+                 _R_TRNG_GetRandomNumber
+                                 0000a87c 0007(00007354:.textf)
+0068 r_cg_lvd_common
+0069 r_cg_lvd_common_user
+0070 r_lamp
+     SECTION=.const
+                 _g_dimming_table
+                                 00002a82 0066(0000a70c:.textf)
+                                          0066(0000a788:.textf)
+                                          0071(0000b406:.textf)
+                                          0071(0000b4c9:.textf)
+                                          0071(0000b570:.textf)
+                                          0071(0000b5e5:.textf)
+                                          0071(0000b677:.textf)
+                                          0071(0000b6f3:.textf)
+                                          0071(0000b786:.textf)
+                                          0072(0000b8e1:.textf)
+                                          0072(0000bbcd:.textf)
+                                          0072(0000bbed:.textf)
+                                          0072(0000bbfd:.textf)
+                                          0072(0000bc1e:.textf)
+                                          0072(0000bc3c:.textf)
+                                          0072(0000bc42:.textf)
+                                          0072(0000bc69:.textf)
+                 _g_dimming_rate
+                                 00003682 0070(0000ab42:.textf)
+                 _g_dali209_general_callback
+                                 000039fc 0007(000073a6:.textf)
+     SECTION=.textf
+                 _R_LAMP_Init
+                                 0000a8a9 0007(00007361:.textf)
+                 _R_LAMP_Start
+                                 0000a8da 0007(000077ce:.textf)
+                 _R_LAMP_Tick1ms
+                                 0000a8de
+                 _R_LAMP_Task
+                                 0000a8ec 0007(00007a1c:.textf)
+                 _R_LAMP_IsOn
+                                 0000a9c4 0007(0000783a:.textf)
+                 _R_LAMP_IsFailure
+                                 0000aa13 0007(0000781f:.textf)
+                 _R_LAMP_IsFailureSpecified
+                                 0000aa5d 0066(0000a727:.textf)
+                                          0066(0000a733:.textf)
+                                          0066(0000a7eb:.textf)
+                                          0066(0000a7f7:.textf)
+                                          0071(0000b42d:.textf)
+                                          0071(0000b43d:.textf)
+                                          0071(0000b44e:.textf)
+                                          0071(0000b7fa:.textf)
+                                          0071(0000b82c:.textf)
+                                          0071(0000b83d:.textf)
+                                          0072(0000b908:.textf)
+                                          0072(0000b913:.textf)
+                                          0072(0000b91f:.textf)
+                                          0072(0000bcca:.textf)
+                                          0072(0000bcd5:.textf)
+                                          0072(0000bce1:.textf)
+                 _R_LAMP_IsStartup
+                                 0000aa9e 0007(00007813:.textf)
+                                          0007(00007833:.textf)
+                                          0007(0000784e:.textf)
+                 _R_LAMP_Startup
+                                 0000aaa5 0066(0000a772:.textf)
+                                          0066(0000a861:.textf)
+                                          0071(0000b4a6:.textf)
+                                          0071(0000b8c1:.textf)
+                                          0072(0000b972:.textf)
+                                          0072(0000bd60:.textf)
+                 _R_LAMP_SetActiveColourSpace
+                                 0000ab02 0007(00007990:.textf)
+                                          0007(000079ac:.textf)
+                                          0007(000079ef:.textf)
+                 _R_LAMP_SetDimmingCurve
+                                 0000ab06 0007(000079f5:.textf)
+                 _R_LAMP_SetDimmingLevelTc
+                                 0000ab0a 0007(0000798a:.textf)
+                 _R_LAMP_SetDimmingLevelXy
+                                 0000ab12 0007(000079a6:.textf)
+                 _R_LAMP_SetDimmingLevelRgbwaf
+                                 0000ab1e 0007(000079e9:.textf)
+                 _R_LAMP_GetDimmingRate
+                                 0000ab38 0070(000039fc:.const)
+                                          0070(000039fe:.const)
+                 _R_LAMP_ColourIsAttainable
+                                 0000ab53 0070(00003a00:.const)
+                                          0070(00003a02:.const)
+                 _R_LAMP_TranslateColourValueTCtoRGB
+                                 0000ab55 0070(00003a04:.const)
+                                          0070(00003a06:.const)
+                 _R_LAMP_TranslateColourValueRGBtoTC
+                                 0000ac77 0070(00003a08:.const)
+                                          0070(00003a0a:.const)
+                 _R_LAMP_TranslateColourValueTCtoXY
+                                 0000af45 0070(00003a0c:.const)
+                                          0070(00003a0e:.const)
+                 _R_LAMP_TranslateColourValueXYtoTC
+                                 0000afca 0070(00003a10:.const)
+                                          0070(00003a12:.const)
+                 _R_LAMP_TranslateColourValueXYtoRGB
+                                 0000b0f1 0070(00003a14:.const)
+                                          0070(00003a16:.const)
+                 _R_LAMP_TranslateColourValueRGBtoXY
+                                 0000b1ae 0070(00003a18:.const)
+                                          0070(00003a1a:.const)
+                 _R_LAMP_EnableFlashing
+                                 0000b3c7 0007(00007a03:.textf)
+                 _R_LAMP_DisableFlashing
+                                 0000b3dc 0007(00007a09:.textf)
+                 _R_LAMP_EnableCurrentProtector
+                                 0000b3e3 0007(00007a18:.textf)
+                 _R_LAMP_DisableCurrentProtector
+                                 0000b3e7 0007(00007a12:.textf)
+     SECTION=.bss
+0071 r_lamp_rgbwaf
+     SECTION=.textf
+                 _R_LAMP_InitColourTypeRgbwaf
+                                 0000b3eb 0070(0000a8d7:.textf)
+                                          0070(0000a97d:.textf)
+                                          0070(0000a99f:.textf)
+                 _R_LAMP_DimmingFlashRgbwaf
+                                 0000b3f6 0070(0000a95a:.textf)
+                 _R_LAMP_DimmingRgbwaf
+                                 0000b4ac 0070(0000a9b6:.textf)
+     SECTION=.bss
+0072 r_lamp_xy
+     SECTION=.textf
+                 _R_LAMP_InitColourTypeXy
+                                 0000b8c7 0070(0000a8d2:.textf)
+                                          0070(0000a979:.textf)
+                                          0070(0000a9bf:.textf)
+                 _R_LAMP_DimmingFlashXy
+                                 0000b8d2 0070(0000a949:.textf)
+                 _R_LAMP_DimmingXy
+                                 0000b978 0070(0000a996:.textf)
+                 _R_LAMP_CalculateForLinerRgbFromXy
+                                 0000bd66 0070(0000abce:.textf)
+                                          0070(0000b105:.textf)
+     SECTION=.bss
+0073 Config_DALI
+     SECTION=.textf
+                 _R_Config_DALI_Create
+                                 0000bfa7 0007(0000735c:.textf)
+                 _R_Config_DALI_Start
+                                 0000c04a 0011(00008d06:.textf)
+                 _R_Config_DALI_Stop
+                                 0000c076
+                 _R_Config_DALI_Softwarereset
+                                 0000c096
+                 _R_Config_DALI_Send8bit
+                                 0000c09b 0012(00008d61:.textf)
+                 _R_Config_DALI_GetReceivedFrame
+                                 0000c0d3 0013(00008e83:.textf)
+                 _R_Config_DALI_IsBusPowerDown
+                                 0000c0fb 0013(00008dcf:.textf)
+                 _R_Config_DALI_EnableForceActiveState
+                                 0000c104 0012(00008d67:.textf)
+                 _R_Config_DALI_DisableForceActiveState
+                                 0000c10b 0012(00008d31:.textf)
+     SECTION=.bss
+                 _g_rx_frame_data
+                                 000fdd9c 0073(0000c06a:.textf)
+                                          0073(0000c06d:.textf)
+                                          0073(0000c0e2:.textf)
+                                          0073(0000c0e5:.textf)
+                                          0074(00004501:.text)
+                                          0074(00004506:.text)
+                 _g_rx_frame_length
+                                 000fdda0 0073(0000c070:.textf)
+                                          0073(0000c0ec:.textf)
+                                          0074(0000450f:.text)
+                                          0074(00004514:.text)
+                 _g_rx_frame_exists
+                                 000fdda1 0073(0000c073:.textf)
+                                          0073(0000c0d6:.textf)
+                                          0073(0000c0f2:.textf)
+                                          0074(00004518:.text)
+0074 Config_DALI_user
+     SECTION=.textf
+                 _R_Config_DALI_Create_UserInit
+                                 0000c110 0073(0000c047:.textf)
+     SECTION=.text
+0075 Config_TAU
+     SECTION=.textf
+                 _R_Config_TAU_Create
+                                 0000c111 0057(00009da5:.textf)
+                 _R_Config_TAU_Start
+                                 0000c157 0009(000085b7:.textf)
+                 _R_Config_TAU_Stop
+                                 0000c168 0009(000085d9:.textf)
+0076 Config_TAU_user
+     SECTION=.textf
+                 _R_Config_TAU_Create_UserInit
+                                 0000c179 0075(0000c154:.textf)
+                 _r_Config_TAU_getTImerFlag
+                                 0000c17a 0009(0000847b:.textf)
+                 _r_Config_TAU_setTImerFlag
+                                 0000c17e 0009(000084ad:.textf)
+                                          0009(000085de:.textf)
+                 _r_Config_TAU_setMaxCount
+                                 0000c182 0009(000085b3:.textf)
+     SECTION=.dataR
+                 _count
+                                 000fd404 0076(00004533:.text)
+                                          0076(00004536:.text)
+                                          0076(00004542:.text)
+                 _maxCount
+                                 000fd406 0076(00004539:.text)
+                                          0076(0000c183:.textf)
+                 _timer_flag
+                                 000fd408 0076(00004545:.text)
+                                          0076(0000c17b:.textf)
+                                          0076(0000c17f:.textf)
+     SECTION=.text
+     SECTION=.data
+0077 Pin
+     SECTION=.textf
+                 _R_Pins_Create
+                                 0000c186
+0078 Config_UART
+     SECTION=.textf
+                 _R_Config_UART_Create
+                                 0000c239 0055(00009d19:.textf)
+                 _R_Config_UART_Start
+                                 0000c2d5 0009(0000845b:.textf)
+                 _R_Config_UART_Stop
+                                 0000c306
+                 _R_Config_UART_Send
+                                 0000c32d 0009(00008491:.textf)
+                                          0009(000084a4:.textf)
+                 _R_Config_UART_Receive
+                                 0000c355 0009(00008465:.textf)
+                                          0009(00008b3d:.textf)
+                 _R_Config_UART_Loopback_Enable
+                                 0000c36d
+                 _R_Config_UART_Loopback_Disable
+                                 0000c372
+     SECTION=.bss
+                 _gp_uart1_tx_address
+                                 000fdda2 0078(0000c339:.textf)
+                                          0078(0000c343:.textf)
+                                          0078(0000c34b:.textf)
+                                          0079(00004562:.text)
+                                          0079(0000456a:.text)
+                 _g_uart1_tx_count
+                                 000fdda4 0078(0000c33d:.textf)
+                                          0078(0000c34e:.textf)
+                                          0079(00004555:.text)
+                                          0079(0000456d:.text)
+                 _gp_uart1_rx_address
+                                 000fdda6 0078(0000c369:.textf)
+                                          0079(00004593:.text)
+                                          0079(00004599:.text)
+                                          0079(000045c9:.text)
+                 _g_uart1_rx_count
+                                 000fdda8 0078(0000c361:.textf)
+                                          0079(0000c383:.textf)
+                                          0079(0000458c:.text)
+                                          0079(0000459c:.text)
+                                          0079(000045a2:.text)
+                 _g_uart1_rx_length
+                                 000fddaa 0078(0000c365:.textf)
+                                          0079(00004589:.text)
+                                          0079(0000459f:.text)
+0079 Config_UART_user
+     SECTION=.textf
+                 _R_Config_UART_Create_UserInit
+                                 0000c377 0078(0000c2d2:.textf)
+                 _R_Config_UART_GetReceiveCount
+                                 0000c382 0009(00008b06:.textf)
+     SECTION=.dataR
+                 _g_tx_end_flag
+                                 000fd40a
+                 _g_rx_end_flag
+                                 000fd40b 0079(0000c37d:.textf)
+     SECTION=.text
+     SECTION=.data
+0080 r_dali207_api
+     SECTION=.textf
+                 _R_DALI207_InitLibrary
+                                 0000c386 0007(000073a2:.textf)
+                 _R_DALI207_InitLogicalUnit
+                                 0000c387 0007(00007405:.textf)
+                 _R_DALI207_SetNvm
+                                 0000c3ff 0007(000077b0:.textf)
+                 _R_DALI207_GetNvm
+                                 0000c406 0007(00007a88:.textf)
+                                          0007(00007b04:.textf)
+                 _R_DALI207_NvmIsValid
+                                 0000c40d 0007(0000776d:.textf)
+                 _R_DALI207_NvmIsChanged
+                                 0000c414 0007(00007a46:.textf)
+                 _R_DALI207_GetStatus
+                                 0000c41b 0007(00007865:.textf)
+                                          0007(00007974:.textf)
+                                          0007(00007cb1:.textf)
+                                          0007(00007d62:.textf)
+                 _R_DALI207_GetDimmingCurve
+                                 0000c43e 0007(00007962:.textf)
+                 _R_DALI207_SetFailureStatus
+                                 0000c445 0007(000078e6:.textf)
+                 _R_DALI207_AddFailureStatus
+                                 0000c44c
+                 _R_DALI207_RemoveFailureStatus
+                                 0000c453
+                 _R_DALI207_SetOperatingMode
+                                 0000c45a
+                 _R_DALI207_AddOperatingMode
+                                 0000c461
+                 _R_DALI207_RemoveOperatingMode
+                                 0000c468
+                 _R_DALI207_FinishReferenceMeasurement
+                                 0000c46f 0007(00007d5b:.textf)
+                 _R_DALI207_GetLibraryVersion
+                                 0000c476
+     SECTION=.const
+0081 r_dali102_api
+     SECTION=.textf
+                 _R_DALI102_InitLibrary
+                                 0000c47a 0007(00007398:.textf)
+                 _R_DALI102_InitLogicalUnit
+                                 0000c4cb 0007(000073ee:.textf)
+                 _R_DALI102_NvmIsValid
+                                 0000c58d 0007(00007761:.textf)
+                 _R_DALI102_SetNvm
+                                 0000c5b2 0007(000077a6:.textf)
+                 _R_DALI102_GetNvm
+                                 0000c5b9 0007(00007a7e:.textf)
+                                          0007(00007afa:.textf)
+                 _R_DALI102_NvmIsChanged
+                                 0000c5c0 0007(00007a3d:.textf)
+                 _R_DALI102_NeedsToSaveNvm
+                                 0000c5c7 0007(00007ae6:.textf)
+                 _R_DALI102_NotifySaveNvm
+                                 0000c5cb 0007(00007af0:.textf)
+                 _R_DALI102_StartPowerOnTimer
+                                 0000c5d0 0007(000077ec:.textf)
+                 _R_DALI102_GetOperatingMode
+                                 0000c67b 0007(00007938:.textf)
+                 _R_DALI102_Tick1ms
+                                 0000c682
+                 _R_DALI102_NotifyBeginStartup
+                                 0000c6ff 0007(00007858:.textf)
+                 _R_DALI102_NotifyEndStartup
+                                 0000c704 0007(0000785e:.textf)
+                 _R_DALI102_SetLampOn
+                                 0000c709 0007(00007844:.textf)
+                 _R_DALI102_ClearLampOn
+                                 0000c710 0007(0000784a:.textf)
+                 _R_DALI102_SetLampFailure
+                                 0000c717 0007(00007829:.textf)
+                 _R_DALI102_ClearLampFailure
+                                 0000c71e 0007(0000782f:.textf)
+                 _R_DALI102_SetControlGearFailure
+                                 0000c725 0007(00007800:.textf)
+                 _R_DALI102_ClearControlGearFailure
+                                 0000c72c 0007(00007806:.textf)
+                 _R_DALI102_NotifySystemFailure
+                                 0000c733 0007(000078fc:.textf)
+                 _R_DALI102_GetActualLevel
+                                 0000c797 0007(0000780d:.textf)
+                                          0007(00007874:.textf)
+                                          0007(00007959:.textf)
+                                          0007(00007b67:.textf)
+                                          0110(0000f615:.textf)
+                 _R_DALI102_GetActualLevelHighRes
+                                 0000c7b5
+                 _R_DALI102_IdentificationIsActive
+                                 0000c7c7 0007(000079fc:.textf)
+                 _R_DALI102_CreateCommand
+                                 0000c7d4 0007(00007925:.textf)
+                 _R_DALI102_ExecuteCommand
+                                 0000c7fd 0007(00007948:.textf)
+                 _R_DALI102_GetLibraryVersion
+                                 0000c889
+0082 r_dali209_api
+     SECTION=.textf
+                 _R_DALI209_InitLibrary
+                                 0000c88d 0007(000073a9:.textf)
+                 _R_DALI209_InitLogicalUnit
+                                 0000c89a 0007(0000741a:.textf)
+                 _R_DALI209_NvmIsValid
+                                 0000c9a9 0007(00007779:.textf)
+                 _R_DALI209_SetNvm
+                                 0000c9b0 0007(000077ba:.textf)
+                 _R_DALI209_GetNvm
+                                 0000c9bf 0007(00007a92:.textf)
+                                          0007(00007b0e:.textf)
+                 _R_DALI209_NvmIsChanged
+                                 0000c9c6 0007(00007a4f:.textf)
+                 _R_DALI209_GetActiveColourSpace
+                                 0000c9cd 0007(0000796b:.textf)
+                                          0007(00007b70:.textf)
+                 _R_DALI209_GetActualColourValueTc
+                                 0000c9d2 0007(00007983:.textf)
+                                          0007(00007b7d:.textf)
+                 _R_DALI209_GetActualColourValueXy
+                                 0000ca05 0007(0000799d:.textf)
+                                          0007(00007bb6:.textf)
+                 _R_DALI209_GetActualColourValueRgbwaf
+                                 0000ca31 0007(000079be:.textf)
+                                          0007(00007c08:.textf)
+                 _R_DALI209_GetLibraryVersion
+                                 0000cab5
+     SECTION=.const
+0083 sprintf
+     SECTION=.SLIB
+                 _sprintf
+                                 000051bd 0007(00007ba2:.textf)
+                                          0007(00007be7:.textf)
+                                          0007(00007cc8:.textf)
+                                          0007(00007d10:.textf)
+                                          0007(00007d32:.textf)
+                                          0007(00007d51:.textf)
+     SECTION=.bss
+0084 strlen
+     SECTION=.SLIB
+                 _strlen
+                                 00005279 0007(00007d02:.textf)
+                                          0007(00007d16:.textf)
+                                          0007(00007d43:.textf)
+0085 memcpy
+     SECTION=.RLIB
+                 _memcpy
+                                 000045ee 0002(00015152:NVM_f)
+                                          0002(000154eb:NVM_f)
+                                          0081(0000c6ec:.textf)
+                                          0081(0000c80f:.textf)
+                                          0082(0000ca4d:.textf)
+                                          0082(0000caaf:.textf)
+                                          0100(0000d30c:.textf)
+                                          0101(0000d5ec:.textf)
+                                          0110(0000f3f6:.textf)
+                                          0110(0000f407:.textf)
+                                          0110(0000f418:.textf)
+                                          0110(0000f429:.textf)
+                                          0110(0000f485:.textf)
+                                          0110(0000f496:.textf)
+                                          0110(0000f4a7:.textf)
+                                          0110(0000f4b8:.textf)
+                                          0110(0000f4cf:.textf)
+                                          0110(0000f4e2:.textf)
+                                          0110(0000f4f3:.textf)
+                                          0110(0000f504:.textf)
+                                          0110(0000f515:.textf)
+                                          0110(0000f52c:.textf)
+                                          0110(0000f53d:.textf)
+                                          0110(0000f54e:.textf)
+                                          0110(0000f55f:.textf)
+                                          0110(0000f581:.textf)
+                                          0110(0000f592:.textf)
+                                          0110(0000f5a3:.textf)
+                                          0110(0000f5b4:.textf)
+                                          0110(0000f5cd:.textf)
+                                          0110(0000f607:.textf)
+                                          0110(0000fe49:.textf)
+                                          0110(000103f4:.textf)
+                                          0110(00010ed9:.textf)
+                                          0111(00012648:.textf)
+                                          0111(00012ea5:.textf)
+                                          0113(0001419a:.textf)
+0086 memset
+     SECTION=.RLIB
+                 _memset
+                                 000045fe 0002(00015143:NVM_f)
+                                          0112(00013b2c:.textf)
+                                          0112(00013b3c:.textf)
+                                          0113(000141b2:.textf)
+                                          0113(000142e2:.textf)
+0087 _COM_faddsub
+     SECTION=.RLIB
+                 __COM_fsub
+                                 00004668 0070(0000ae6d:.textf)
+                                          0070(0000b019:.textf)
+                                          0072(0000bbaa:.textf)
+                                          0072(0000bf89:.textf)
+                 __COM_fadd
+                                 00004670 0070(0000ad90:.textf)
+                                          0070(0000ad9e:.textf)
+                                          0070(0000adc3:.textf)
+                                          0070(0000add1:.textf)
+                                          0070(0000ade5:.textf)
+                                          0070(0000ae0a:.textf)
+                                          0070(0000ae18:.textf)
+                                          0070(0000ae25:.textf)
+                                          0070(0000ae49:.textf)
+                                          0070(0000aed2:.textf)
+                                          0070(0000aef7:.textf)
+                                          0070(0000af07:.textf)
+                                          0070(0000afef:.textf)
+                                          0070(0000b07e:.textf)
+                                          0070(0000b0a3:.textf)
+                                          0070(0000b0b3:.textf)
+                                          0070(0000b2c7:.textf)
+                                          0070(0000b2d5:.textf)
+                                          0070(0000b2fa:.textf)
+                                          0070(0000b308:.textf)
+                                          0070(0000b31c:.textf)
+                                          0070(0000b341:.textf)
+                                          0070(0000b34f:.textf)
+                                          0070(0000b35c:.textf)
+                                          0072(0000baf0:.textf)
+                                          0072(0000bb24:.textf)
+                                          0072(0000bb58:.textf)
+                                          0072(0000bb9e:.textf)
+                                          0072(0000bebc:.textf)
+                                          0072(0000bef2:.textf)
+                                          0072(0000bf37:.textf)
+                                          0072(0000bf7d:.textf)
+0088 _COM_fdiv
+     SECTION=.RLIB
+                 __COM_fdiv
+                                 000047a6 0070(0000ac8e:.textf)
+                                          0070(0000acae:.textf)
+                                          0070(0000acce:.textf)
+                                          0070(0000ae39:.textf)
+                                          0070(0000ae5f:.textf)
+                                          0070(0000ae7a:.textf)
+                                          0070(0000af13:.textf)
+                                          0070(0000b026:.textf)
+                                          0070(0000b0bf:.textf)
+                                          0070(0000b1c5:.textf)
+                                          0070(0000b1e5:.textf)
+                                          0070(0000b205:.textf)
+                                          0070(0000b370:.textf)
+                                          0070(0000b395:.textf)
+                                          0072(0000bb74:.textf)
+                                          0072(0000bb8a:.textf)
+                                          0072(0000bf53:.textf)
+                                          0072(0000bf69:.textf)
+                                          0114(00006861:.SLIB)
+0089 _COM_fle
+     SECTION=.RLIB
+                 __COM_fle
+                                 00004875 0072(0000ba2b:.textf)
+                                          0072(0000bb06:.textf)
+                                          0072(0000bb3a:.textf)
+                                          0072(0000bddf:.textf)
+                                          0072(0000bed3:.textf)
+                                          0072(0000bf10:.textf)
+0090 _COM_fmul
+     SECTION=.RLIB
+                 __COM_fmul
+                                 000048d6 0070(0000abfc:.textf)
+                                          0070(0000ac35:.textf)
+                                          0070(0000ace3:.textf)
+                                          0070(0000acfb:.textf)
+                                          0070(0000ad13:.textf)
+                                          0070(0000ad37:.textf)
+                                          0070(0000ad4f:.textf)
+                                          0070(0000ad67:.textf)
+                                          0070(0000ad83:.textf)
+                                          0070(0000adb6:.textf)
+                                          0070(0000adfd:.textf)
+                                          0070(0000ae89:.textf)
+                                          0070(0000ae9e:.textf)
+                                          0070(0000aeb4:.textf)
+                                          0070(0000aec4:.textf)
+                                          0070(0000aeea:.textf)
+                                          0070(0000af23:.textf)
+                                          0070(0000afdf:.textf)
+                                          0070(0000b00b:.textf)
+                                          0070(0000b035:.textf)
+                                          0070(0000b04a:.textf)
+                                          0070(0000b060:.textf)
+                                          0070(0000b070:.textf)
+                                          0070(0000b096:.textf)
+                                          0070(0000b0cf:.textf)
+                                          0070(0000b133:.textf)
+                                          0070(0000b16c:.textf)
+                                          0070(0000b21a:.textf)
+                                          0070(0000b232:.textf)
+                                          0070(0000b24a:.textf)
+                                          0070(0000b26e:.textf)
+                                          0070(0000b286:.textf)
+                                          0070(0000b29e:.textf)
+                                          0070(0000b2ba:.textf)
+                                          0070(0000b2ed:.textf)
+                                          0070(0000b334:.textf)
+                                          0070(0000b37e:.textf)
+                                          0070(0000b3a3:.textf)
+                                          0072(0000bbdc:.textf)
+                                          0072(0000bc2f:.textf)
+                                          0072(0000bc83:.textf)
+                                          0114(00005cbf:.SLIB)
+                                          0114(0000683c:.SLIB)
+0091 _COM_ftoul
+     SECTION=.RLIB
+                 __COM_ftoul
+                                 00004978 0070(0000ac02:.textf)
+                                          0070(0000ac3b:.textf)
+                                          0070(0000af29:.textf)
+                                          0070(0000b0d5:.textf)
+                                          0070(0000b139:.textf)
+                                          0070(0000b172:.textf)
+                                          0070(0000b384:.textf)
+                                          0070(0000b3a9:.textf)
+                                          0072(0000baf6:.textf)
+                                          0072(0000bb2a:.textf)
+                                          0072(0000bb5e:.textf)
+                                          0072(0000bbe2:.textf)
+                                          0072(0000bc35:.textf)
+                                          0072(0000bc89:.textf)
+                                          0072(0000bec2:.textf)
+                                          0072(0000bef8:.textf)
+                                          0072(0000bf3d:.textf)
+0092 _COM_llmul
+     SECTION=.RLIB
+                 __COM_llmul
+                                 00004984 0063(00009f59:.textf)
+                                          0071(0000b4d6:.textf)
+                                          0071(0000b5f2:.textf)
+                                          0071(0000b700:.textf)
+                                          0105(0000e760:.textf)
+                                          0110(0000f838:.textf)
+                                          0110(0000f8fd:.textf)
+                                          0110(0000faeb:.textf)
+                                          0110(0000fb6b:.textf)
+                                          0110(0000fcc8:.textf)
+                                          0110(0000fdaa:.textf)
+                                          0112(00013ec3:.textf)
+                 __REL_llmul_addh
+                                 000049bc 0092(000049a1:.RLIB)
+                                          0092(000049b6:.RLIB)
+0093 _COM_macsi
+     SECTION=.RLIB
+                 __COM_macsi
+                                 000049ce 0014(00009088:.textf)
+                                          0014(000090bb:.textf)
+                                          0014(000091f8:.textf)
+                                          0014(0000922b:.textf)
+                                          0014(00009369:.textf)
+                                          0014(0000939c:.textf)
+0094 _COM_sltof
+     SECTION=.RLIB
+                 __COM_sltof
+                                 000049f6 0072(0000ba1d:.textf)
+                                          0072(0000ba7e:.textf)
+                                          0072(0000bad5:.textf)
+                                          0072(0000bdd1:.textf)
+                                          0072(0000be35:.textf)
+                                          0072(0000be8e:.textf)
+0095 _COM_ulldiv
+     SECTION=.RLIB
+                 __COM_ulldiv
+                                 00004a0e 0063(00009ee0:.textf)
+                                          0063(00009f8a:.textf)
+                                          0063(0000a010:.textf)
+                                          0071(0000b510:.textf)
+                                          0071(0000b62c:.textf)
+                                          0071(0000b73a:.textf)
+                                          0105(0000e82c:.textf)
+                                          0110(0000f818:.textf)
+                                          0110(0000f8dd:.textf)
+                                          0112(00013feb:.textf)
+                                          0114(0000564b:.SLIB)
+0096 _COM_ultof
+     SECTION=.RLIB
+                 __COM_ultof
+                                 00004a38 0070(0000ac82:.textf)
+                                          0070(0000aca2:.textf)
+                                          0070(0000acc2:.textf)
+                                          0070(0000afd3:.textf)
+                                          0070(0000afff:.textf)
+                                          0070(0000b1b9:.textf)
+                                          0070(0000b1d9:.textf)
+                                          0070(0000b1f9:.textf)
+                                          0072(0000bb18:.textf)
+                                          0072(0000bb4c:.textf)
+                                          0072(0000bb62:.textf)
+                                          0072(0000bbd1:.textf)
+                                          0072(0000bc24:.textf)
+                                          0072(0000bc78:.textf)
+                                          0072(0000bee6:.textf)
+                                          0072(0000bf2b:.textf)
+                                          0072(0000bf41:.textf)
+0097 r_dali207
+     SECTION=.textf
+                 _R_DALI207_GetDeviceType
+                                 0000cab9 0080(00003a1c:.const)
+                                          0080(00003a1e:.const)
+                 _R_DALI207_GetExtendedVersionNumber
+                                 0000cac0 0080(00003a20:.const)
+                                          0080(00003a22:.const)
+                 _R_DALI207_IsReset
+                                 0000cac7 0080(00003a24:.const)
+                                          0080(00003a26:.const)
+                 _R_DALI207_ExecutePowerOnProcess
+                                 0000cace 0080(00003a28:.const)
+                                          0080(00003a2a:.const)
+                 _R_DALI207_ExecuteSystemFailureProcess
+                                 0000cacf 0080(00003a2c:.const)
+                                          0080(00003a2e:.const)
+                 _R_DALI207_TickTimer
+                                 0000cad0 0080(00003a48:.const)
+                                          0080(00003a4a:.const)
+                 _R_DALI207_GetFadeTime
+                                 0000cad7 0080(00003a4c:.const)
+                                          0080(00003a4e:.const)
+                 _R_DALI207_GetPhysicalMinimumLevel
+                                 0000cb1f 0080(00003a50:.const)
+                                          0080(00003a52:.const)
+                 _R_DALI207_ReferenceMeasurementIsRunning
+                                 0000cb42 0080(00003a54:.const)
+                                          0080(00003a56:.const)
+     SECTION=.const
+0098 r_dali207_cmd
+     SECTION=.textf
+                 _R_DALI207_StandardCommandIsIgnored
+                                 0000cb49 0080(00003a30:.const)
+                                          0080(00003a32:.const)
+                 _R_DALI207_ApplicationExtendedCommandIsIgnored
+                                 0000cb6b 0080(00003a34:.const)
+                                          0080(00003a36:.const)
+                 _R_DALI207_ExistsReplacementProcess
+                                 0000cb99 0080(00003a38:.const)
+                                          0080(00003a3a:.const)
+                 _R_DALI207_ExecuteReplacementProcess
+                                 0000cb9b 0080(00003a3c:.const)
+                                          0080(00003a3e:.const)
+                 _R_DALI207_ExecuteAdditionalProcess
+                                 0000cb9e 0080(00003a40:.const)
+                                          0080(00003a42:.const)
+                 _R_DALI207_ExecuteApplicationExtendedCommand
+                                 0000cbbb 0080(00003a44:.const)
+                                          0080(00003a46:.const)
+     SECTION=.const
+0099 r_dali207_var
+     SECTION=.textf
+                 _R_DALI207_VAR_Init
+                                 0000cee2 0080(0000c3d6:.textf)
+                 _R_DALI207_VAR_Reset
+                                 0000cef7 0098(0000cbb0:.textf)
+                 _R_DALI207_VAR_IsReset
+                                 0000cf03 0097(0000cacb:.textf)
+                 _R_DALI207_VAR_SetNvm
+                                 0000cf12 0080(0000c403:.textf)
+                 _R_DALI207_VAR_GetNvm
+                                 0000cf2c 0080(0000c40a:.textf)
+                 _R_DALI207_VAR_NvmIsValid
+                                 0000cf49 0080(0000c411:.textf)
+                 _R_DALI207_VAR_NvmIsChanged
+                                 0000cf7d 0080(0000c418:.textf)
+                 _R_DALI207_VAR_GetMinFastFadeTime
+                                 0000cf8b 0098(0000cd60:.textf)
+                                          0098(0000ced9:.textf)
+                 _R_DALI207_VAR_SetFastFadeTime
+                                 0000cf91 0098(0000cd76:.textf)
+                                          0099(0000cefa:.textf)
+                 _R_DALI207_VAR_GetFastFadeTime
+                                 0000cfa0 0097(0000caf6:.textf)
+                                          0098(0000cec9:.textf)
+                 _R_DALI207_VAR_GetGearType
+                                 0000cfa3 0098(0000cda4:.textf)
+                 _R_DALI207_VAR_GetPossibleOperatingModes
+                                 0000cfaa 0098(0000cdc2:.textf)
+                 _R_DALI207_VAR_GetFeatures
+                                 0000cfb1 0098(0000cc43:.textf)
+                                          0098(0000cdd1:.textf)
+                 _R_DALI207_VAR_SetFailureStatus
+                                 0000cfb8 0080(0000c449:.textf)
+                 _R_DALI207_VAR_GetFailureStatus
+                                 0000cfbd 0098(0000cbfb:.textf)
+                                          0098(0000cde3:.textf)
+                                          0098(0000ce3f:.textf)
+                 _R_DALI207_VAR_AddFailureStatus
+                                 0000cfc1 0080(0000c450:.textf)
+                                          0098(0000cc1c:.textf)
+                 _R_DALI207_VAR_RemoveFailureStatus
+                                 0000cfc8 0080(0000c457:.textf)
+                                          0098(0000cc07:.textf)
+                 _R_DALI207_VAR_SetOperatingMode
+                                 0000cfd1 0080(0000c45e:.textf)
+                 _R_DALI207_VAR_AddOperatingMode
+                                 0000cfd6 0080(0000c465:.textf)
+                 _R_DALI207_VAR_RemoveOperatingMode
+                                 0000cfdd 0080(0000c46c:.textf)
+                 _R_DALI207_VAR_GetOperatingMode
+                                 0000cfe6 0098(0000ceb9:.textf)
+                 _R_DALI207_VAR_SetDimmingCurve
+                                 0000cff2 0098(0000cc9f:.textf)
+                                          0099(0000cf01:.textf)
+                 _R_DALI207_VAR_GetDimmingCurve
+                                 0000cffd 0080(0000c442:.textf)
+                                          0097(0000cb27:.textf)
+                                          0098(0000cdb3:.textf)
+                 _R_DALI207_VAR_GetExtendedVersionNumber
+                                 0000d001 0097(0000cac4:.textf)
+                 _R_DALI207_VAR_GetDeviceType
+                                 0000d003 0097(0000cabd:.textf)
+                 _R_DALI207_VAR_EnableCurrentProtector
+                                 0000d006 0098(0000cc35:.textf)
+                 _R_DALI207_VAR_DisableCurrentProtector
+                                 0000d015 0098(0000cc6d:.textf)
+                 _R_DALI207_VAR_CurrentProtectorIsEnabled
+                                 0000d027 0080(0000c431:.textf)
+                                          0098(0000ceaa:.textf)
+                 _R_DALI207_VAR_LampIsFailure
+                                 0000d02f
+                 _R_DALI207_VAR_GetPhm
+                                 0000d039 0097(0000cb32:.textf)
+0100 r_dali102
+     SECTION=.textf
+                 _R_DALI102_RegisterCallback
+                                 0000d040 0081(0000c4bb:.textf)
+                 _R_DALI102_GetRandomAddress
+                                 0000d044 0101(0000e36d:.textf)
+                 _R_DALI102_GetFadeTimeMs
+                                 0000d050 0101(0000d6c2:.textf)
+                                          0101(0000db10:.textf)
+                                          0111(00011e78:.textf)
+                                          0111(00012c4f:.textf)
+                 _R_DALI102_CalcActualLevelDuringFade
+                                 0000d07f 0100(0000d13e:.textf)
+                                          0110(00010a68:.textf)
+                 _R_DALI102_FadeTryStart
+                                 0000d0cf 0100(0000d172:.textf)
+                                          0100(0000d20e:.textf)
+                                          0101(0000d797:.textf)
+                                          0101(0000d8b3:.textf)
+                                          0110(00010aa9:.textf)
+                 _R_DALI102_Fading
+                                 0000d11e 0081(0000c686:.textf)
+                 _R_DALI102_SetTargetLevelProcess
+                                 0000d186 0081(0000c761:.textf)
+                                          0100(0000d370:.textf)
+                                          0101(0000d6a9:.textf)
+                                          0101(0000d6f5:.textf)
+                                          0101(0000d710:.textf)
+                                          0101(0000d800:.textf)
+                                          0101(0000d844:.textf)
+                                          0101(0000d8f3:.textf)
+                                          0101(0000db25:.textf)
+                                          0101(0000db34:.textf)
+                                          0101(0000dd03:.textf)
+                 _R_DALI102_FadeSetAbsoluteProcess
+                                 0000d1b1 0101(0000d6b8:.textf)
+                                          0101(0000db43:.textf)
+                 _R_DALI102_FadeStopProcess
+                                 0000d210 0081(0000c63d:.textf)
+                                          0081(0000c750:.textf)
+                                          0101(0000d62f:.textf)
+                 _R_DALI102_SetLimitError
+                                 0000d24a 0100(0000d2ac:.textf)
+                                          0100(0000d2be:.textf)
+                                          0101(0000d82a:.textf)
+                                          0101(0000d904:.textf)
+                                          0101(0000dcfa:.textf)
+                 _R_DALI102_ClearLimitError
+                                 0000d25d 0100(0000d28f:.textf)
+                                          0100(0000d2c6:.textf)
+                                          0101(0000d709:.textf)
+                                          0101(0000d83b:.textf)
+                                          0101(0000da8b:.textf)
+                                          0101(0000dcd6:.textf)
+                 _R_DALI102_EnableLimitError
+                                 0000d26b 0081(0000c76f:.textf)
+                                          0101(0000d6e2:.textf)
+                                          0101(0000d720:.textf)
+                                          0101(0000d79d:.textf)
+                                          0101(0000d9bd:.textf)
+                                          0101(0000da75:.textf)
+                                          0101(0000db4b:.textf)
+                 _R_DALI102_CalcTargetLevelDirectly
+                                 0000d270 0081(0000c758:.textf)
+                                          0100(0000d368:.textf)
+                                          0101(0000d681:.textf)
+                                          0101(0000d7e4:.textf)
+                                          0101(0000db08:.textf)
+                 _R_DALI102_GetDiscreteLevel
+                                 0000d2cc 0101(0000d833:.textf)
+                 _R_DALI102_GetResetState
+                                 0000d2d0 0101(0000def9:.textf)
+                                          0101(0000df89:.textf)
+                 _R_DALI102_IsEqualShortAddress
+                                 0000d316 0101(0000d549:.textf)
+                                          0101(0000e459:.textf)
+                 _R_DALI102_ListContains
+                                 0000d32f 0081(0000c50a:.textf)
+                                          0081(0000c5a6:.textf)
+                                          0101(0000d518:.textf)
+                 _R_DALI102_PowerOnProcess
+                                 0000d349 0081(0000c661:.textf)
+                                          0081(0000c698:.textf)
+                 _R_DALI102_GetPhysicalMinimumLevel
+                                 0000d3a4 0098(0000cd2d:.textf)
+                                          0101(0000dd26:.textf)
+                                          0101(0000e00b:.textf)
+                 _R_DALI102_ReferenceMeasurementIsRunning
+                                 0000d3ba 0098(0000cb8e:.textf)
+                 _R_DALI102_FadeIsRunning
+                                 0000d3c5 0101(0000deea:.textf)
+     SECTION=.data
+     SECTION=.dataR
+0101 r_dali102_cmd
+     SECTION=.textf
+                 _R_DALI102_GetCommandNumber
+                                 0000d3d6 0081(0000c7db:.textf)
+                 _R_DALI102_GetCommandExecuteCondition
+                                 0000d3fc 0081(0000c7e1:.textf)
+                 _R_DALI102_GetCommandFunction
+                                 0000d404 0081(0000c86f:.textf)
+                 _R_DALI102_IsAddressingTarget
+                                 0000d411 0101(0000d479:.textf)
+                 _R_DALI102_CommandIsIgnored
+                                 0000d472 0081(0000c818:.textf)
+                 _R_DALI102_ExecuteCommandCommonProcess
+                                 0000d5fb 0098(0000cd97:.textf)
+                                          0098(0000cdfb:.textf)
+                                          0101(0000d7bc:.textf)
+                                          0101(0000db7a:.textf)
+                                          0101(0000db85:.textf)
+                                          0111(00012be6:.textf)
+                                          0111(000131cb:.textf)
+     SECTION=.const
+0102 r_dali102_dt6_if
+     SECTION=.textf
+                 _R_DALI102_DT6_IF_Init
+                                 0000e52a 0080(0000c3ca:.textf)
+                 _R_DALI102_DT6_IF_GetFadeTime
+                                 0000e531 0100(0000d07c:.textf)
+                 _R_DALI102_DT6_IF_GetPhysicalMinimumLevel
+                                 0000e53f 0100(0000d3b1:.textf)
+                 _R_DALI102_DT6_IF_ReferenceMeasurementIsRunning
+                                 0000e54e 0100(0000d3c2:.textf)
+0103 r_dali102_dt8_if
+     SECTION=.textf
+                 _R_DALI102_DT8_IF_Init
+                                 0000e559 0082(0000c91b:.textf)
+                 _R_DALI102_DT8_IF_FadeTryStart
+                                 0000e560 0100(0000d111:.textf)
+                 _R_DALI102_DT8_IF_FadeIsRunning
+                                 0000e56a 0100(0000d3d3:.textf)
+                 _R_DALI102_DT8_IF_Fading
+                                 0000e579 0100(0000d177:.textf)
+                 _R_DALI102_DT8_IF_FadeStopProcess
+                                 0000e588 0100(0000d247:.textf)
+0104 r_dali102_dtx_if
+     SECTION=.textf
+                 _R_DALI102_DTX_IF_Init
+                                 0000e593 0080(0000c3bb:.textf)
+                                          0082(0000c8fd:.textf)
+                 _R_DALI102_DTX_IF_GetDeviceType
+                                 0000e59a 0101(0000dff6:.textf)
+                                          0101(0000e1ac:.textf)
+                                          0101(0000e1d2:.textf)
+                                          0101(0000e4a8:.textf)
+                 _R_DALI102_DTX_IF_GetExtendedVersionNumber
+                                 0000e5a4 0101(0000e2f8:.textf)
+                 _R_DALI102_DTX_IF_IsReset
+                                 0000e5b3 0100(0000d2f2:.textf)
+                 _R_DALI102_DTX_IF_ExecutePowerOnProcess
+                                 0000e5be 0100(0000d393:.textf)
+                 _R_DALI102_DTX_IF_ExecuteSystemFailureProcess
+                                 0000e5c9 0081(0000c786:.textf)
+                 _R_DALI102_DTX_IF_StandardCommandIsIgnored
+                                 0000e5d8 0101(0000d59d:.textf)
+                 _R_DALI102_DTX_IF_ApplicationExtendedCommandIsIgnored
+                                 0000e5e3 0101(0000d493:.textf)
+                 _R_DALI102_DTX_IF_ExistsReplacementProcess
+                                 0000e5f2 0081(0000c833:.textf)
+                 _R_DALI102_DTX_IF_ExecuteReplacementProcess
+                                 0000e5fd 0081(0000c844:.textf)
+                 _R_DALI102_DTX_IF_ExecuteAdditionalProcess
+                                 0000e60c 0081(0000c857:.textf)
+                 _R_DALI102_DTX_IF_ExecuteApplicationExtendedCommand
+                                 0000e61b 0101(0000e2e2:.textf)
+                 _R_DALI102_DTX_IF_TickTimer
+                                 0000e62a 0081(0000c6db:.textf)
+0105 r_dali102_fade
+     SECTION=.textf
+                 _R_DALI102_FADE_Init
+                                 0000e635 0081(0000c542:.textf)
+                 _R_DALI102_FADE_Tick1ms
+                                 0000e648 0100(0000d136:.textf)
+                                          0110(00010a5f:.textf)
+                 _R_DALI102_FADE_IsRunning
+                                 0000e67e 0100(0000d12d:.textf)
+                                          0100(0000d21e:.textf)
+                                          0100(0000d3cf:.textf)
+                                          0110(00010a2e:.textf)
+                                          0110(00010a52:.textf)
+                                          0110(00010b75:.textf)
+                 _R_DALI102_FADE_IsRequested
+                                 0000e681 0100(0000d100:.textf)
+                                          0100(0000d227:.textf)
+                                          0110(00010329:.textf)
+                                          0110(000104ec:.textf)
+                                          0110(000106ac:.textf)
+                                          0110(000109fe:.textf)
+                                          0110(00010b82:.textf)
+                 _R_DALI102_FADE_Start
+                                 0000e695 0100(0000d10b:.textf)
+                                          0110(00010337:.textf)
+                                          0110(000104fa:.textf)
+                                          0110(000106b9:.textf)
+                                          0110(00010a0b:.textf)
+                 _R_DALI102_FADE_Stop
+                                 0000e6cb 0100(0000d155:.textf)
+                                          0100(0000d241:.textf)
+                                          0110(00010a89:.textf)
+                                          0110(00010ba4:.textf)
+                 _R_DALI102_FADE_Set
+                                 0000e6da 0100(0000d204:.textf)
+                                          0101(0000d78f:.textf)
+                                          0101(0000d8ab:.textf)
+                 _R_DALI102_FADE_GetType
+                                 0000e700 0101(0000d7ae:.textf)
+                 _R_DALI102_FADE_GetRelativeLevel
+                                 0000e704 0101(0000d810:.textf)
+                 _R_DALI102_FADE_GetFadeTimeMs
+                                 0000e70c 0097(0000cb1c:.textf)
+                                          0100(0000d076:.textf)
+                 _R_DALI102_FADE_GetExFadeTimeMs
+                                 0000e718 0097(0000cb08:.textf)
+                                          0100(0000d072:.textf)
+                 _R_DALI102_FADE_CalcActualLevel
+                                 0000e73a 0100(0000d086:.textf)
+                 _R_DALI102_FADE_InvalidFadeIsRunning
+                                 0000e7f1 0081(0000c7aa:.textf)
+     SECTION=.const
+0106 r_dali102_list
+     SECTION=.textf
+                 _R_DALI102_LIST_Init
+                                 0000e842 0081(0000c54e:.textf)
+                 _R_DALI102_LIST_Entry
+                                 0000e850 0081(0000c6f2:.textf)
+                                          0081(0000c885:.textf)
+                                          0100(0000d312:.textf)
+                                          0101(0000d5f2:.textf)
+                                          0101(0000dfda:.textf)
+                                          0101(0000e1a8:.textf)
+                                          0106(0000e86f:.textf)
+                 _R_DALI102_LIST_Next
+                                 0000e85e 0081(0000c6fc:.textf)
+                                          0081(0000c78f:.textf)
+                                          0100(0000d2fd:.textf)
+                                          0100(0000d39c:.textf)
+                                          0101(0000d5a7:.textf)
+                                          0101(0000e1c4:.textf)
+                                          0101(0000e4b7:.textf)
+                                          0106(0000e87f:.textf)
+                 _R_DALI102_LIST_Add
+                                 0000e865 0080(0000c3ee:.textf)
+                                          0082(0000c90c:.textf)
+                 _R_DALI102_LIST_GetSize
+                                 0000e8a6 0101(0000dfea:.textf)
+                                          0101(0000e190:.textf)
+0107 r_dali102_mb_if
+     SECTION=.textf
+                 _R_DALI102_MB_IF_Init
+                                 0000e8be 0081(0000c4c1:.textf)
+                 _R_DALI102_MB_IF_Reset
+                                 0000e8c2 0101(0000dc6e:.textf)
+                 _R_DALI102_MB_IF_Read
+                                 0000e8d4 0101(0000d57e:.textf)
+                                          0101(0000dc36:.textf)
+                                          0101(0000dfac:.textf)
+                                          0101(0000e288:.textf)
+                 _R_DALI102_MB_IF_Write
+                                 0000e8f4 0101(0000e50d:.textf)
+                 _R_DALI102_MB_IF_UnlatchRead
+                                 0000e907 0101(0000d63c:.textf)
+                 _R_DALI102_MB_IF_CancelWrite
+                                 0000e920 0101(0000d649:.textf)
+     SECTION=.data
+     SECTION=.dataR
+0108 r_dali102_timer
+     SECTION=.textf
+                 _R_DALI102_TIMER8_Init
+                                 0000e92b 0081(0000c582:.textf)
+                 _R_DALI102_TIMER8_Tick
+                                 0000e930 0081(0000c6c5:.textf)
+                 _R_DALI102_TIMER8_Start
+                                 0000e93b 0101(0000d699:.textf)
+                                          0101(0000dae5:.textf)
+                 _R_DALI102_TIMER8_Stop
+                                 0000e943 0081(0000c5f6:.textf)
+                 _R_DALI102_TIMER8_IsRunning
+                                 0000e948 0101(0000d68e:.textf)
+                 _R_DALI102_TIMER16_Init
+                                 0000e950 0081(0000c570:.textf)
+                                          0081(0000c579:.textf)
+                 _R_DALI102_TIMER16_Tick
+                                 0000e954 0081(0000c68f:.textf)
+                                          0081(0000c6bc:.textf)
+                 _R_DALI102_TIMER16_Start
+                                 0000e965 0081(0000c66d:.textf)
+                                          0101(0000da0d:.textf)
+                 _R_DALI102_TIMER16_Stop
+                                 0000e96e 0081(0000c5ed:.textf)
+                                          0081(0000c6b3:.textf)
+                                          0081(0000c74a:.textf)
+                                          0101(0000d65d:.textf)
+                                          0101(0000d938:.textf)
+                 _R_DALI102_TIMER16_IsRunning
+                                 0000e972 0081(0000c7cb:.textf)
+                                          0101(0000d4f9:.textf)
+                 _R_DALI102_TIMER32_Init
+                                 0000e978 0080(0000c3df:.textf)
+                                          0081(0000c567:.textf)
+                 _R_DALI102_TIMER32_Tick
+                                 0000e97e 0081(0000c6a1:.textf)
+                                          0097(0000cad4:.textf)
+                 _R_DALI102_TIMER32_Start
+                                 0000e9a0 0098(0000cc16:.textf)
+                                          0101(0000e35e:.textf)
+                 _R_DALI102_TIMER32_Stop
+                                 0000e9ae 0080(0000c473:.textf)
+                                          0081(0000c5e4:.textf)
+                                          0098(0000cbb8:.textf)
+                                          0101(0000e31c:.textf)
+                 _R_DALI102_TIMER32_IsRunning
+                                 0000e9b0 0080(0000c421:.textf)
+                                          0097(0000cb46:.textf)
+                                          0098(0000cb5d:.textf)
+                                          0098(0000ce85:.textf)
+0109 r_dali102_var
+     SECTION=.textf
+                 _R_DALI102_VAR_Init
+                                 0000e9bd 0081(0000c536:.textf)
+                 _R_DALI102_VAR_Reset
+                                 0000ea31 0101(0000dba0:.textf)
+                 _R_DALI102_VAR_IsReset
+                                 0000eabd 0100(0000d2d7:.textf)
+                 _R_DALI102_VAR_NvmIsValid
+                                 0000eb20 0081(0000c595:.textf)
+                 _R_DALI102_VAR_SetNvm
+                                 0000eb93 0081(0000c5b6:.textf)
+                 _R_DALI102_VAR_GetNvm
+                                 0000ec12 0081(0000c5bd:.textf)
+                 _R_DALI102_VAR_NvmIsChanged
+                                 0000ec7a 0081(0000c5c4:.textf)
+                 _R_DALI102_VAR_SetActualLevel
+                                 0000ec81 0081(0000c60a:.textf)
+                                          0081(0000c769:.textf)
+                                          0098(0000cce6:.textf)
+                                          0100(0000d15f:.textf)
+                                          0100(0000d1df:.textf)
+                                          0100(0000d377:.textf)
+                                          0101(0000d6dc:.textf)
+                                          0101(0000d71a:.textf)
+                                          0101(0000d7fc:.textf)
+                                          0101(0000d8fb:.textf)
+                                          0101(0000d977:.textf)
+                                          0101(0000d9ca:.textf)
+                                          0101(0000da6f:.textf)
+                                          0101(0000db2e:.textf)
+                                          0101(0000dd0c:.textf)
+                                          0109(0000ea36:.textf)
+                                          0110(00010a96:.textf)
+                 _R_DALI102_VAR_GetActualLevel
+                                 0000ec86 0081(0000c7a3:.textf)
+                                          0098(0000ccda:.textf)
+                                          0100(0000d11b:.textf)
+                                          0101(0000dbc4:.textf)
+                                          0101(0000dcbd:.textf)
+                                          0101(0000dd46:.textf)
+                                          0110(00010b8f:.textf)
+                                          0111(00012b1f:.textf)
+                 _R_DALI102_VAR_SetActualLevelHighRes
+                                 0000ec8c 0100(0000d16a:.textf)
+                                          0110(00010aa3:.textf)
+                 _R_DALI102_VAR_GetActualLevelHighRes
+                                 0000ec90 0081(0000c7c4:.textf)
+                                          0100(0000d1bb:.textf)
+                                          0101(0000d7cb:.textf)
+                                          0101(0000d7f2:.textf)
+                 _R_DALI102_VAR_SetTargetLevel
+                                 0000ec93 0081(0000c603:.textf)
+                                          0098(0000ccf9:.textf)
+                                          0100(0000d196:.textf)
+                                          0100(0000d239:.textf)
+                                          0110(00010b9a:.textf)
+                 _R_DALI102_VAR_GetTargetLevel
+                                 0000ec98 0081(0000c79f:.textf)
+                                          0081(0000c7bc:.textf)
+                                          0098(0000cced:.textf)
+                                          0100(0000d148:.textf)
+                                          0100(0000d29c:.textf)
+                                          0101(0000d75a:.textf)
+                                          0101(0000d877:.textf)
+                                          0101(0000d913:.textf)
+                                          0101(0000d993:.textf)
+                                          0110(00010a74:.textf)
+                 _R_DALI102_VAR_SetLastActiveLevel
+                                 0000ec9c 0081(0000c623:.textf)
+                                          0098(0000cd0c:.textf)
+                                          0100(0000d1ab:.textf)
+                 _R_DALI102_VAR_GetLastActiveLevel
+                                 0000eca1 0098(0000cd00:.textf)
+                                          0101(0000daf9:.textf)
+                 _R_DALI102_VAR_SetLastLightLevel
+                                 0000eca5 0098(0000cd22:.textf)
+                                          0100(0000d19e:.textf)
+                                          0109(0000ea46:.textf)
+                 _R_DALI102_VAR_GetLastLightLevel
+                                 0000ecb8 0098(0000cd13:.textf)
+                                          0100(0000d35a:.textf)
+                 _R_DALI102_VAR_SetPowerOnLevel
+                                 0000ecbc 0101(0000dd9e:.textf)
+                                          0109(0000ea4d:.textf)
+                 _R_DALI102_VAR_GetPowerOnLevel
+                                 0000eccf 0100(0000d352:.textf)
+                                          0101(0000e119:.textf)
+                 _R_DALI102_VAR_SetSystemFailureLevel
+                                 0000ecd3 0101(0000dd6e:.textf)
+                                          0109(0000ea54:.textf)
+                 _R_DALI102_VAR_GetSystemFailureLevel
+                                 0000ece6 0081(0000c73c:.textf)
+                                          0101(0000e129:.textf)
+                 _R_DALI102_VAR_SetMinLevel
+                                 0000ecea 0098(0000ccc0:.textf)
+                                          0101(0000dd40:.textf)
+                                          0109(0000ea60:.textf)
+                 _R_DALI102_VAR_GetMinLevel
+                                 0000ecfd 0098(0000ccb4:.textf)
+                                          0100(0000d096:.textf)
+                                          0100(0000d1c3:.textf)
+                                          0100(0000d27a:.textf)
+                                          0101(0000d854:.textf)
+                                          0101(0000d91b:.textf)
+                                          0101(0000d94a:.textf)
+                                          0101(0000da1d:.textf)
+                                          0101(0000da26:.textf)
+                                          0101(0000da82:.textf)
+                                          0101(0000dca0:.textf)
+                                          0101(0000e109:.textf)
+                 _R_DALI102_VAR_SetMaxLevel
+                                 0000ed01 0098(0000ccd3:.textf)
+                                          0101(0000dcb7:.textf)
+                                          0109(0000ea67:.textf)
+                 _R_DALI102_VAR_GetMaxLevel
+                                 0000ed19 0081(0000c61c:.textf)
+                                          0098(0000ccc7:.textf)
+                                          0100(0000d09e:.textf)
+                                          0100(0000d282:.textf)
+                                          0101(0000d737:.textf)
+                                          0101(0000d8c8:.textf)
+                                          0101(0000d99b:.textf)
+                                          0101(0000d9ab:.textf)
+                                          0101(0000d9b4:.textf)
+                                          0101(0000da3e:.textf)
+                                          0101(0000da9d:.textf)
+                                          0101(0000dd1e:.textf)
+                                          0101(0000e0f9:.textf)
+                 _R_DALI102_VAR_SetFadeRate
+                                 0000ed1d 0101(0000ddd6:.textf)
+                                          0109(0000ea6e:.textf)
+                 _R_DALI102_VAR_GetFadeRate
+                                 0000ed30 0101(0000d80c:.textf)
+                                          0101(0000e14d:.textf)
+                 _R_DALI102_VAR_SetFadeTime
+                                 0000ed34 0101(0000ddb3:.textf)
+                                          0109(0000ea77:.textf)
+                 _R_DALI102_VAR_GetFadeTime
+                                 0000ed47 0097(0000cadf:.textf)
+                                          0100(0000d05d:.textf)
+                                          0101(0000e145:.textf)
+                 _R_DALI102_VAR_SetExtendedFadeTime
+                                 0000ed4b 0101(0000ddec:.textf)
+                                          0109(0000ea7d:.textf)
+                 _R_DALI102_VAR_GetExtendedFadeTime
+                                 0000ed81 0097(0000caeb:.textf)
+                                          0100(0000d065:.textf)
+                                          0101(0000e1fb:.textf)
+                 _R_DALI102_VAR_SetExtendedFadeTimeBase
+                                 0000ed87
+                 _R_DALI102_VAR_GetExtendedFadeTimeBase
+                                 0000ed9b
+                 _R_DALI102_VAR_SetExtendedFadeTimeMultiplier
+                                 0000eda1
+                 _R_DALI102_VAR_GetExtendedFadeTimeMultiplier
+                                 0000edba
+                 _R_DALI102_VAR_SetShortAddress
+                                 0000edc2 0101(0000de7d:.textf)
+                                          0101(0000e42c:.textf)
+                 _R_DALI102_VAR_GetShortAddress
+                                 0000edd5 0100(0000d31c:.textf)
+                                          0101(0000d46f:.textf)
+                                          0101(0000d52f:.textf)
+                                          0101(0000df08:.textf)
+                                          0101(0000df98:.textf)
+                                          0101(0000e46d:.textf)
+                 _R_DALI102_VAR_SetSearchAddress
+                                 0000edd9 0081(0000c62e:.textf)
+                                          0101(0000e3c5:.textf)
+                 _R_DALI102_VAR_GetSearchAddress
+                                 0000ede1 0101(0000d5d9:.textf)
+                                          0101(0000e3bb:.textf)
+                                          0101(0000e3fe:.textf)
+                 _R_DALI102_VAR_SetRandomAddress
+                                 0000ede8 0101(0000e379:.textf)
+                                          0109(0000ea91:.textf)
+                 _R_DALI102_VAR_GetRandomAddress
+                                 0000ee0a 0101(0000d5ce:.textf)
+                                          0101(0000e266:.textf)
+                 _R_DALI102_VAR_SetOperatingMode
+                                 0000ee11 0101(0000dbff:.textf)
+                 _R_DALI102_VAR_GetOperatingMode
+                                 0000ee24 0081(0000c67f:.textf)
+                                          0101(0000dbee:.textf)
+                                          0101(0000e050:.textf)
+                 _R_DALI102_VAR_GetDefaultOperatingMode
+                                 0000ee28
+                 _R_DALI102_VAR_SetInitialisationState
+                                 0000ee2e 0081(0000c672:.textf)
+                                          0101(0000e313:.textf)
+                                          0101(0000e34f:.textf)
+                                          0101(0000e3a5:.textf)
+                 _R_DALI102_VAR_GetInitialisationState
+                                 0000ee33 0101(0000d5c5:.textf)
+                                          0101(0000d9df:.textf)
+                                          0101(0000e345:.textf)
+                 _R_DALI102_VAR_EnableWriteEnableState
+                                 0000ee37 0101(0000de98:.textf)
+                 _R_DALI102_VAR_DisableWriteEnableState
+                                 0000ee3c 0081(0000c5db:.textf)
+                                          0101(0000d614:.textf)
+                 _R_DALI102_VAR_WriteEnableStateIsEnabled
+                                 0000ee41 0101(0000d56b:.textf)
+                 _R_DALI102_VAR_SetControlGearFailure
+                                 0000ee45 0081(0000c729:.textf)
+                 _R_DALI102_VAR_ClearControlGearFailure
+                                 0000ee4b 0081(0000c637:.textf)
+                                          0081(0000c730:.textf)
+                 _R_DALI102_VAR_ControlGearIsFailure
+                                 0000ee51 0101(0000deb0:.textf)
+                                          0101(0000e20b:.textf)
+                 _R_DALI102_VAR_SetLampFailure
+                                 0000ee57 0081(0000c71b:.textf)
+                 _R_DALI102_VAR_ClearLampFailure
+                                 0000ee5d 0081(0000c722:.textf)
+                 _R_DALI102_VAR_LampIsFailure
+                                 0000ee63 0100(0000d0eb:.textf)
+                                          0101(0000debd:.textf)
+                                          0101(0000df4b:.textf)
+                 _R_DALI102_VAR_SetLampOn
+                                 0000ee6b 0081(0000c70d:.textf)
+                 _R_DALI102_VAR_ClearLampOn
+                                 0000ee76 0081(0000c610:.textf)
+                                          0081(0000c714:.textf)
+                 _R_DALI102_VAR_LampIsOn
+                                 0000ee7c 0100(0000d0e2:.textf)
+                                          0101(0000decc:.textf)
+                                          0101(0000df5a:.textf)
+                                          0101(0000e0e2:.textf)
+                                          0111(00012b37:.textf)
+                 _R_DALI102_VAR_SetLimitError
+                                 0000ee84 0100(0000d254:.textf)
+                 _R_DALI102_VAR_ClearLimitError
+                                 0000ee8a 0081(0000c616:.textf)
+                                          0100(0000d267:.textf)
+                                          0109(0000ea9a:.textf)
+                 _R_DALI102_VAR_LimitIsError
+                                 0000ee90 0101(0000dedb:.textf)
+                                          0101(0000df69:.textf)
+                 _R_DALI102_VAR_SetPowerCycleSeen
+                                 0000ee98 0081(0000c5fc:.textf)
+                 _R_DALI102_VAR_ClearPowerCycleSeen
+                                 0000ee9e 0101(0000d623:.textf)
+                                          0109(0000ea9f:.textf)
+                 _R_DALI102_VAR_PowerCycleIsSeen
+                                 0000eea4 0101(0000df17:.textf)
+                                          0101(0000e01a:.textf)
+                 _R_DALI102_VAR_SetGearGroups
+                                 0000eeac 0109(0000eaa5:.textf)
+                 _R_DALI102_VAR_GetGearGroups
+                                 0000eec0 0101(0000e235:.textf)
+                 _R_DALI102_VAR_AddGearGroups
+                                 0000eec4 0101(0000de3d:.textf)
+                 _R_DALI102_VAR_RemoveGearGroups
+                                 0000eef0 0101(0000de65:.textf)
+                 _R_DALI102_VAR_GearGroupIsContained
+                                 0000ef12 0101(0000d463:.textf)
+                 _R_DALI102_VAR_SetScene
+                                 0000ef23 0101(0000de0b:.textf)
+                                          0109(0000eaaf:.textf)
+                 _R_DALI102_VAR_GetScene
+                                 0000ef3a 0101(0000d4ee:.textf)
+                                          0101(0000db65:.textf)
+                                          0101(0000e21c:.textf)
+                 _R_DALI102_VAR_SetDtr0
+                                 0000ef40 0081(0000c644:.textf)
+                                          0101(0000dbb8:.textf)
+                                          0101(0000e098:.textf)
+                                          0101(0000e0a0:.textf)
+                                          0101(0000e0a9:.textf)
+                                          0101(0000e2db:.textf)
+                                          0101(0000e32d:.textf)
+                                          0111(00013a42:.textf)
+                 _R_DALI102_VAR_GetDtr0
+                                 0000ef45 0098(0000cd47:.textf)
+                                          0101(0000d50e:.textf)
+                                          0101(0000d55b:.textf)
+                                          0101(0000dbe6:.textf)
+                                          0101(0000dc25:.textf)
+                                          0101(0000dce2:.textf)
+                                          0101(0000dd89:.textf)
+                                          0101(0000de15:.textf)
+                                          0101(0000dfc5:.textf)
+                                          0101(0000e2b3:.textf)
+                                          0111(000132bb:.textf)
+                 _R_DALI102_VAR_SetDtr1
+                                 0000ef49 0081(0000c64b:.textf)
+                                          0101(0000e081:.textf)
+                                          0101(0000e4d7:.textf)
+                                          0111(00013a4c:.textf)
+                 _R_DALI102_VAR_GetDtr1
+                                 0000ef4e 0101(0000d563:.textf)
+                                          0101(0000e02a:.textf)
+                                          0101(0000e2bb:.textf)
+                                          0111(00012c24:.textf)
+                 _R_DALI102_VAR_SetDtr2
+                                 0000ef52 0081(0000c652:.textf)
+                                          0101(0000e089:.textf)
+                                          0101(0000e4ee:.textf)
+                 _R_DALI102_VAR_GetDtr2
+                                 0000ef57 0101(0000e039:.textf)
+                                          0111(00011c94:.textf)
+                 _R_DALI102_VAR_GetPhm
+                                 0000ef5b 0097(0000cb3f:.textf)
+                                          0100(0000d3ad:.textf)
+0110 r_dali209
+     SECTION=.textf
+                 _R_DALI209_RegisterCallback
+                                 0000ef62 0082(0000c895:.textf)
+                 _R_DALI209_TranslateToLightOutput
+                                 0000ef66
+                 _R_DALI209_ColourIsAttainable
+                                 0000ef74
+                 _R_DALI209_TranslateColourValueTCtoRGB
+                                 0000ef85
+                 _R_DALI209_TranslateColourValueRGBtoTC
+                                 0000ef96
+                 _R_DALI209_TranslateColourValueTCtoXY
+                                 0000efa7
+                 _R_DALI209_TranslateColourValueXYtoTC
+                                 0000efb8
+                 _R_DALI209_TranslateColourValueXYtoRGB
+                                 0000efc9
+                 _R_DALI209_TranslateColourValueRGBtoXY
+                                 0000efda
+                 _R_DALI209_CanTranslateToLightOutput
+                                 0000efeb 0082(0000c8e1:.textf)
+                 _R_DALI209_CanJudgeColourIsAttainable
+                                 0000efff 0082(0000c8ee:.textf)
+                 _R_DALI209_CanTranslateColourValueTCtoRGB
+                                 0000f013
+                 _R_DALI209_CanTranslateColourValueRGBtoTC
+                                 0000f027
+                 _R_DALI209_CanTranslateColourValueTCtoXY
+                                 0000f03b
+                 _R_DALI209_CanTranslateColourValueXYtoTC
+                                 0000f04f
+                 _R_DALI209_CanTranslateColourValueXYtoRGB
+                                 0000f063
+                 _R_DALI209_CanTranslateColourValueRGBtoXY
+                                 0000f077
+                 _R_DALI209_CalcTriangleCenterPointForXy
+                                 0000f08b 0082(0000c957:.textf)
+                 _R_DALI209_SetPrimaryCoordinateForCrossJudge
+                                 0000f115 0082(0000c95d:.textf)
+                 _R_DALI209_CalcInRangeColour
+                                 0000f378 0110(000103e4:.textf)
+                                          0111(00012e75:.textf)
+                 _R_DALI209_CalcLightOutputRgbwaf
+                                 0000f60d 0082(0000ca3d:.textf)
+                                          0110(00010eca:.textf)
+                 _R_DALI209_CheckSupportedColourType
+                                 0000fe4f 0082(0000c9bc:.textf)
+                 _R_DALI209_GetSupportedColourType
+                                 0001018f 0082(0000c969:.textf)
+                                          0111(00012bd0:.textf)
+                                          0111(00012f0c:.textf)
+                                          0111(00013088:.textf)
+                                          0111(000131d1:.textf)
+                                          0111(00013346:.textf)
+                                          0111(0001365a:.textf)
+                 _R_DALI209_SetActiveColourType
+                                 000101b1 0111(00011de0:.textf)
+                                          0111(00011fbe:.textf)
+                                          0111(00012060:.textf)
+                                          0111(00012185:.textf)
+                                          0111(000122bb:.textf)
+                                          0111(00012c7e:.textf)
+                                          0111(00012d78:.textf)
+                 _R_DALI209_GetActiveColourType
+                                 0001021a 0111(00011c8b:.textf)
+                                          0111(00012557:.textf)
+                                          0111(00012b03:.textf)
+                                          0111(00012e44:.textf)
+                                          0111(000130a5:.textf)
+                                          0111(0001354c:.textf)
+                                          0111(00013662:.textf)
+                 _R_DALI209_ActivateOnTcSpace
+                                 0001026e 0110(00010961:.textf)
+                                          0111(00011db2:.textf)
+                                          0111(00012071:.textf)
+                                          0111(0001224a:.textf)
+                                          0111(00012406:.textf)
+                                          0111(00012417:.textf)
+                                          0111(00012cec:.textf)
+                                          0111(000134ac:.textf)
+                 _R_DALI209_ActivateOnXySpace
+                                 0001035b 0110(0001086f:.textf)
+                                          0110(000109a0:.textf)
+                                          0111(00011ecc:.textf)
+                                          0111(00012067:.textf)
+                                          0111(00012283:.textf)
+                                          0111(00012ccb:.textf)
+                 _R_DALI209_ActivateOnRgbwafSpace
+                                 0001051e 0110(00010934:.textf)
+                                          0110(000109ed:.textf)
+                                          0111(00011f27:.textf)
+                                          0111(00012107:.textf)
+                                          0111(000122af:.textf)
+                                          0111(00012dbe:.textf)
+                                          0111(000135a0:.textf)
+                 _R_DALI209_GetDeviceType
+                                 000106dc 0082(00003a58:.const)
+                                          0082(00003a5a:.const)
+                 _R_DALI209_GetExtendedVersionNumber
+                                 000106df 0082(00003a5c:.const)
+                                          0082(00003a5e:.const)
+                 _R_DALI209_IsReset
+                                 000106e2 0082(00003a60:.const)
+                                          0082(00003a62:.const)
+                 _R_DALI209_ExecutePowerOnProcess
+                                 000106e9 0082(00003a64:.const)
+                                          0082(00003a66:.const)
+                 _R_DALI209_ExecuteSystemFailureProcess
+                                 00010939 0082(00003a68:.const)
+                                          0082(00003a6a:.const)
+                 _R_DALI209_TickTimer
+                                 000109f4 0082(00003a84:.const)
+                                          0082(00003a86:.const)
+                 _R_DALI209_FadeTryStart
+                                 000109f5 0082(00003a88:.const)
+                                          0082(00003a8a:.const)
+                 _R_DALI209_FadeIsRunning
+                                 00010a25 0082(00003a8c:.const)
+                                          0082(00003a8e:.const)
+                 _R_DALI209_Fading
+                                 00010a47 0082(00003a90:.const)
+                                          0082(00003a92:.const)
+                 _R_DALI209_FadeStopProcess
+                                 00010b6a 0082(00003a94:.const)
+                                          0082(00003a96:.const)
+                 _R_DALI209_UpdateActualColourValue
+                                 00010cbc 0110(00010356:.textf)
+                                          0110(00010519:.textf)
+                                          0110(000106d7:.textf)
+                                          0110(0001078a:.textf)
+                                          0110(00010b25:.textf)
+                                          0111(00012f28:.textf)
+                                          0111(000130fe:.textf)
+                 _R_DALI209_ColourTypeChangeToTc
+                                 00010f3e 0111(00012679:.textf)
+                                          0111(00012811:.textf)
+                                          0111(000130c1:.textf)
+                                          0111(00013813:.textf)
+                 _R_DALI209_ColourTypeChangeToXy
+                                 00010ffe 0111(00011f01:.textf)
+                                          0111(00012e62:.textf)
+                                          0111(00013a34:.textf)
+                 _R_DALI209_ColourTypeChangeToRgbwaf
+                                 000110bf 0111(00011e8f:.textf)
+                                          0111(00012709:.textf)
+                                          0111(000128ac:.textf)
+                 _R_DALI209_ColourValueChangeFromTc
+                                 000111c3 0111(00011ea9:.textf)
+                                          0111(00012049:.textf)
+                                          0111(00012ca1:.textf)
+     SECTION=.data
+     SECTION=.dataR
+0111 r_dali209_cmd
+     SECTION=.textf
+                 _R_DALI209_StandardCommandIsIgnored
+                                 00011c1a 0082(00003a6c:.const)
+                                          0082(00003a6e:.const)
+                 _R_DALI209_ApplicationExtendedCommandIsIgnored
+                                 00011c1c 0082(00003a70:.const)
+                                          0082(00003a72:.const)
+                 _R_DALI209_ExistsReplacementProcess
+                                 00011c9c 0082(00003a74:.const)
+                                          0082(00003a76:.const)
+                 _R_DALI209_ExecuteReplacementProcess
+                                 00011cb6 0082(00003a78:.const)
+                                          0082(00003a7a:.const)
+                 _R_DALI209_ExecuteAdditionalProcess
+                                 00011ce9 0082(00003a7c:.const)
+                                          0082(00003a7e:.const)
+                 _R_DALI209_ExecuteApplicationExtendedCommand
+                                 00011d0a 0082(00003a80:.const)
+                                          0082(00003a82:.const)
+     SECTION=.const
+0112 r_dali209_fade
+     SECTION=.textf
+                 _R_DALI209_FADE_Init
+                                 00013b13 0082(0000c944:.textf)
+                 _R_DALI209_FADE_Tick1ms
+                                 00013b4e 0110(00010ac0:.textf)
+                 _R_DALI209_FADE_IsRunning
+                                 00013b84 0110(00010a3d:.textf)
+                                          0110(00010ab4:.textf)
+                                          0110(00010baf:.textf)
+                 _R_DALI209_FADE_IsRequested
+                                 00013b87 0110(0001033d:.textf)
+                                          0110(00010500:.textf)
+                                          0110(000106bf:.textf)
+                                          0110(00010a16:.textf)
+                                          0110(00010bb8:.textf)
+                 _R_DALI209_FADE_Start
+                                 00013b9b 0110(00010346:.textf)
+                                          0110(00010509:.textf)
+                                          0110(000106c8:.textf)
+                                          0110(00010a20:.textf)
+                 _R_DALI209_FADE_Stop
+                                 00013bd1 0110(00010af0:.textf)
+                                          0110(00010cb6:.textf)
+                 _R_DALI209_FADE_Set
+                                 00013bd9 0110(0001031c:.textf)
+                                          0110(000104df:.textf)
+                                          0110(000106a0:.textf)
+                 _R_DALI209_FADE_GetType
+                                 00013c95 0110(00010ae0:.textf)
+                 _R_DALI209_FADE_GetRgbwafControl
+                                 00013c99 0110(00010b2d:.textf)
+                                          0110(00010b4f:.textf)
+                 _R_DALI209_FADE_CalcActualColourValue
+                                 00013c9d 0110(00010ace:.textf)
+                 _R_DALI209_FADE_GetTargetColourValue
+                                 00013f17 0082(0000c9ff:.textf)
+                                          0110(00010ada:.textf)
+                 _R_DALI209_FADE_InvalidFadeIsRunning
+                                 00013fb0 0082(0000c9f1:.textf)
+0113 r_dali209_var
+     SECTION=.textf
+                 _R_DALI209_VAR_Init
+                                 00014001 0082(0000c935:.textf)
+                                          0110(00010094:.textf)
+                 _R_DALI209_VAR_Reset
+                                 000141b5 0111(0001254d:.textf)
+                 _R_DALI209_VAR_IsReset
+                                 000142d3 0110(000106e6:.textf)
+                 _R_DALI209_VAR_NvmIsValid
+                                 00014374 0082(0000c9ad:.textf)
+                 _R_DALI209_VAR_SetNvm
+                                 00014429 0082(0000c9b5:.textf)
+                 _R_DALI209_VAR_GetNvm
+                                 000144c8 0082(0000c9c3:.textf)
+                 _R_DALI209_VAR_NvmIsChanged
+                                 00014549 0082(0000c9ca:.textf)
+                 _R_DALI209_VAR_SetTemporaryXyCoordinate
+                                 00014550 0111(0001253e:.textf)
+                                          0111(00012bfa:.textf)
+                                          0111(000132fb:.textf)
+                                          0111(0001330a:.textf)
+                                          0113(000142b9:.textf)
+                 _R_DALI209_VAR_GetTemporaryXyCoordinate
+                                 00014556 0111(00012085:.textf)
+                                          0111(0001230e:.textf)
+                                          0111(0001269d:.textf)
+                                          0111(000138f1:.textf)
+                 _R_DALI209_VAR_SetReportXyCoordinate
+                                 0001455c 0111(000129c7:.textf)
+                                          0111(00013a89:.textf)
+                                          0111(00013a93:.textf)
+                                          0113(000141c5:.textf)
+                                          0113(000141d2:.textf)
+                 _R_DALI209_VAR_GetReportXyCoordinate
+                                 00014573 0111(000132f3:.textf)
+                                          0111(00013302:.textf)
+                                          0111(00013961:.textf)
+                 _R_DALI209_VAR_SetXyCoordinate
+                                 0001457c 0110(0001006b:.textf)
+                                          0110(00010075:.textf)
+                                          0110(000100f5:.textf)
+                                          0110(00010d79:.textf)
+                                          0111(00011f12:.textf)
+                                          0111(00011f1a:.textf)
+                                          0111(00012d36:.textf)
+                                          0111(00012d40:.textf)
+                 _R_DALI209_VAR_GetXyCoordinate
+                                 00014585 0082(0000ca1f:.textf)
+                                          0082(0000ca28:.textf)
+                                          0110(0000f5de:.textf)
+                                          0110(0000f5e7:.textf)
+                                          0110(0001038a:.textf)
+                                          0110(00010393:.textf)
+                                          0110(00010c46:.textf)
+                                          0110(00010f66:.textf)
+                                          0110(00010f6f:.textf)
+                                          0110(00011139:.textf)
+                                          0110(00011142:.textf)
+                                          0111(0001258a:.textf)
+                                          0111(00012b71:.textf)
+                                          0111(00012e19:.textf)
+                                          0111(00012e53:.textf)
+                                          0111(00012f62:.textf)
+                                          0111(000137d0:.textf)
+                 _R_DALI209_VAR_SetTemporaryColourTemperatureTc
+                                 00014595 0111(000124a2:.textf)
+                                          0111(00012fea:.textf)
+                                          0111(000132e7:.textf)
+                                          0111(00013ade:.textf)
+                 _R_DALI209_VAR_GetTemporaryColourTemperatureTc
+                                 0001459a 0111(0001202d:.textf)
+                                          0111(00012307:.textf)
+                                          0111(00012663:.textf)
+                                          0111(00013907:.textf)
+                 _R_DALI209_VAR_SetReportColourTemperatureTc
+                                 0001459e 0111(0001257b:.textf)
+                                          0111(00012a61:.textf)
+                                          0111(00012b61:.textf)
+                                          0111(00013a7f:.textf)
+                 _R_DALI209_VAR_GetReportColourTemperatureTc
+                                 000145a3 0111(000132e0:.textf)
+                                          0111(0001399b:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTc
+                                 000145a7 0110(0000fe94:.textf)
+                                          0110(00010de6:.textf)
+                                          0111(00011ec0:.textf)
+                                          0111(00012cb3:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTc
+                                 000145ac 0082(0000c9e5:.textf)
+                                          0110(00010279:.textf)
+                                          0110(0001071b:.textf)
+                                          0110(00010884:.textf)
+                                          0110(00010b09:.textf)
+                                          0110(00010c19:.textf)
+                                          0110(00011023:.textf)
+                                          0110(000110e5:.textf)
+                                          0111(00012574:.textf)
+                                          0111(00012b5a:.textf)
+                                          0111(000130b3:.textf)
+                                          0111(000134de:.textf)
+                                          0111(00013804:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTcCoolest
+                                 000145b0 0111(000134d8:.textf)
+                                          0113(000141e1:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTcCoolest
+                                 000145c4 0110(0001028d:.textf)
+                                          0110(00010729:.textf)
+                                          0110(00010892:.textf)
+                                          0111(0001304b:.textf)
+                                          0111(000133c6:.textf)
+                                          0111(000138aa:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTcWarmest
+                                 000145c8 0111(000134b9:.textf)
+                                          0113(000141ea:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTcWarmest
+                                 000145dc 0110(00010295:.textf)
+                                          0110(00010731:.textf)
+                                          0110(0001089a:.textf)
+                                          0111(00013118:.textf)
+                                          0111(000133ce:.textf)
+                                          0111(000138c6:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTcPhysicalCoolest
+                                 000145e0 0111(0001349a:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTcPhysicalCoolest
+                                 000145f4 0111(000133b6:.textf)
+                                          0111(000138b8:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTcPhysicalWarmest
+                                 000145f8 0111(00013411:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTcPhysicalWarmest
+                                 00014611 0111(000133be:.textf)
+                                          0111(000138d4:.textf)
+                 _R_DALI209_VAR_SetColourTemperatureTcStepIncrement
+                                 00014615 0111(0001337a:.textf)
+                                          0113(000141f0:.textf)
+                 _R_DALI209_VAR_GetColourTemperatureTcStepIncrement
+                                 00014628 0111(0001309d:.textf)
+                                          0111(000138e2:.textf)
+                 _R_DALI209_VAR_SetTemporaryRgbwafDimlevel
+                                 0001462c 0111(0001317f:.textf)
+                                          0111(00013188:.textf)
+                                          0111(0001321c:.textf)
+                                          0111(00013223:.textf)
+                                          0111(0001323e:.textf)
+                                          0111(00013247:.textf)
+                                          0111(0001334a:.textf)
+                                          0113(000142c2:.textf)
+                 _R_DALI209_VAR_GetTemporaryRgbwafDimlevel
+                                 0001463a 0111(00011e5d:.textf)
+                                          0111(000122cc:.textf)
+                                          0111(000126de:.textf)
+                                          0111(00013918:.textf)
+                                          0111(00013936:.textf)
+                 _R_DALI209_VAR_SetReportRgbwafDimlevel
+                                 0001463f 0111(000129dc:.textf)
+                                          0111(00013ac4:.textf)
+                                          0113(000142c8:.textf)
+                 _R_DALI209_VAR_GetReportRgbwafDimlevel
+                                 0001464d 0111(00013322:.textf)
+                                          0111(000139ac:.textf)
+                                          0111(000139ce:.textf)
+                 _R_DALI209_VAR_SetRgbwafDimlevel
+                                 00014652 0110(0000ff2a:.textf)
+                                          0110(0000ffd5:.textf)
+                                          0110(00010153:.textf)
+                                          0110(00010e3f:.textf)
+                                          0110(00010e7c:.textf)
+                                          0111(000121fb:.textf)
+                 _R_DALI209_VAR_GetRgbwafDimlevel
+                                 00014660 0110(0000f64f:.textf)
+                                          0110(0000f964:.textf)
+                                          0110(00010543:.textf)
+                                          0110(00010c8b:.textf)
+                                          0110(00010fb3:.textf)
+                                          0110(0001106a:.textf)
+                                          0111(000125a4:.textf)
+                                          0111(00012b98:.textf)
+                                          0111(00013564:.textf)
+                                          0111(00013829:.textf)
+                                          0111(00013856:.textf)
+                 _R_DALI209_VAR_SetTemporaryRgbwafControl
+                                 00014665 0111(0001252c:.textf)
+                                          0111(00013294:.textf)
+                                          0111(00013b0d:.textf)
+                 _R_DALI209_VAR_GetTemporaryRgbwafControl
+                                 0001466a 0111(000120ce:.textf)
+                                          0111(00012339:.textf)
+                                          0111(00012712:.textf)
+                                          0111(00013948:.textf)
+                 _R_DALI209_VAR_SetReportRgbwafControl
+                                 0001466e 0111(000129f7:.textf)
+                                          0111(00012b8e:.textf)
+                                          0111(00013ac0:.textf)
+                 _R_DALI209_VAR_GetReportRgbwafControl
+                                 00014673 0111(00013315:.textf)
+                                          0111(000139e0:.textf)
+                 _R_DALI209_VAR_SetRgbwafControl
+                                 00014677 0110(0000ff48:.textf)
+                                          0110(0001012d:.textf)
+                                          0110(00010ea8:.textf)
+                 _R_DALI209_VAR_GetRgbwafControl
+                                 0001467c 0110(0000f62f:.textf)
+                                          0110(00010c7a:.textf)
+                                          0111(0001259a:.textf)
+                                          0111(00012b87:.textf)
+                                          0111(0001358f:.textf)
+                                          0111(0001386d:.textf)
+                                          0111(00013a63:.textf)
+                 _R_DALI209_VAR_SetReportLightOutputRgbwaf
+                                 00014680 0110(00010f2f:.textf)
+                                          0111(00012d84:.textf)
+                                          0113(000142ce:.textf)
+                 _R_DALI209_VAR_GetReportLightOutputRgbwaf
+                                 00014694 0111(000139fa:.textf)
+                                          0111(00013a1b:.textf)
+                 _R_DALI209_VAR_SetDeratingFactor
+                                 00014699 0110(0000fa8d:.textf)
+                 _R_DALI209_VAR_GetDeratingFactor
+                                 0001469e 0111(0001388e:.textf)
+                 _R_DALI209_VAR_SetEnabledChannels
+                                 000146a2 0111(00013546:.textf)
+                 _R_DALI209_VAR_GetEnabledChannels
+                                 000146b5 0082(0000ca56:.textf)
+                                          0110(0000f63c:.textf)
+                                          0110(0000f948:.textf)
+                                          0110(00010529:.textf)
+                                          0110(00010e01:.textf)
+                                          0111(000131bb:.textf)
+                                          0111(0001389c:.textf)
+                 _R_DALI209_VAR_SetTemporaryColourType
+                                 000146b9 0111(000124ad:.textf)
+                                          0111(000124ee:.textf)
+                                          0111(00012c14:.textf)
+                                          0111(00013010:.textf)
+                                          0111(00013020:.textf)
+                                          0111(000131f5:.textf)
+                                          0111(000132af:.textf)
+                                          0111(00013340:.textf)
+                 _R_DALI209_VAR_GetTemporaryColourType
+                                 000146be 0111(00011f3a:.textf)
+                                          0111(00012301:.textf)
+                                          0111(00012651:.textf)
+                                          0111(00013951:.textf)
+                 _R_DALI209_VAR_SetReportColourType
+                                 000146c2 0111(0001256e:.textf)
+                                          0111(000125b7:.textf)
+                                          0111(000129b1:.textf)
+                                          0111(00012a94:.textf)
+                                          0111(00012b4e:.textf)
+                                          0111(00013a77:.textf)
+                 _R_DALI209_VAR_GetReportColourType
+                                 000146c7 0111(000132cf:.textf)
+                                          0111(000139e9:.textf)
+                 _R_DALI209_VAR_SetLastActiveColourType
+                                 000146cb 0110(00010c25:.textf)
+                                          0110(00010c3c:.textf)
+                                          0110(00010c74:.textf)
+                                          0110(00010d37:.textf)
+                 _R_DALI209_VAR_GetLastActiveColourType
+                                 000146de 0110(0000fe60:.textf)
+                                          0110(000106fa:.textf)
+                 _R_DALI209_VAR_SetLastActiveColourValueTc
+                                 000146e2 0110(00010c2e:.textf)
+                                          0110(00010df1:.textf)
+                 _R_DALI209_VAR_GetLastActiveColourValueTc
+                                 000146f6 0110(0000fe81:.textf)
+                                          0110(000100b5:.textf)
+                                          0110(00010879:.textf)
+                 _R_DALI209_VAR_SetLastActiveColourValueXy
+                                 000146fa 0110(00010c5e:.textf)
+                                          0110(00010d86:.textf)
+                 _R_DALI209_VAR_GetLastActiveColourValueXy
+                                 0001470d 0110(000100dd:.textf)
+                                          0110(0001083f:.textf)
+                 _R_DALI209_VAR_SetLastActiveColourValueRgbwaf
+                                 00014716 0110(00010ca7:.textf)
+                                          0110(00010e4a:.textf)
+                                          0110(00010e89:.textf)
+                 _R_DALI209_VAR_GetLastActiveColourValueRgbwaf
+                                 00014723 0110(0000fecf:.textf)
+                                          0110(00010137:.textf)
+                                          0110(000108ff:.textf)
+                 _R_DALI209_VAR_SetLastActiveColourRgbwafControl
+                                 00014729 0110(00010c81:.textf)
+                                          0110(00010eb3:.textf)
+                 _R_DALI209_VAR_GetLastActiveColourRgbwafControl
+                                 00014730 0110(0000ff01:.textf)
+                                          0110(00010124:.textf)
+                                          0110(000108f3:.textf)
+                 _R_DALI209_VAR_SetSceneColourType
+                                 00014736 0111(00012924:.textf)
+                                          0111(00012943:.textf)
+                                          0113(000142a0:.textf)
+                 _R_DALI209_VAR_GetSceneColourType
+                                 00014743 0111(0001234e:.textf)
+                                          0111(00012a6d:.textf)
+                 _R_DALI209_VAR_SetSceneColourValueTc
+                                 00014749 0111(00012821:.textf)
+                 _R_DALI209_VAR_GetSceneColourValueTc
+                                 0001476d 0111(000123bb:.textf)
+                                          0111(00012496:.textf)
+                                          0111(00012a89:.textf)
+                 _R_DALI209_VAR_SetSceneColourValueXy
+                                 00014781 0111(00012858:.textf)
+                 _R_DALI209_VAR_GetSceneColourValueXy
+                                 000147aa 0111(000124fb:.textf)
+                                          0111(00012aa1:.textf)
+                 _R_DALI209_VAR_SetSceneColourValueRgbwaf
+                                 000147b0 0111(000128c7:.textf)
+                 _R_DALI209_VAR_GetSceneColourValueRgbwaf
+                                 000147d4 0111(000124e5:.textf)
+                                          0111(00012ac1:.textf)
+                 _R_DALI209_VAR_SetSceneColourRgbwafControl
+                                 000147ed 0111(000128df:.textf)
+                 _R_DALI209_VAR_GetSceneColourRgbwafControl
+                                 000147fb 0111(00012390:.textf)
+                                          0111(00012470:.textf)
+                                          0111(00012ab4:.textf)
+                 _R_DALI209_VAR_SetPowerOnColourType
+                                 00014800 0111(00012758:.textf)
+                                          0111(000127aa:.textf)
+                                          0113(00014274:.textf)
+                 _R_DALI209_VAR_GetPowerOnColourType
+                                 00014813 0110(0000fe58:.textf)
+                                          0110(000106f2:.textf)
+                                          0111(00012950:.textf)
+                 _R_DALI209_VAR_SetPowerOnColourValueTc
+                                 00014817 0111(00012761:.textf)
+                 _R_DALI209_VAR_GetPowerOnColourValueTc
+                                 0001482b 0110(0000fe77:.textf)
+                                          0110(0000ffe9:.textf)
+                                          0110(0001070b:.textf)
+                                          0111(0001296b:.textf)
+                 _R_DALI209_VAR_SetPowerOnColourValueXy
+                                 0001482f 0111(00012772:.textf)
+                 _R_DALI209_VAR_GetPowerOnColourValueXy
+                                 00014849 0110(0001001c:.textf)
+                                          0110(0001079c:.textf)
+                                          0111(0001297a:.textf)
+                 _R_DALI209_VAR_SetPowerOnColourValueRgbwaf
+                                 00014852 0111(0001279c:.textf)
+                 _R_DALI209_VAR_GetPowerOnColourValueRgbwaf
+                                 0001485e 0110(0000feb8:.textf)
+                                          0110(0000ff6e:.textf)
+                                          0110(000107f2:.textf)
+                                          0111(00012991:.textf)
+                 _R_DALI209_VAR_SetPowerOnColourRgbwafControl
+                                 00014864 0111(000127b3:.textf)
+                 _R_DALI209_VAR_GetPowerOnColourRgbwafControl
+                                 0001486c 0110(0000fef7:.textf)
+                                          0110(0000ff91:.textf)
+                                          0110(000107e4:.textf)
+                                          0111(00012987:.textf)
+                 _R_DALI209_VAR_SetSystemFailureColourType
+                                 00014872 0111(000125ce:.textf)
+                                          0111(00012620:.textf)
+                                          0113(0001428a:.textf)
+                 _R_DALI209_VAR_GetSystemFailureColourType
+                                 00014885 0110(00010942:.textf)
+                                          0111(00012a05:.textf)
+                 _R_DALI209_VAR_SetSystemFailureColourValueTc
+                                 00014889 0111(000125d7:.textf)
+                 _R_DALI209_VAR_GetSystemFailureColourValueTc
+                                 0001489d 0110(0001094c:.textf)
+                                          0111(00012a20:.textf)
+                 _R_DALI209_VAR_SetSystemFailureColourValueXy
+                                 000148a1 0111(000125e8:.textf)
+                 _R_DALI209_VAR_GetSystemFailureColourValueXy
+                                 000148b4 0110(00010970:.textf)
+                                          0111(00012a2f:.textf)
+                 _R_DALI209_VAR_SetSystemFailureColourValueRgbwaf
+                                 000148bd 0111(00012612:.textf)
+                 _R_DALI209_VAR_GetSystemFailureColourValueRgbwaf
+                                 000148ca 0110(000109b0:.textf)
+                                          0111(00012a46:.textf)
+                 _R_DALI209_VAR_SetSystemFailureColourRgbwafControl
+                                 000148d0 0111(0001262a:.textf)
+                 _R_DALI209_VAR_GetSystemFailureColourRgbwafControl
+                                 000148d6 0110(000109da:.textf)
+                                          0111(00012a3c:.textf)
+                 _R_DALI209_VAR_SetAutomaticActivation
+                                 000148dc 0111(0001350f:.textf)
+                                          0113(00014296:.textf)
+                 _R_DALI209_VAR_ClearAutomaticActivation
+                                 000148e3 0111(00013508:.textf)
+                 _R_DALI209_VAR_AutomaticActivationIsActive
+                                 000148ea 0111(00011e83:.textf)
+                                          0111(00012025:.textf)
+                                          0111(0001221a:.textf)
+                                          0111(000135b5:.textf)
+                 _R_DALI209_VAR_SetTcPhysicalLimitReadOnly
+                                 000148f0
+                 _R_DALI209_VAR_ClearTcPhysicalLimitReadOnly
+                                 000148f7
+                 _R_DALI209_VAR_TcPhysicalLimitIsReadOnly
+                                 000148fe 0111(000133f1:.textf)
+                                          0111(0001347a:.textf)
+                                          0111(000135bc:.textf)
+                 _R_DALI209_VAR_SetXyOutOfRange
+                                 00014906 0110(0001042e:.textf)
+                                          0110(00010dc0:.textf)
+                                          0111(00012ed0:.textf)
+                 _R_DALI209_VAR_ClearXyOutOfRange
+                                 0001490c 0110(0000ffbe:.textf)
+                                          0110(0001000d:.textf)
+                                          0110(000100af:.textf)
+                                          0110(0001011e:.textf)
+                                          0110(000101dc:.textf)
+                                          0110(0001041f:.textf)
+                                          0110(00010d29:.textf)
+                                          0110(00010db9:.textf)
+                                          0111(00012ec1:.textf)
+                 _R_DALI209_VAR_XyIsOutOfRange
+                                 00014912 0111(000135eb:.textf)
+                 _R_DALI209_VAR_SetTcOutOfRange
+                                 00014918 0110(000102c7:.textf)
+                                          0110(00010763:.textf)
+                                          0110(000108cc:.textf)
+                                          0111(000130d7:.textf)
+                                          0111(000130ea:.textf)
+                 _R_DALI209_VAR_ClearTcOutOfRange
+                                 0001491e 0110(0000ffb8:.textf)
+                                          0110(00010061:.textf)
+                                          0110(000100d3:.textf)
+                                          0110(00010118:.textf)
+                                          0110(000101f9:.textf)
+                                          0110(00010215:.textf)
+                                          0110(000102e0:.textf)
+                                          0110(0001077c:.textf)
+                                          0110(000108e5:.textf)
+                                          0110(00010d04:.textf)
+                                          0110(00010d23:.textf)
+                                          0111(000130f2:.textf)
+                 _R_DALI209_VAR_TcIsOutOfRange
+                                 00014924 0111(000135f2:.textf)
+                 _R_DALI209_VAR_SetColourTypeXyActive
+                                 0001492c 0110(0001004f:.textf)
+                                          0110(000100c1:.textf)
+                                          0110(000101e6:.textf)
+                                          0110(00010cf2:.textf)
+                 _R_DALI209_VAR_ClearColourTypeXyActive
+                                 00014937 0110(0000ffb2:.textf)
+                                          0110(00010001:.textf)
+                                          0110(000100a3:.textf)
+                                          0110(00010112:.textf)
+                                          0110(000101cf:.textf)
+                                          0110(0001020f:.textf)
+                                          0110(00010cdf:.textf)
+                                          0110(00010d1d:.textf)
+                 _R_DALI209_VAR_ColourTypeXyIsActive
+                                 0001493d 0082(0000c986:.textf)
+                                          0110(00010171:.textf)
+                                          0110(0001022a:.textf)
+                                          0110(0001046c:.textf)
+                                          0110(0001062c:.textf)
+                                          0110(00010bd1:.textf)
+                                          0111(00013601:.textf)
+                 _R_DALI209_VAR_SetColourTypeTcActive
+                                 00014945 0110(0000fffb:.textf)
+                                          0110(0001009d:.textf)
+                                          0110(000101c9:.textf)
+                                          0110(00010cd9:.textf)
+                 _R_DALI209_VAR_ClearColourTypeTcActive
+                                 0001494b 0110(0000ffac:.textf)
+                                          0110(00010055:.textf)
+                                          0110(000100c7:.textf)
+                                          0110(0001010c:.textf)
+                                          0110(000101ec:.textf)
+                                          0110(00010209:.textf)
+                                          0110(00010cf8:.textf)
+                                          0110(00010d17:.textf)
+                 _R_DALI209_VAR_ColourTypeTcIsActive
+                                 00014951 0082(0000c976:.textf)
+                                          0110(00010162:.textf)
+                                          0110(00010222:.textf)
+                                          0110(00010464:.textf)
+                                          0110(00010624:.textf)
+                                          0110(00010bc9:.textf)
+                                          0111(00013610:.textf)
+                 _R_DALI209_VAR_SetColourTypeRgbwafActive
+                                 00014959 0110(0000ffa6:.textf)
+                                          0110(00010106:.textf)
+                                          0110(00010203:.textf)
+                                          0110(00010d11:.textf)
+                 _R_DALI209_VAR_ClearColourTypeRgbwafActive
+                                 0001495f 0110(00010007:.textf)
+                                          0110(0001005b:.textf)
+                                          0110(000100a9:.textf)
+                                          0110(000100cd:.textf)
+                                          0110(000101d5:.textf)
+                                          0110(000101f2:.textf)
+                                          0110(00010ce5:.textf)
+                                          0110(00010cfe:.textf)
+                 _R_DALI209_VAR_ColourTypeRgbwafIsActive
+                                 00014965 0082(0000c996:.textf)
+                                          0110(00010180:.textf)
+                                          0110(00010232:.textf)
+                                          0110(00010474:.textf)
+                                          0110(00010634:.textf)
+                                          0110(00010bd9:.textf)
+                                          0111(0001361f:.textf)
+                 _R_DALI209_VAR_GetPowerRatio
+                                 0001496d 0110(0000f9fa:.textf)
+                                          0111(0001387b:.textf)
+                 _R_DALI209_VAR_GetColourTypeFeatures
+                                 00014974 0110(00010193:.textf)
+                                          0111(00013637:.textf)
+                                          0111(000137ae:.textf)
+                 _R_DALI209_VAR_GetRgbwafChannelsPresent
+                                 0001497a 0111(00013535:.textf)
+                 _R_DALI209_VAR_GetPrimaryRedXyCoordinate
+                                 00014981 0110(0000f095:.textf)
+                                          0110(0000f09e:.textf)
+                                          0110(0000f11f:.textf)
+                                          0110(0000f128:.textf)
+                                          0110(0000f385:.textf)
+                                          0110(0000f391:.textf)
+                 _R_DALI209_VAR_GetPrimaryGreenXyCoordinate
+                                 0001498a 0110(0000f0a7:.textf)
+                                          0110(0000f0b0:.textf)
+                                          0110(0000f131:.textf)
+                                          0110(0000f13a:.textf)
+                                          0110(0000f39d:.textf)
+                                          0110(0000f3a9:.textf)
+                 _R_DALI209_VAR_GetPrimaryBlueXyCoordinate
+                                 0001499c 0110(0000f0b9:.textf)
+                                          0110(0000f0c2:.textf)
+                                          0110(0000f143:.textf)
+                                          0110(0000f14c:.textf)
+                                          0110(0000f3b5:.textf)
+                                          0110(0000f3c1:.textf)
+0114 _REL_print
+     SECTION=.SLIB
+                 __REL_print
+                                 00005284 0083(00005226:.SLIB)
+     SECTION=.constf
+     SECTION=.bss
+0115 _COM_lmul
+     SECTION=.RLIB
+                 __COM_lmul
+                                 00004a3e 0092(0000499d:.RLIB)
+                                          0092(000049b2:.RLIB)
+                                          0105(0000e734:.textf)
+                                          0110(0000fa29:.textf)
+                                          0110(00011323:.textf)
+                                          0110(000113bd:.textf)
+                                          0110(00011451:.textf)
+                                          0110(000114bb:.textf)
+                                          0110(0001156d:.textf)
+                                          0110(000115f9:.textf)
+                                          0110(00011699:.textf)
+                                          0110(000116d8:.textf)
+                                          0110(0001171f:.textf)
+                                          0110(00011750:.textf)
+                                          0110(00011774:.textf)
+                                          0110(000117a5:.textf)
+                                          0110(000117da:.textf)
+                                          0110(000117fe:.textf)
+                                          0110(00011821:.textf)
+                                          0110(00011845:.textf)
+                                          0110(00011942:.textf)
+                                          0110(000119e6:.textf)
+                                          0110(00011a89:.textf)
+                                          0110(00011b10:.textf)
+                                          0110(00011b9f:.textf)
+                                          0110(00011bc5:.textf)
+                                          0110(00011bed:.textf)
+                                          0110(00011c03:.textf)
+0116 _COM_mulul
+     SECTION=.RLIB
+                 __COM_mulul
+                                 00004a58 0092(00004994:.RLIB)
+0117 _REL_fcmp
+     SECTION=.RLIB
+                 __REL_fcmp
+                                 00004aa7 0089(0000487f:.RLIB)
+                                          0127(00004db5:.RLIB)
+                                          0128(00004dcb:.RLIB)
+                                          0129(00004de1:.RLIB)
+0118 _REL_fordered_core
+     SECTION=.RLIB
+                 __REL_fordered_core
+                                 00004adf 0089(00004878:.RLIB)
+                                          0127(00004dae:.RLIB)
+                                          0128(00004dc4:.RLIB)
+                                          0129(00004dda:.RLIB)
+                                          0132(00004e09:.RLIB)
+0119 _REL_ftol
+     SECTION=.RLIB
+                 __REL_ftol
+                                 00004afb 0091(0000497e:.RLIB)
+                                          0131(00004dff:.RLIB)
+0120 _REL_f_inf
+     SECTION=.RLIB
+                 __REL_f_inf
+                                 00004b30 0087(000046ff:.RLIB)
+                                          0088(00004790:.RLIB)
+                                          0088(00004830:.RLIB)
+                                          0090(000048a8:.RLIB)
+                                          0090(0000494b:.RLIB)
+0121 _REL_f_norm
+     SECTION=.RLIB
+                 __REL_f_norm
+                                 00004b38 0088(00004771:.RLIB)
+                                          0088(0000479c:.RLIB)
+                                          0090(000048c9:.RLIB)
+0122 _REL_f_round
+     SECTION=.RLIB
+                 __REL_f_round
+                                 00004b48 0087(0000470c:.RLIB)
+                                          0087(00004744:.RLIB)
+                                          0088(00004872:.RLIB)
+                                          0090(00004958:.RLIB)
+0123 _REL_lldiv
+     SECTION=.RLIB
+                 __REL_lldiv
+                                 00004b77 0095(00004a35:.RLIB)
+                                          0137(00004f0a:.RLIB)
+0124 _REL_ltof
+     SECTION=.RLIB
+                 __REL_ltof
+                                 00004d61 0094(00004a0b:.RLIB)
+                                          0096(00004a3b:.RLIB)
+0125 isdigit
+     SECTION=.SLIB
+                 _isdigit
+                                 00006ebe 0114(00006621:.SLIB)
+0126 memcmp
+     SECTION=.SLIB
+                 _memcmp
+                                 00006ec8 0113(0001436e:.textf)
+0127 _COM_feq
+     SECTION=.RLIB
+                 __COM_feq
+                                 00004dab 0114(00005a74:.SLIB)
+                                          0130(00004df6:.RLIB)
+0128 _COM_fge
+     SECTION=.RLIB
+                 __COM_fge
+                                 00004dc1 0114(00006813:.SLIB)
+0129 _COM_flt
+     SECTION=.RLIB
+                 __COM_flt
+                                 00004dd7 0114(00005a88:.SLIB)
+                                          0114(0000600d:.SLIB)
+                                          0114(00006855:.SLIB)
+0130 _COM_fne
+     SECTION=.RLIB
+                 __COM_fne
+                                 00004ded 0114(00005b38:.SLIB)
+                                          0114(00005c58:.SLIB)
+                                          0114(00005ff6:.SLIB)
+0131 _COM_ftosl
+     SECTION=.RLIB
+                 __COM_ftosl
+                                 00004dfe 0114(00005cd8:.SLIB)
+0132 _COM_funordered
+     SECTION=.RLIB
+                 __COM_funordered
+                                 00004e06 0114(00006830:.SLIB)
+0133 _COM_lshr
+     SECTION=.RLIB
+                 __COM_lshr
+                                 00004e1b 0119(00004b27:.RLIB)
+0134 _COM_sidiv
+     SECTION=.RLIB
+                 __COM_sidiv
+                                 00004e34 0114(00006118:.SLIB)
+                                          0114(00006c34:.SLIB)
+0135 _COM_sirem
+     SECTION=.RLIB
+                 __COM_sirem
+                                 00004e54 0114(0000610d:.SLIB)
+0136 _COM_sldiv
+     SECTION=.RLIB
+                 __COM_sldiv
+                                 00004e79 0110(0000fa38:.textf)
+                                          0110(00010f22:.textf)
+0137 _COM_slldiv
+     SECTION=.RLIB
+                 __COM_slldiv
+                                 00004ec3 0110(0000fbd3:.textf)
+                                          0110(0000fca7:.textf)
+                                          0110(0000fd02:.textf)
+                                          0110(0000fd89:.textf)
+                                          0110(0000fde4:.textf)
+0138 _COM_uidiv
+     SECTION=.RLIB
+                 __COM_uidiv
+                                 00004f18 0110(0000f6ba:.textf)
+                                          0110(0000fa12:.textf)
+0139 _COM_uldiv
+     SECTION=.RLIB
+                 __COM_uldiv
+                                 00004f29 0110(0000f0e2:.textf)
+                                          0110(0000f101:.textf)
+                                          0110(00011b8b:.textf)
+0140 _COM_ullrem
+     SECTION=.RLIB
+                 __COM_ullrem
+                                 00004f43 0114(00005625:.SLIB)
+0141 _REL_llrem
+     SECTION=.RLIB
+                 __REL_llrem
+                                 00004f91 0140(00004f71:.RLIB)
+0142 _REL_llrev
+     SECTION=.RLIB
+                 __REL_llrev
+                                 00005178 0137(00004eef:.RLIB)
+                                          0137(00004eff:.RLIB)
+                                          0137(00004f12:.RLIB)
+0143 _REL_ltosl
+     SECTION=.RLIB
+                 __REL_ltosl
+                                 00005198 0131(00004e03:.RLIB)
+0144 rlink_generates_01
+     SECTION=.option_byte
+0145 rlink_generates_02
+     SECTION=.monitor1
+     SECTION=.monitor2
+0146 rlink_generates_03
+     SECTION=.security_id
+0147 rlink_generates_04
+     SECTION=.vect
+0148 rlink_generates_05
+     SECTION=
+                 __s.vect
+                                 00000000
+                 __s.init_array
+                                 00000080
+                 __e.init_array
+                                 00000080
+                 __e.vect
+                                 00000080
+                 __s.option_byte
+                                 000000c0
+                 __e.option_byte
+                                 000000c4
+                 __s.security_id
+                                 000000c4
+                 __s.monitor1
+                                 000000ce
+                 __e.security_id
+                                 000000ce
+                 __e.monitor1
+                                 000000d8
+                 __s.const
+                                 00002000
+                 __e.const
+                                 000043bd
+                 __s.text
+                                 000043bd
+                 __e.text
+                                 000045ee
+                 __s.RLIB
+                                 000045ee
+                 __e.RLIB
+                                 000051bd
+                 __s.SLIB
+                                 000051bd
+                 __s.textf
+                                 00006eda
+                 __e.SLIB
+                                 00006eda
+                 __e.textf
+                                 000149a5
+                 __s.constf
+                                 000149a6
+                 __s.data
+                                 000149ba
+                 __e.constf
+                                 000149ba
+                 __e.data
+                                 00014ecc
+                 __s.sdata
+                                 00014ecc
+                 __e.sdata
+                                 00014efe
+                 __sRFD_DATA_n
+                                 00014efe
+                 __sRFD_CMN_f
+                                 00014f03
+                 __eRFD_DATA_n
+                                 00014f03
+                 __sRFD_DF_f
+                                 000150e1
+                 __eRFD_CMN_f
+                                 000150e1
+                 __sNVM_f
+                                 0001512e
+                 __eRFD_DF_f
+                                 0001512e
+                 __eNVM_f
+                                 00015b7f
+                 __s.monitor2
+                                 0001fe00
+                 __e.monitor2
+                                 00020000
+                 __s.dataR
+                                 000fcf00
+                 __RAM_ADDR_START
+                                 000fcf00
+                 __e.dataR
+                                 000fd412
+                 __s.stack_bss
+                                 000fd412
+                 __s.bss
+                                 000fd612
+                 __e.stack_bss
+                                 000fd612
+                 __e.bss
+                                 000fde30
+                 __sRFD_DATA_nR
+                                 000fde30
+                 __eRFD_DATA_nR
+                                 000fde35
+                 __STACK_ADDR_END
+                                 000fde36 0062(0000442b:.text)
+                 __s.sdataR
+                                 000ffe20
+                 __STACK_ADDR_START
+                                 000ffe20 0062(00004428:.text)
+                 __s.sbss
+                                 000ffe52
+                 __e.sbss
+                                 000ffe52
+                 __e.sdataR
+                                 000ffe52
+                 __RAM_ADDR_END
+                                 000ffee0


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Introduce a new test to parse CS+ .map files by adding the `MemoryMappingTest` class, which reads and processes the file to extract relevant sections and symbols. Update the module dependencies to include `org.apache.commons.io`.

Tests:
- Add a new test class `MemoryMappingTest` to parse and validate the contents of a CS+ .map file, focusing on extracting sections and symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了对 Apache Commons IO 库的模块依赖，增强了模块的功能。
	- 引入了新的 JUnit 测试类 `MemoryMappingTest`，用于读取和处理特定的内存映射文件格式。

- **修复**
	- 无修复内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->