### PR TITLE
ci: Update jre.sh

### DIFF
--- a/jenkins/jre.sh
+++ b/jenkins/jre.sh
@@ -28,10 +28,10 @@
 #
 
 # see https://api.adoptium.net/q/swagger-ui/#/Binary/getBinaryByVersion
-winApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.9%2B9.1/windows/x64/jre/hotspot/normal/eclipse?project=jdk'
-macApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.9%2B9/mac/aarch64/jre/hotspot/normal/eclipse?project=jdk'
-linuxApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.9%2B9/linux/x64/jre/hotspot/normal/eclipse?project=jdk'
-wget -c ${winApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_x64_windows_hotspot_17.0.9_9.zip
-wget -c ${linuxApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_x64_linux_hotspot_17.0.9_9.tar.gz
-wget -c ${macApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.9_9.tar.gz
+winApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.13%2B11/windows/x64/jre/hotspot/normal/eclipse?project=jdk'
+macApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.13%2B11/mac/aarch64/jre/hotspot/normal/eclipse?project=jdk'
+linuxApi='https://api.adoptium.net/v3/binary/version/jdk-17.0.13%2B11/linux/x64/jre/hotspot/normal/eclipse?project=jdk'
+wget -c ${winApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_x64_windows_hotspot_17.0.13_11.zip
+wget -c ${linuxApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_x64_linux_hotspot_17.0.13_11.tar.gz
+wget -c ${macApi} --no-check-certificate -O aftifact/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.13_11.tar.gz
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

CI:
- Update JRE download URLs in jre.sh script to use version 17.0.13+11 for Windows, macOS, and Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了脚本以引用较新版本的JDK二进制文件，支持Windows、macOS和Linux平台。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->