### PR TITLE
test: Add MemoryMappingTest for iar

### DIFF
--- a/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
+++ b/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
@@ -104,6 +104,45 @@ public class MemoryMappingTest {
         System.out.println(symbols);
     }
 
+    private final String iarSymbolFlag = "*** ENTRY LIST";
+    private final String iarGlobalVarFlag = "Data  Gb";
+
+    @Test
+    public void readIarMap() throws IOException {
+        File file = new File(ResourceUtil.getResource("iar.map").getPath());
+        List<String> content = FileUtils.readLines(file, StandardCharsets.UTF_8);
+        String previousLine = "";
+        for (String line : content) {
+            if (!inSymbol) {
+                if (line.equals(iarSymbolFlag)) {
+                    inSymbol = true;
+                }
+            } else {
+                if (line.contains(iarGlobalVarFlag)) {
+                    String[] data = line.split("\\s+");
+                    int size = 0;
+                    if (!data[2].equals("Data")) {
+                        size = Integer.decode(data[2]);
+                    }
+                    if (!line.startsWith("_") && previousLine.startsWith("_")) {
+                        symbols.add(
+                            new Symbol(previousLine.trim(), data[1].replaceAll("'", ""), size));
+                    } else {
+                        symbols.add(
+                            new Symbol(data[0], data[1].replaceAll("'", ""), size));
+                    }
+                }
+                previousLine = line;
+                if (line.startsWith(endFlag) && !line.equals(iarSymbolFlag)) {
+                    inSymbol = false;
+                    break;
+                }
+            }
+        }
+        content = null;
+        System.out.println(symbols);
+    }
+
     private record Symbol(String name, String address, int size) {
 
     }

--- a/qe/src/test/resources/iar.map
+++ b/qe/src/test/resources/iar.map
@@ -1,0 +1,3167 @@
+###############################################################################
+#
+# IAR ELF Linker V5.10.3.2716/W64 for RL78                30/Oct/2024  19:18:37
+# Copyright 2011-2023 IAR Systems AB.
+#
+#    Output file  =
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out
+#    Map file     =
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\List\DALI102_207_209_sample.map
+#    Command line =
+#        -f
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out.rsp
+#        (C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\cstartup.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\hdwinit.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\mcu_clocks.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common_iar.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\r_bsp_init.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_cg.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_ad_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_da_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common_user.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_pgacomp_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_sau_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_systeminit.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tau_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tkb_common.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_bft.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_rx.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_debug.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_rgbwaf.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_tc.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_xy.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led1.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led2.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led3.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_main.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_bank.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_banks.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_nvm.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_port.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_random.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_api.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_control_api.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_extension_api.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_get_api.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown\r_rfd_common_userown.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash\r_rfd_data_flash_api.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility\r_timer16.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_trng.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit0_memory_bank.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit1_memory_bank.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit2_memory_bank.o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\vecttbl.o
+#        --no_out_extension -o
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out
+#        --map
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\List\DALI102_207_209_sample.map
+#        --config "C:\Program Files\IAR Systems\Embedded Workbench
+#        9.1\rl78\config\lnkr7f101glg.icf" --config_def _STACK_SIZE=512
+#        --config_def _NEAR_HEAP_SIZE=256 --config_def _FAR_HEAP_SIZE=4096
+#        --config_def _HUGE_HEAP_SIZE=0 --define_symbol _NEAR_CONST_LOCATION=0
+#        --config_def _NEAR_CONST_LOCATION_START=0x2000 --config_def
+#        _NEAR_CONST_LOCATION_SIZE=0xAF00 --vfe
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a
+#        C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a
+#        --entry __iar_program_start --debug_lib --inline --text_out locale)
+#
+###############################################################################
+
+*******************************************************************************
+*** MESSAGES
+***
+
+
+  C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\cstartup.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\hdwinit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\mcu_clocks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common_iar.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\r_bsp_init.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_cg.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_ad_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_da_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_pgacomp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_sau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_systeminit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tkb_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_bft.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_rx.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_debug.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_rgbwaf.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_tc.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_xy.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_main.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_banks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_nvm.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_port.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_random.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_control_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_extension_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_get_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown\r_rfd_common_userown.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash\r_rfd_data_flash_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility\r_timer16.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_trng.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit0_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit1_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit2_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\vecttbl.o --no_out_extension -o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out --map C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\List\DALI102_207_209_sample.map --config "C:\Program Files\IAR Systems\Embedded Workbench 9.1\rl78\config\lnkr7f101glg.icf" --config_def _STACK_SIZE=512 --config_def _NEAR_HEAP_SIZE=256 --config_def _FAR_HEAP_SIZE=4096 --config_def _HUGE_HEAP_SIZE=0 --define_symbol _NEAR_CONST_LOCATION=0 --config_def _NEAR_CONST_LOCATION_START=0x2000 --config_def _NEAR_CONST_LOCATION_SIZE=0xAF00 --vfe C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a --entry __iar_program_start --debug_lib --inline --text_out locale
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^
+"C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out.rsp",1  Warning[Li065]: 
+          duplicate file: "C:\work\workspace\runtime-lighting.product\qwq\qeLig
+          hting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a"
+
+  C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\cstartup.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\hdwinit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\mcu_clocks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common_iar.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\r_bsp_init.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_cg.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_ad_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_da_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_pgacomp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_sau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_systeminit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tkb_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_bft.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_rx.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_debug.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_rgbwaf.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_tc.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_xy.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_main.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_banks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_nvm.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_port.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_random.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_control_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_extension_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_get_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown\r_rfd_common_userown.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash\r_rfd_data_flash_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility\r_timer16.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_trng.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit0_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit1_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit2_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\vecttbl.o --no_out_extension -o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out --map C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\List\DALI102_207_209_sample.map --config "C:\Program Files\IAR Systems\Embedded Workbench 9.1\rl78\config\lnkr7f101glg.icf" --config_def _STACK_SIZE=512 --config_def _NEAR_HEAP_SIZE=256 --config_def _FAR_HEAP_SIZE=4096 --config_def _HUGE_HEAP_SIZE=0 --define_symbol _NEAR_CONST_LOCATION=0 --config_def _NEAR_CONST_LOCATION_START=0x2000 --config_def _NEAR_CONST_LOCATION_SIZE=0xAF00 --vfe C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a --entry __iar_program_start --debug_lib --inline --text_out locale
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^
+"C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out.rsp",1  Warning[Li065]: 
+          duplicate file: "C:\work\workspace\runtime-lighting.product\qwq\qeLig
+          hting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a"
+
+  C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC\Config_ADC_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0\Config_COMP0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1\Config_COMP1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2\Config_COMP2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0\Config_DAC0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\Config_DALI_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA\Config_PGA_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT\Config_PORT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0\Config_TAU0_0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1\Config_TAU0_1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2\Config_TAU0_2_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3\Config_TAU0_3_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0\Config_TKB0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1\Config_TKB1_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0\Config_UART0_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT\Config_WDT_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\cstartup.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\hdwinit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\mcu_clocks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all\r_bsp_common_iar.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24\r_bsp_init.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_cg.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_ad_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_da_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_lvd_common_user.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_pgacomp_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_sau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_systeminit.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tau_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general\r_cg_tkb_common.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_bft.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_dali101_rx.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_debug.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_rgbwaf.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_tc.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_lamp_xy.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led1.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led2.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_led3.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_main.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_memory_banks.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_nvm.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_port.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_random.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_control_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_extension_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common\r_rfd_common_get_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown\r_rfd_common_userown.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash\r_rfd_data_flash_api.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility\r_timer16.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver\r_trng.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit0_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit1_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App\r_unit2_memory_bank.o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24\vecttbl.o --no_out_extension -o C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out --map C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\List\DALI102_207_209_sample.map --config "C:\Program Files\IAR Systems\Embedded Workbench 9.1\rl78\config\lnkr7f101glg.icf" --config_def _STACK_SIZE=512 --config_def _NEAR_HEAP_SIZE=256 --config_def _FAR_HEAP_SIZE=4096 --config_def _HUGE_HEAP_SIZE=0 --define_symbol _NEAR_CONST_LOCATION=0 --config_def _NEAR_CONST_LOCATION_START=0x2000 --config_def _NEAR_CONST_LOCATION_SIZE=0xAF00 --vfe C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI102\r_dali_102_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI207\r_dali_207_iar_gen2_v1_01.a C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a --entry __iar_program_start --debug_lib --inline --text_out locale
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ^
+"C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Exe\DALI102_207_209_sample.out.rsp",1  Warning[Li065]: 
+          duplicate file: "C:\work\workspace\runtime-lighting.product\qwq\qeLig
+          hting_gen\solution\Library\DALI209\r_dali_209_iar_gen2_v2_00.a"
+
+
+*******************************************************************************
+*** RUNTIME MODEL ATTRIBUTES
+***
+
+__SystemLibrary            = DLib
+__calling_convention       = v2
+__code_model               = far
+__core                     = s3
+__data_model               = near
+__dlib_file_descriptor     = 0
+__dlib_full_locale_support = 0
+__dlib_version             = 6
+__double_size              = 32
+__far_rt_calls             = false
+__near_const               = rom0
+__rt_version               = 2
+
+
+*******************************************************************************
+*** RESERVED RANGES
+***
+
+Ranges reserved by mirroring and reserve directives:
+
+      From        To    Size
+      ----        --    ----
+  0xf'2000  0xf'ceff  0xaf00
+
+
+*******************************************************************************
+*** PLACEMENT SUMMARY
+***
+
+"RESET":
+       place at address 0x0 { ro section .reset };
+"VECTOR":
+       place at address 0x4 { ro section .intvec };
+define block OPT_BYTE
+   with size = 4 { R_OPT_BYTE, ro section .option_byte, ro section OPTBYTE };
+"A2":  place at address 0xc0 { block OPT_BYTE };
+define block SECUR_ID
+   with size = 10 { R_SECUR_ID, ro section .security_id, ro section SECUID };
+"A3":  place at address 0xc4 { block SECUR_ID };
+"MIRROR":
+       place in [from 0x2000 to 0xceff] with mirroring to 0xf'2000 {
+          ro R_CONST_init, ro section .const, ro section .switch };
+"ROMNEAR":
+       place in [from 0xd8 to 0xffff] { R_TEXT, ro section .text };
+define block INIT_ARRAY
+   with fixed order, alignment = 2 {
+      ro section .preinit_array, ro section .init_array };
+define block INIT_ARRAY_TLS
+   with fixed order, alignment = 2 {
+      ro section .preinit_array_tls, ro section .init_array_tls };
+define block MIRROR_AREA { };
+"ROMFAR":
+       place in [from 0xd8 to 0xffff] |
+                [from 0x1'0000 to 0x1'ffff] {
+          block INIT_ARRAY, block INIT_ARRAY_TLS, block MIRROR_AREA,
+          R_TEXTF_UNIT64KP, ro section .textf_unit64kp, ro section .constf,
+          ro section .switchf, ro };
+"ROMHUGE":
+       place in [from 0xd8 to 0x1'ffff] {
+          ro section .consth, R_TEXTF, ro section .textf };
+define block NEAR_HEAP with size = 256, alignment = 2 { };
+define block CSTACK with size = 512, alignment = 2 { rw section CSTACK };
+"RAMNEAR":
+       place in [from 0xf'cf00 to 0xf'fe1f] {
+          block NEAR_HEAP, block CSTACK, zi section .iar.dynexit, R_DATA,
+          rw section .data, R_BSS, rw section .bss*, rw };
+"SADDRMEM":
+       place in [from 0xf'fe20 to 0xf'fedf] {
+          rw section .sdata, R_SDATA, rw section .sbss*, R_SBSS,
+          rw section .wrkseg };
+initialize by copy with simple ranges {
+   rw, R_DATA, R_BSS, R_DATAF, R_BSSF, R_SDATA, R_SBSS };
+
+No sections matched the following patterns:
+
+  R_BSS                          in "RAMNEAR"
+  R_BSSF                         in "RAMFAR"
+  R_CALLT0                       in "CALLT"
+  R_DATA                         in "RAMNEAR"
+  R_DATAF                        in "RAMFAR"
+  R_OPT_BYTE                     in block OPT_BYTE
+  R_SBSS                         in "SADDRMEM"
+  R_SDATA                        in "SADDRMEM"
+  R_SECUR_ID                     in block SECUR_ID
+  R_TEXT                         in "ROMNEAR"
+  R_TEXTF                        in "ROMHUGE"
+  R_TEXTF_UNIT64KP               in "ROMFAR"
+  ro R_CONST_init                in "MIRROR"
+  ro section .callt0             in "CALLT"
+  ro section .constf             in "ROMFAR"
+  ro section .consth             in "ROMHUGE"
+  ro section .init_array         in block INIT_ARRAY
+  ro section .init_array_tls     in block INIT_ARRAY_TLS
+  ro section .option_byte        in block OPT_BYTE
+  ro section .preinit_array      in block INIT_ARRAY
+  ro section .preinit_array_tls  in block INIT_ARRAY_TLS
+  ro section .security_id        in block SECUR_ID
+  ro section .switch             in "MIRROR"
+  ro section .switchf            in "ROMFAR"
+  ro section .textf_unit64kp     in "ROMFAR"
+  rw section .bss_unit64kp       in "RAMFAR"
+  rw section .bssf*              in "RAMFAR"
+  rw section .data_unit64kp      in "RAMFAR"
+  rw section .dataf              in "RAMFAR"
+  rw section .hbss*              in "RAMHUGE"
+  rw section .hdata              in "RAMHUGE"
+  rw section .sdata              in "SADDRMEM"
+  zi section .iar.dynexit        in "RAMNEAR"
+
+
+  Section            Kind      Address    Size  Object
+  -------            ----      -------    ----  ------
+"RESET":                                   0x2
+  .reset             const         0x0     0x2  interrupt_vector.o [27]
+                                 - 0x2     0x2
+
+"VECTOR":                                 0x7c
+  .intvec            const         0x4    0x7c  interrupt_vector.o [27]
+                                - 0x80    0x7c
+
+"A2":                                      0x4
+  OPT_BYTE                        0xc0     0x4  <Block>
+    OPTBYTE          const        0xc0     0x1  vecttbl.o [24]
+    OPTBYTE          const        0xc1     0x1  vecttbl.o [24]
+    OPTBYTE          const        0xc2     0x1  vecttbl.o [24]
+    OPTBYTE          const        0xc3     0x1  vecttbl.o [24]
+                                - 0xc4     0x4
+
+"A3":                                      0xa
+  SECUR_ID                        0xc4     0xa  <Block>
+    SECUID           const        0xc4     0xa  vecttbl.o [24]
+                                - 0xce     0xa
+
+"MIRROR":                               0x20de
+  .const             const      0x2000   0xc00  r_lamp.o [1]
+  .const             const      0x2c00   0x200  r_lamp.o [1]
+  .const             const      0x2e00   0x17a  r_lamp.o [1]
+  .const             const      0x2f7a   0x158  r_dali102_cmd.o [28]
+  .const             const      0x30d2   0x158  r_dali209_cmd.o [30]
+  .const             const      0x322a   0x158  r_dali209_cmd.o [30]
+  .const             const      0x3382   0x12e  r_nvm.o [1]
+  .const             const      0x34b0   0x10e  r_unit0_memory_bank.o [1]
+  .const             const      0x35be   0x100  r_dali102_cmd.o [28]
+  .const             const      0x36be    0xac  r_dali102_cmd.o [28]
+  .const             const      0x376a    0x80  r_dali209_cmd.o [30]
+  .const             const      0x37ea    0x7c  r_dali207_cmd.o [29]
+  .const             const      0x3866    0x70  r_dali207.o [29]
+  .const             const      0x38d6    0x56  r_dali207_cmd.o [29]
+  .const             const      0x392c    0x42  r_cg.o [1]
+  .const             const      0x396e    0x40  r_dali209_api.o [30]
+  .const             const      0x39ae    0x40  r_dali102_fade.o [28]
+  .const             const      0x39ee    0x3c  r_dali207_api.o [29]
+  .const             const      0x3a2a    0x32  r_dali209_cmd.o [30]
+  .const             const      0x3a5c    0x2e  r_debug.o [1]
+  .const             const      0x3a8a    0x2e  r_debug.o [1]
+  .const             const      0x3ab8    0x2e  r_debug.o [1]
+  .const             const      0x3ae6    0x2e  r_debug.o [1]
+  .const             const      0x3b14    0x2c  r_debug.o [1]
+  .const             const      0x3b40    0x2c  r_debug.o [1]
+  .const             const      0x3b6c    0x2c  r_debug.o [1]
+  .const             const      0x3b98    0x2c  r_debug.o [1]
+  .const             const      0x3bc4    0x2c  r_debug.o [1]
+  .const             const      0x3bf0    0x2c  r_dali102_cmd.o [28]
+  .const             const      0x3c1c    0x2a  r_debug.o [1]
+  .const             const      0x3c46    0x2a  r_debug.o [1]
+  .const             const      0x3c70    0x2a  r_debug.o [1]
+  .const             const      0x3c9a    0x2a  r_debug.o [1]
+  .const             const      0x3cc4    0x2a  r_port.o [2]
+  .const             const      0x3cee    0x28  r_cg.o [1]
+  .const             const      0x3d16    0x28  r_debug.o [1]
+  .const             const      0x3d3e    0x24  r_debug.o [1]
+  .const             const      0x3d62    0x24  r_debug.o [1]
+  .const             const      0x3d86    0x22  r_cg.o [1]
+  .const             const      0x3da8    0x22  r_cg.o [1]
+  .const             const      0x3dca    0x22  r_debug.o [1]
+  .const             const      0x3dec    0x22  r_debug.o [1]
+  .const             const      0x3e0e    0x20  r_debug.o [1]
+  .const             const      0x3e2e    0x20  r_debug.o [1]
+  .const             const      0x3e4e    0x20  r_lamp.o [1]
+  .const             const      0x3e6e    0x20  r_dali102_fade.o [28]
+  .const             const      0x3e8e    0x20  r_dali102_fade.o [28]
+  .const             const      0x3eae    0x20  r_dali207_cmd.o [29]
+  .const             const      0x3ece    0x20  r_dali209_cmd.o [30]
+  .const             const      0x3eee    0x1e  r_debug.o [1]
+  .const             const      0x3f0c    0x1e  r_debug.o [1]
+  .const             const      0x3f2a    0x1e  r_debug.o [1]
+  .const             const      0x3f48    0x1e  r_debug.o [1]
+  .const             const      0x3f66    0x1e  r_debug.o [1]
+  .const             const      0x3f84    0x1a  r_debug.o [1]
+  .const             const      0x3f9e    0x1a  r_debug.o [1]
+  .const             const      0x3fb8    0x18  r_cg.o [1]
+  .const             const      0x3fd0    0x16  r_debug.o [1]
+  .const             const      0x3fe6    0x10  r_dali102_fade.o [28]
+  .const             const      0x3ff6     0xe  r_debug.o [1]
+  .const             const      0x4004     0xa  r_cg.o [1]
+  .const             const      0x400e     0x8  r_bsp_common.o [23]
+  .const             const      0x4016     0x8  r_lamp_rgbwaf.o [1]
+  .const             const      0x401e     0x8  r_lamp_rgbwaf.o [1]
+  .const             const      0x4026     0x8  r_dali102_fade.o [28]
+  .const             const      0x402e     0x8  r_dali209.o [30]
+  .const             const      0x4036     0x8  r_dali209.o [30]
+  .const             const      0x403e     0x6  r_cg.o [1]
+  .const             const      0x4044     0x4  r_cg.o [1]
+  .const             const      0x4048     0x4  r_cg.o [1]
+  .const             const      0x404c     0x4  r_led.o [2]
+  .const             const      0x4050     0x4  r_nvm.o [1]
+  .const             const      0x4054     0x2  r_cg.o [1]
+  .const             const      0x4056     0x2  r_cg.o [1]
+  .const             const      0x4058     0x2  r_cg.o [1]
+  .const             const      0x405a     0x2  r_unit0_memory_bank.o [1]
+  .const             const      0x405c     0x1  r_dali102_cmd.o [28]
+  .const             const      0x405d     0x1  r_dali102_cmd.o [28]
+  .const             const      0x405e     0x1  r_dali102_cmd.o [28]
+  .const             const      0x405f     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4060     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4061     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4062     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4063     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4064     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4065     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4066     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4067     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4068     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4069     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406a     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406b     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406c     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406d     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406e     0x1  r_dali102_cmd.o [28]
+  .const             const      0x406f     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4070     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4071     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4072     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4073     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4074     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4075     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4076     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4077     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4078     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4079     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407a     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407b     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407c     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407d     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407e     0x1  r_dali102_cmd.o [28]
+  .const             const      0x407f     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4080     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4081     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4082     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4083     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4084     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4085     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4086     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4087     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4088     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4089     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408a     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408b     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408c     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408d     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408e     0x1  r_dali102_cmd.o [28]
+  .const             const      0x408f     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4090     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4091     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4092     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4093     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4094     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4095     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4096     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4097     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4098     0x1  r_dali102_cmd.o [28]
+  .const             const      0x4099     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409a     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409b     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409c     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409d     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409e     0x1  r_dali102_cmd.o [28]
+  .const             const      0x409f     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a0     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a1     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a2     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a3     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a4     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a5     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a6     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a7     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a8     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40a9     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40aa     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40ab     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40ac     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40ad     0x1  r_dali102_cmd.o [28]
+  .const             const      0x40ae     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40af     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b0     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b1     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b2     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b3     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b4     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b5     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b6     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b7     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b8     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40b9     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40ba     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40bb     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40bc     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40bd     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40be     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40bf     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c0     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c1     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c2     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c3     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c4     0x1  r_dali207_cmd.o [29]
+  .const             const      0x40c5     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40c6     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40c7     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40c8     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40c9     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40ca     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40cb     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40cc     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40cd     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40ce     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40cf     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d0     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d1     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d2     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d3     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d4     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d5     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d6     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d7     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d8     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40d9     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40da     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40db     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40dc     0x1  r_dali209_cmd.o [30]
+  .const             const      0x40dd     0x1  r_dali209_cmd.o [30]
+                              - 0x40de  0x20de
+
+"ROMNEAR":                              0x1218
+  .text              ro code    0x40de   0x3e2  longlong.o [27]
+  .text              ro code    0x44c0   0x38d  r_led.o [2]
+  .text              ro code    0x484d   0x26d  fadd.o [27]
+  .text              ro code    0x4aba   0x237  l03.o [27]
+  .text              ro code    0x4cf1   0x178  fdiv.o [27]
+  .text              ro code    0x4e69   0x165  fmul.o [27]
+  .text              ro code    0x4fce    0x7f  Config_DALI_user.o [2]
+  .text              ro code    0x504d    0x6b  ftol.o [27]
+  .text              ro code    0x50b8    0x69  ltof.o [27]
+  .text              ro code    0x5121    0x50  cstartup.o [23]
+  .text              ro code    0x5171    0x4d  fcmp.o [27]
+  .text              ro code    0x51be    0x39  fmex.o [27]
+  .text              ro code    0x51f7    0x30  l01.o [27]
+  .text              ro code    0x5227    0x30  l06.o [27]
+  .text              ro code    0x5257    0x28  Config_UART0_user.o [19]
+  .text              ro code    0x527f    0x23  l02.o [27]
+  .text              ro code    0x52a2    0x14  Config_TAU0_2_user.o [15]
+  .text              ro code    0x52b6    0x14  Config_TAU0_3_user.o [16]
+  .text              ro code    0x52ca    0x14  default_handler.o [27]
+  .text              ro code    0x52de    0x12  l11.o [27]
+  .text              ro code    0x52f0     0x6  cexit.o [27]
+                              - 0x52f6  0x1218
+
+"ROMFAR", part 1 of 2:                   0x1a0
+  RFD_CMN            ro code    0x52f6    0xcf  r_rfd_common_api.o [3]
+  RFD_DF             ro code    0x53c5    0x56  r_rfd_data_flash_api.o [4]
+  RFD_CMN            ro code    0x541b    0x36  r_rfd_common_control_api.o [3]
+  .iar.init_table    const      0x5452    0x24  - Linker created -
+  RFD_CMN            ro code    0x5476    0x13  r_rfd_common_userown.o [5]
+  CODE               ro code    0x548a     0xc  r_bsp_common_iar.o [23]
+                              - 0x5496   0x1a0
+
+"ROMHUGE", part 1 of 2:                 0x6475
+  .textf             ro code    0x5496  0x35a1  r_dali209_cmd.o [30]
+  .textf             ro code    0x8a37  0x2ed4  r_dali209.o [30]
+                              - 0xb90b  0x6475
+
+"ROMFAR", part 2 of 2:                    0x72
+  Initializer bytes  const      0xb90b    0x72  <for RAMNEAR-1>
+                              - 0xb97d    0x72
+
+"ROMHUGE", part 2 of 2:                 0x8fec
+  .textf             ro code  0x1'0000  0x17ca  r_dali102_cmd.o [28]
+  .textf             ro code  0x1'17ca  0x1122  r_cg.o [1]
+  .textf             ro code  0x1'28ec   0xa4f  r_nvm.o [1]
+  .textf             ro code  0x1'333b   0x92e  r_dali209_var.o [30]
+  .textf             ro code  0x1'3c69   0x883  r_lamp.o [1]
+  .textf             ro code  0x1'44ec   0x71e  xprintfsmall_nomb.o [27]
+  .textf             ro code  0x1'4c0a   0x616  r_dali209_fade.o [30]
+  .textf             ro code  0x1'5220   0x54b  r_dali207_cmd.o [29]
+  .textf             ro code  0x1'576b   0x517  r_dali102_var.o [28]
+  .textf             ro code  0x1'5c82   0x483  r_lamp_xy.o [1]
+  .textf             ro code  0x1'6105   0x445  r_dali102_api.o [28]
+  .textf             ro code  0x1'654a   0x3c5  r_memory_banks.o [1]
+  .textf             ro code  0x1'690f   0x3c0  r_dali102.o [28]
+  .textf             ro code  0x1'6ccf   0x2fb  r_lamp_rgbwaf.o [1]
+  .textf             ro code  0x1'6fca   0x23c  r_dali102_fade.o [28]
+  .textf             ro code  0x1'7206   0x238  r_dali209_api.o [30]
+  .textf             ro code  0x1'743e   0x1d1  r_debug.o [1]
+  .textf             ro code  0x1'760f   0x1ca  r_dali101_rx.o [2]
+  .textf             ro code  0x1'77d9   0x18a  r_lamp_tc.o [1]
+  .textf             ro code  0x1'7963   0x175  r_memory_bank.o [1]
+  .textf             ro code  0x1'7ad8   0x172  r_dali207_var.o [29]
+  .textf             ro code  0x1'7c4a   0x136  Config_DALI.o [2]
+  .textf             ro code  0x1'7d80   0x129  r_led.o [2]
+  .textf             ro code  0x1'7ea9    0xfb  Config_UART0.o [19]
+  .textf             ro code  0x1'7fa4    0xe1  r_dali102_mb_if.o [28]
+  .textf             ro code  0x1'8085    0xe0  r_dali207_api.o [29]
+  .textf             ro code  0x1'8165    0xc3  mcu_clocks.o [24]
+  .textf             ro code  0x1'8228    0xbf  r_random.o [1]
+  .textf             ro code  0x1'82e7    0xbc  near_packbits_single_init.o [27]
+  .textf             ro code  0x1'83a3    0xa8  r_dali102_timer.o [28]
+  .textf             ro code  0x1'844b    0xa5  Config_TKB0.o [17]
+  .textf             ro code  0x1'84f0    0xa1  Config_PORT.o [12]
+  .textf             ro code  0x1'8591    0xa0  r_dali102_dtx_if.o [28]
+  .textf             ro code  0x1'8631    0x8f  r_dali207.o [29]
+  .textf             ro code  0x1'86c0    0x8e  Config_TKB1.o [18]
+  .textf             ro code  0x1'874e    0x86  r_dali102_list.o [28]
+  .textf             ro code  0x1'87d4    0x82  Config_ADC.o [6]
+  .textf             ro code  0x1'8856    0x7f  r_dali101_bft.o [2]
+  .textf             ro code  0x1'88d5    0x65  Config_TAU0_3.o [16]
+  .textf             ro code  0x1'893a    0x61  r_led1.o [2]
+  .textf             ro code  0x1'899b    0x61  r_led2.o [2]
+  .textf             ro code  0x1'89fc    0x61  r_led3.o [2]
+  .textf             ro code  0x1'8a5d    0x5f  Config_TAU0_2.o [15]
+  .textf             ro code  0x1'8abc    0x54  Config_TAU0_1.o [14]
+  .textf             ro code  0x1'8b10    0x51  r_trng.o [2]
+  .textf             ro code  0x1'8b61    0x44  Config_COMP0.o [7]
+  .textf             ro code  0x1'8ba5    0x44  Config_COMP1.o [8]
+  .textf             ro code  0x1'8be9    0x44  Config_COMP2.o [9]
+  .textf             ro code  0x1'8c2d    0x41  data_init.o [27]
+  .textf             ro code  0x1'8c6e    0x3e  r_dali102_dt8_if.o [28]
+  .textf             ro code  0x1'8cac    0x3b  sprintf.o [27]
+  .textf             ro code  0x1'8ce7    0x3a  r_dali101.o [2]
+  .textf             ro code  0x1'8d21    0x38  Config_TAU0_0.o [13]
+  .textf             ro code  0x1'8d59    0x38  r_cg_systeminit.o [21]
+  .textf             ro code  0x1'8d91    0x37  xfail_s.o [27]
+  .textf             ro code  0x1'8dc8    0x32  r_dali102_dt6_if.o [28]
+  .textf             ro code  0x1'8dfa    0x31  r_timer16.o [25]
+  .textf             ro code  0x1'8e2b    0x25  near_zero_init.o [27]
+  .textf             ro code  0x1'8e50    0x24  memcmp.o [27]
+  .textf             ro code  0x1'8e74    0x23  Config_DAC0.o [10]
+  .textf             ro code  0x1'8e97    0x1e  Config_PGA.o [11]
+  .textf             ro code  0x1'8eb5    0x1d  r_main.o [1]
+  .textf             ro code  0x1'8ed2    0x1c  r_port.o [2]
+  .textf             ro code  0x1'8eee    0x18  r_bsp_init.o [22]
+  .textf             ro code  0x1'8f06    0x17  memchr.o [27]
+  .textf             ro code  0x1'8f1d    0x15  memset.o [27]
+  .textf             ro code  0x1'8f32    0x14  r_cg_pgacomp_common.o [21]
+  .textf             ro code  0x1'8f46    0x14  r_cg_tau_common.o [21]
+  .textf             ro code  0x1'8f5a    0x14  strchr.o [27]
+  .textf             ro code  0x1'8f6e    0x12  __dbg_xxexit.o [26]
+  .textf             ro code  0x1'8f80     0xe  Config_WDT.o [20]
+  .textf             ro code  0x1'8f8e     0xc  r_cg_tkb_common.o [21]
+  .textf             ro code  0x1'8f9a     0xc  strlen.o [27]
+  .textf             ro code  0x1'8fa6     0xc  __dbg_abort.o [26]
+  .textf             ro code  0x1'8fb2     0xb  hdwinit.o [22]
+  .textf             ro code  0x1'8fbd     0xa  xsprout.o [27]
+  .textf             ro code  0x1'8fc7     0x8  r_cg_da_common.o [21]
+  .textf             ro code  0x1'8fcf     0x8  r_cg_sau_common.o [21]
+  .textf             ro code  0x1'8fd7     0x4  exit.o [27]
+  .textf             ro code  0x1'8fdb     0x3  __dbg_break.o [26]
+  .textf             ro code  0x1'8fde     0x1  Config_COMP0_user.o [7]
+  .textf             ro code  0x1'8fdf     0x1  Config_COMP1_user.o [8]
+  .textf             ro code  0x1'8fe0     0x1  Config_COMP2_user.o [9]
+  .textf             ro code  0x1'8fe1     0x1  Config_DAC0_user.o [10]
+  .textf             ro code  0x1'8fe2     0x1  Config_DALI_user.o [2]
+  .textf             ro code  0x1'8fe3     0x1  Config_PGA_user.o [11]
+  .textf             ro code  0x1'8fe4     0x1  Config_TAU0_0_user.o [13]
+  .textf             ro code  0x1'8fe5     0x1  Config_TAU0_1_user.o [14]
+  .textf             ro code  0x1'8fe6     0x1  Config_TAU0_2_user.o [15]
+  .textf             ro code  0x1'8fe7     0x1  Config_TAU0_3_user.o [16]
+  .textf             ro code  0x1'8fe8     0x1  Config_TKB0_user.o [17]
+  .textf             ro code  0x1'8fe9     0x1  Config_TKB1_user.o [18]
+  .textf             ro code  0x1'8fea     0x1  Config_UART0_user.o [19]
+  .textf             ro code  0x1'8feb     0x1  Config_WDT_user.o [20]
+                            - 0x1'8fec  0x8fec
+
+Absolute sections, part 1 of 90:           0x3
+  .bss.noinit        uninit   0xf'0010     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'0011     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'0012     0x1  Config_ADC.o [6]
+                            - 0xf'0013     0x3
+
+Absolute sections, part 2 of 90:           0x2
+  .bss.noinit        uninit   0xf'0014     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'0015     0x1  Config_ADC.o [6]
+                            - 0xf'0016     0x2
+
+Absolute sections, part 3 of 90:           0x2
+  .bss.noinit        uninit   0xf'0019     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'001a     0x1  Config_ADC.o [6]
+                            - 0xf'001b     0x2
+
+Absolute sections, part 4 of 90:           0x2
+  .bss.noinit        uninit   0xf'0020     0x2  Config_ADC.o [6]
+                            - 0xf'0022     0x2
+
+Absolute sections, part 5 of 90:           0x2
+  .bss.noinit        uninit   0xf'0028     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'0029     0x1  Config_ADC.o [6]
+                            - 0xf'002a     0x2
+
+Absolute sections, part 6 of 90:           0x1
+  .bss.noinit        uninit   0xf'0031     0x1  Config_PORT.o [12]
+                            - 0xf'0032     0x1
+
+Absolute sections, part 7 of 90:           0x1
+  .bss.noinit        uninit   0xf'003c     0x1  Config_PORT.o [12]
+                            - 0xf'003d     0x1
+
+Absolute sections, part 8 of 90:           0x1
+  .bss.noinit        uninit   0xf'003e     0x1  Config_PORT.o [12]
+                            - 0xf'003f     0x1
+
+Absolute sections, part 9 of 90:           0x2
+  .bss.noinit        uninit   0xf'0040     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'0041     0x1  Config_PORT.o [12]
+                            - 0xf'0042     0x2
+
+Absolute sections, part 10 of 90:          0x2
+  .bss.noinit        uninit   0xf'0050     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'0051     0x1  Config_PORT.o [12]
+                            - 0xf'0052     0x2
+
+Absolute sections, part 11 of 90:          0x1
+  .bss.noinit        uninit   0xf'0053     0x1  Config_PORT.o [12]
+                            - 0xf'0054     0x1
+
+Absolute sections, part 12 of 90:          0x1
+  .bss.noinit        uninit   0xf'0055     0x1  Config_PORT.o [12]
+                            - 0xf'0056     0x1
+
+Absolute sections, part 13 of 90:          0x1
+  .bss.noinit        uninit   0xf'0057     0x1  Config_PORT.o [12]
+                            - 0xf'0058     0x1
+
+Absolute sections, part 14 of 90:          0x3
+  .bss.noinit        uninit   0xf'0060     0x1  Config_COMP1.o [8]
+  .bss.noinit        uninit   0xf'0061     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'0062     0x1  Config_ADC.o [6]
+                            - 0xf'0063     0x3
+
+Absolute sections, part 15 of 90:          0x1
+  .bss.noinit        uninit   0xf'006c     0x1  Config_COMP0.o [7]
+                            - 0xf'006d     0x1
+
+Absolute sections, part 16 of 90:          0x1
+  .bss.noinit        uninit   0xf'006e     0x1  Config_PORT.o [12]
+                            - 0xf'006f     0x1
+
+Absolute sections, part 17 of 90:          0x1
+  .bss.noinit        uninit   0xf'0070     0x1  Config_UART0.o [19]
+                            - 0xf'0071     0x1
+
+Absolute sections, part 18 of 90:          0x2
+  .bss.noinit        uninit   0xf'0077     0x1  r_bsp_init.o [22]
+  .bss.noinit        uninit   0xf'0078     0x1  hdwinit.o [22]
+                            - 0xf'0079     0x2
+
+Absolute sections, part 19 of 90:          0x1
+  .bss.noinit        uninit   0xf'007c     0x1  mcu_clocks.o [24]
+                            - 0xf'007d     0x1
+
+Absolute sections, part 20 of 90:          0x1
+  .bss.noinit        uninit   0xf'0098     0x1  mcu_clocks.o [24]
+                            - 0xf'0099     0x1
+
+Absolute sections, part 21 of 90:          0x1
+  .bss.noinit        uninit   0xf'00a8     0x1  mcu_clocks.o [24]
+                            - 0xf'00a9     0x1
+
+Absolute sections, part 22 of 90:          0x2
+  .bss.noinit        uninit   0xf'00aa     0x1  mcu_clocks.o [24]
+  .bss.noinit        uninit   0xf'00ab     0x1  mcu_clocks.o [24]
+                            - 0xf'00ac     0x2
+
+Absolute sections, part 23 of 90:          0x2
+  .bss.noinit        uninit   0xf'00f0     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'00f1     0x1  r_cg_ad_common.o [21]
+                            - 0xf'00f2     0x2
+
+Absolute sections, part 24 of 90:          0x1
+  .bss.noinit        uninit   0xf'00f3     0x1  mcu_clocks.o [24]
+                            - 0xf'00f4     0x1
+
+Absolute sections, part 25 of 90:          0x4
+  .bss.noinit        uninit   0xf'00fa     0x1  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'00fb     0x1  r_cg_da_common.o [21]
+  .bss.noinit        uninit   0xf'00fc     0x1  r_cg_tkb_common.o [21]
+  .bss.noinit        uninit   0xf'00fd     0x1  r_cg_systeminit.o [21]
+                            - 0xf'00fe     0x4
+
+Absolute sections, part 26 of 90:          0x2
+  .bss.noinit        uninit   0xf'0102     0x2  Config_UART0.o [19]
+                            - 0xf'0104     0x2
+
+Absolute sections, part 27 of 90:          0x2
+  .bss.noinit        uninit   0xf'010a     0x2  Config_UART0.o [19]
+                            - 0xf'010c     0x2
+
+Absolute sections, part 28 of 90:          0x4
+  .bss.noinit        uninit   0xf'0110     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'0112     0x2  Config_UART0.o [19]
+                            - 0xf'0114     0x4
+
+Absolute sections, part 29 of 90:          0x4
+  .bss.noinit        uninit   0xf'0118     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'011a     0x2  Config_UART0.o [19]
+                            - 0xf'011c     0x4
+
+Absolute sections, part 30 of 90:          0xa
+  .bss.noinit        uninit   0xf'0122     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'0124     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'0126     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'0128     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'012a     0x2  Config_UART0.o [19]
+                            - 0xf'012c     0xa
+
+Absolute sections, part 31 of 90:          0x2
+  .bss.noinit        uninit   0xf'0134     0x2  Config_UART0.o [19]
+                            - 0xf'0136     0x2
+
+Absolute sections, part 32 of 90:          0x8
+  .bss.noinit        uninit   0xf'0190     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'0192     0x2  Config_TAU0_1.o [14]
+  .bss.noinit        uninit   0xf'0194     0x2  Config_TAU0_2.o [15]
+  .bss.noinit        uninit   0xf'0196     0x2  Config_TAU0_3.o [16]
+                            - 0xf'0198     0x8
+
+Absolute sections, part 33 of 90:          0xe
+  .bss.noinit        uninit   0xf'01b2     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'01b4     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'01b6     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'01b8     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'01ba     0x2  Config_TAU0_0.o [13]
+  .bss.noinit        uninit   0xf'01bc     0x2  Config_TAU0_1.o [14]
+  .bss.noinit        uninit   0xf'01be     0x2  Config_TAU0_1.o [14]
+                            - 0xf'01c0     0xe
+
+Absolute sections, part 34 of 90:          0x1
+  .bss.noinit        uninit   0xf'0215     0x1  mcu_clocks.o [24]
+                            - 0xf'0216     0x1
+
+Absolute sections, part 35 of 90:          0x1
+  .bss.noinit        uninit   0xf'0219     0x1  mcu_clocks.o [24]
+                            - 0xf'021a     0x1
+
+Absolute sections, part 36 of 90:          0x1
+  .bss.noinit        uninit   0xf'02a8     0x1  Config_PORT.o [12]
+                            - 0xf'02a9     0x1
+
+Absolute sections, part 37 of 90:          0x5
+  .bss.noinit        uninit   0xf'02ad     0x1  r_bsp_init.o [22]
+  .bss.noinit        uninit   0xf'02ae     0x1  r_bsp_init.o [22]
+  .bss.noinit        uninit   0xf'02af     0x1  r_bsp_init.o [22]
+  .bss.noinit        uninit   0xf'02b0     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'02b1     0x1  Config_PORT.o [12]
+                            - 0xf'02b2     0x5
+
+Absolute sections, part 38 of 90:          0x1
+  .bss.noinit        uninit   0xf'02b3     0x1  Config_PORT.o [12]
+                            - 0xf'02b4     0x1
+
+Absolute sections, part 39 of 90:          0x1
+  .bss.noinit        uninit   0xf'02b5     0x1  Config_PORT.o [12]
+                            - 0xf'02b6     0x1
+
+Absolute sections, part 40 of 90:          0x1
+  .bss.noinit        uninit   0xf'02b7     0x1  Config_PORT.o [12]
+                            - 0xf'02b8     0x1
+
+Absolute sections, part 41 of 90:          0x1
+  .bss.noinit        uninit   0xf'02bd     0x1  Config_PORT.o [12]
+                            - 0xf'02be     0x1
+
+Absolute sections, part 42 of 90:          0x2
+  .bss.noinit        uninit   0xf'02e5     0x1  mcu_clocks.o [24]
+  .bss.noinit        uninit   0xf'02e6     0x1  mcu_clocks.o [24]
+                            - 0xf'02e7     0x2
+
+Absolute sections, part 43 of 90:          0x2
+  .bss.noinit        uninit   0xf'0330     0x1  Config_DAC0.o [10]
+  .bss.noinit        uninit   0xf'0331     0x1  Config_DAC0.o [10]
+                            - 0xf'0332     0x2
+
+Absolute sections, part 44 of 90:          0x2
+  .bss.noinit        uninit   0xf'0334     0x2  Config_DAC0.o [10]
+                            - 0xf'0336     0x2
+
+Absolute sections, part 45 of 90:          0x3
+  .bss.noinit        uninit   0xf'0340     0x1  Config_COMP0.o [7]
+  .bss.noinit        uninit   0xf'0341     0x1  Config_COMP0.o [7]
+  .bss.noinit        uninit   0xf'0342     0x1  Config_COMP0.o [7]
+                            - 0xf'0343     0x3
+
+Absolute sections, part 46 of 90:          0x5
+  .bss.noinit        uninit   0xf'0344     0x1  Config_COMP2.o [9]
+  .bss.noinit        uninit   0xf'0345     0x1  Config_COMP2.o [9]
+  .bss.noinit        uninit   0xf'0346     0x1  Config_COMP2.o [9]
+  .bss.noinit        uninit   0xf'0347     0x1  Config_PGA.o [11]
+  .bss.noinit        uninit   0xf'0348     0x1  Config_PGA.o [11]
+                            - 0xf'0349     0x5
+
+Absolute sections, part 47 of 90:          0x3
+  .bss.noinit        uninit   0xf'034a     0x1  Config_COMP0.o [7]
+  .bss.noinit        uninit   0xf'034b     0x1  Config_COMP1.o [8]
+  .bss.noinit        uninit   0xf'034c     0x1  Config_COMP2.o [9]
+                            - 0xf'034d     0x3
+
+Absolute sections, part 48 of 90:          0x1
+  .bss.noinit        uninit   0xf'0373     0x1  Config_TKB0.o [17]
+                            - 0xf'0374     0x1
+
+Absolute sections, part 49 of 90:          0x1
+  .bss.noinit        uninit   0xf'0490     0x1  Config_TKB0.o [17]
+                            - 0xf'0491     0x1
+
+Absolute sections, part 50 of 90:          0x1
+  .bss.noinit        uninit   0xf'0492     0x1  Config_TKB1.o [18]
+                            - 0xf'0493     0x1
+
+Absolute sections, part 51 of 90:          0x8
+  .bss.noinit        uninit   0xf'04c0     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04c2     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04c4     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04c6     0x2  Config_DALI.o [2]
+                            - 0xf'04c8     0x8
+
+Absolute sections, part 52 of 90:          0x8
+  .bss.noinit        uninit   0xf'04d2     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04d4     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04d6     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04d8     0x2  Config_DALI.o [2]
+                            - 0xf'04da     0x8
+
+Absolute sections, part 53 of 90:          0xa
+  .bss.noinit        uninit   0xf'04e0     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04e2     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04e4     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04e6     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04e8     0x2  Config_DALI.o [2]
+                            - 0xf'04ea     0xa
+
+Absolute sections, part 54 of 90:          0x8
+  .bss.noinit        uninit   0xf'04ee     0x2  Config_DALI_user.o [2]
+  .bss.noinit        uninit   0xf'04f0     0x2  Config_DALI_user.o [2]
+  .bss.noinit        uninit   0xf'04f2     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'04f4     0x2  Config_DALI_user.o [2]
+                            - 0xf'04f6     0x8
+
+Absolute sections, part 55 of 90:          0x2
+  .bss.noinit        uninit   0xf'04fa     0x2  Config_DALI.o [2]
+                            - 0xf'04fc     0x2
+
+Absolute sections, part 56 of 90:          0x1
+  .bss.noinit        uninit   0xf'0540     0x1  r_trng.o [2]
+                            - 0xf'0541     0x1
+
+Absolute sections, part 57 of 90:          0x1
+  .bss.noinit        uninit   0xf'0542     0x1  r_trng.o [2]
+                            - 0xf'0543     0x1
+
+Absolute sections, part 58 of 90:          0xa
+  .bss.noinit        uninit   0xf'0740     0x2  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0742     0x2  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0744     0x2  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0746     0x2  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0748     0x2  Config_TKB0.o [17]
+                            - 0xf'074a     0xa
+
+Absolute sections, part 59 of 90:          0x1
+  .bss.noinit        uninit   0xf'074e     0x1  Config_TKB0.o [17]
+                            - 0xf'074f     0x1
+
+Absolute sections, part 60 of 90:          0x1
+  .bss.noinit        uninit   0xf'0750     0x1  Config_TKB0.o [17]
+                            - 0xf'0751     0x1
+
+Absolute sections, part 61 of 90:          0x1
+  .bss.noinit        uninit   0xf'0752     0x1  Config_TKB0.o [17]
+                            - 0xf'0753     0x1
+
+Absolute sections, part 62 of 90:          0x4
+  .bss.noinit        uninit   0xf'0754     0x2  r_led.o [2]
+  .bss.noinit        uninit   0xf'0756     0x2  r_led.o [2]
+                            - 0xf'0758     0x4
+
+Absolute sections, part 63 of 90:          0x2
+  .bss.noinit        uninit   0xf'0762     0x2  Config_TKB0.o [17]
+                            - 0xf'0764     0x2
+
+Absolute sections, part 64 of 90:          0x1
+  .bss.noinit        uninit   0xf'0766     0x1  Config_TKB0.o [17]
+                            - 0xf'0767     0x1
+
+Absolute sections, part 65 of 90:          0x2
+  .bss.noinit        uninit   0xf'0768     0x1  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0769     0x1  Config_TKB0.o [17]
+                            - 0xf'076a     0x2
+
+Absolute sections, part 66 of 90:          0x4
+  .bss.noinit        uninit   0xf'0770     0x2  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0772     0x2  Config_TKB0.o [17]
+                            - 0xf'0774     0x4
+
+Absolute sections, part 67 of 90:          0x4
+  .bss.noinit        uninit   0xf'0776     0x1  r_led1.o [2]
+  .bss.noinit        uninit   0xf'0777     0x1  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0778     0x1  Config_TKB0.o [17]
+  .bss.noinit        uninit   0xf'0779     0x1  Config_TKB0.o [17]
+                            - 0xf'077a     0x4
+
+Absolute sections, part 68 of 90:          0xa
+  .bss.noinit        uninit   0xf'0780     0x2  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'0782     0x2  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'0784     0x2  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'0786     0x2  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'0788     0x2  Config_TKB1.o [18]
+                            - 0xf'078a     0xa
+
+Absolute sections, part 69 of 90:          0x1
+  .bss.noinit        uninit   0xf'078e     0x1  Config_TKB1.o [18]
+                            - 0xf'078f     0x1
+
+Absolute sections, part 70 of 90:          0x1
+  .bss.noinit        uninit   0xf'0792     0x1  Config_TKB1.o [18]
+                            - 0xf'0793     0x1
+
+Absolute sections, part 71 of 90:          0x2
+  .bss.noinit        uninit   0xf'0794     0x2  r_led.o [2]
+                            - 0xf'0796     0x2
+
+Absolute sections, part 72 of 90:          0x2
+  .bss.noinit        uninit   0xf'07a2     0x2  Config_TKB1.o [18]
+                            - 0xf'07a4     0x2
+
+Absolute sections, part 73 of 90:          0x1
+  .bss.noinit        uninit   0xf'07a6     0x1  Config_TKB1.o [18]
+                            - 0xf'07a7     0x1
+
+Absolute sections, part 74 of 90:          0x2
+  .bss.noinit        uninit   0xf'07a8     0x1  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'07a9     0x1  Config_TKB1.o [18]
+                            - 0xf'07aa     0x2
+
+Absolute sections, part 75 of 90:          0x2
+  .bss.noinit        uninit   0xf'07b0     0x2  Config_TKB1.o [18]
+                            - 0xf'07b2     0x2
+
+Absolute sections, part 76 of 90:          0x4
+  .bss.noinit        uninit   0xf'07b6     0x1  r_led3.o [2]
+  .bss.noinit        uninit   0xf'07b7     0x1  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'07b8     0x1  Config_TKB1.o [18]
+  .bss.noinit        uninit   0xf'07b9     0x1  Config_TKB1.o [18]
+                            - 0xf'07ba     0x4
+
+"RAMNEAR", part 1 of 2:                  0x526
+  RAMNEAR-1                   0xf'cf00   0x325  <Init block>
+    .data            inited   0xf'cf00   0x2ca  r_cg.o [1]
+    .data            inited   0xf'd1ca     0xa  r_led.o [2]
+    .data            inited   0xf'd1d4     0x4  r_led1.o [2]
+    .data            inited   0xf'd1d8     0x4  r_led2.o [2]
+    .data            inited   0xf'd1dc     0x4  r_led3.o [2]
+    .data            inited   0xf'd1e0     0x6  xprintfsmall_nomb.o [27]
+    .data            inited   0xf'd1e6    0x1a  xprintfsmall_nomb.o [27]
+    .data            inited   0xf'd200    0x20  xfail_s.o [27]
+    .data            inited   0xf'd220     0x1  xprintfsmall_nomb.o [27]
+    RFD_DATA         inited   0xf'd221     0x3  r_rfd_common_api.o [3]
+    RFD_DATA         inited   0xf'd224     0x1  r_rfd_common_userown.o [5]
+  CSTACK                      0xf'd226   0x200  <Block>
+    CSTACK           rw data  0xf'd226     0x0  cstartup.o [23]
+    CSTACK           uninit   0xf'd226   0x200  <Block tail>
+                            - 0xf'd426   0x526
+
+"RAMNEAR", part 2 of 2:                  0x392
+  .bss               zero     0xf'd426   0x106  r_nvm.o [1]
+  .bss               zero     0xf'd52c   0x100  r_cg.o [1]
+  .bss               zero     0xf'd62c    0xd4  r_cg.o [1]
+  .bss               zero     0xf'd700    0x1c  r_nvm.o [1]
+  .bss               zero     0xf'd71c    0x18  r_cg.o [1]
+  .bss               zero     0xf'd734    0x18  r_lamp.o [1]
+  .bss               zero     0xf'd74c    0x14  r_dali101_rx.o [2]
+  .bss               zero     0xf'd760     0xc  r_cg.o [1]
+  .bss               zero     0xf'd76c     0xc  r_nvm.o [1]
+  .bss               zero     0xf'd778     0xa  r_dali101_rx.o [2]
+  .bss               zero     0xf'd782     0x6  Config_DALI.o [2]
+  .bss               zero     0xf'd788     0x6  r_debug.o [1]
+  .bss               zero     0xf'd78e     0x6  r_lamp_rgbwaf.o [1]
+  .bss               zero     0xf'd794     0x6  r_lamp_xy.o [1]
+  .bss               zero     0xf'd79a     0x4  Config_UART0.o [19]
+  .bss               zero     0xf'd79e     0x4  r_cg.o [1]
+  .bss               zero     0xf'd7a2     0x4  r_dali101_bft.o [2]
+  .bss               zero     0xf'd7a6     0x4  r_lamp_tc.o [1]
+  .bss               zero     0xf'd7aa     0x4  r_random.o [1]
+  .bss               zero     0xf'd7ae     0x4  xfail_s.o [27]
+  .bss               zero     0xf'd7b2     0x2  r_dali102.o [28]
+  .bss               zero     0xf'd7b4     0x2  r_dali102_mb_if.o [28]
+  .bss               zero     0xf'd7b6     0x2  r_dali209.o [30]
+                            - 0xf'd7b8   0x392
+
+"SADDRMEM", part 1 of 2:                   0x4
+  .wrkseg                     0xf'fe20     0x4  <Block>
+    .wrkseg          rw data  0xf'fe20     0x0  cstartup.o [23]
+    .wrkseg          zero     0xf'fe20     0x4  l09.o [27]
+                            - 0xf'fe24     0x4
+
+"SADDRMEM", part 2 of 2:                  0x3e
+  .sbss              zero     0xf'fe24     0x4  r_led1.o [2]
+  .sbss              zero     0xf'fe28     0x4  r_led1.o [2]
+  .sbss              zero     0xf'fe2c     0x4  r_led2.o [2]
+  .sbss              zero     0xf'fe30     0x4  r_led2.o [2]
+  .sbss              zero     0xf'fe34     0x4  r_led3.o [2]
+  .sbss              zero     0xf'fe38     0x4  r_led3.o [2]
+  .sbss              zero     0xf'fe3c     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe3e     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe40     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe42     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe44     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe46     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe48     0x2  r_led.o [2]
+  .sbss              zero     0xf'fe4a     0x2  r_led1.o [2]
+  .sbss              zero     0xf'fe4c     0x2  r_led1.o [2]
+  .sbss              zero     0xf'fe4e     0x2  r_led1.o [2]
+  .sbss              zero     0xf'fe50     0x2  r_led1.o [2]
+  .sbss              zero     0xf'fe52     0x2  r_led2.o [2]
+  .sbss              zero     0xf'fe54     0x2  r_led2.o [2]
+  .sbss              zero     0xf'fe56     0x2  r_led2.o [2]
+  .sbss              zero     0xf'fe58     0x2  r_led2.o [2]
+  .sbss              zero     0xf'fe5a     0x2  r_led3.o [2]
+  .sbss              zero     0xf'fe5c     0x2  r_led3.o [2]
+  .sbss              zero     0xf'fe5e     0x2  r_led3.o [2]
+  .sbss              zero     0xf'fe60     0x2  r_led3.o [2]
+                            - 0xf'fe62    0x3e
+
+Absolute sections, part 77 of 90:          0x8
+  .sbss.noinit       uninit   0xf'ff00     0x1  Config_DALI.o [2]
+  .sbss.noinit       uninit   0xf'ff01     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff02     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff03     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff04     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff05     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff06     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff07     0x1  Config_PORT.o [12]
+                            - 0xf'ff08     0x8
+
+Absolute sections, part 78 of 90:          0x3
+  .sbss.noinit       uninit   0xf'ff0c     0x1  r_port.o [2]
+  .sbss.noinit       uninit   0xf'ff0d     0x1  Config_PORT.o [12]
+  .sbss.noinit       uninit   0xf'ff0e     0x1  Config_PORT.o [12]
+                            - 0xf'ff0f     0x3
+
+Absolute sections, part 79 of 90:          0x4
+  .sbss.noinit       uninit   0xf'ff10     0x2  Config_UART0.o [19]
+  .sbss.noinit       uninit   0xf'ff12     0x2  Config_UART0.o [19]
+                            - 0xf'ff14     0x4
+
+Absolute sections, part 80 of 90:          0x4
+  .sbss.noinit       uninit   0xf'ff18     0x2  Config_TAU0_0.o [13]
+  .sbss.noinit       uninit   0xf'ff1a     0x2  Config_TAU0_1.o [14]
+                            - 0xf'ff1c     0x4
+
+Absolute sections, part 81 of 90:          0x8
+  .bss.noinit        uninit   0xf'ff20     0x1  Config_COMP1.o [8]
+  .bss.noinit        uninit   0xf'ff21     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'ff22     0x1  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ff23     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'ff24     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'ff25     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'ff26     0x1  Config_PORT.o [12]
+  .bss.noinit        uninit   0xf'ff27     0x1  Config_PORT.o [12]
+                            - 0xf'ff28     0x8
+
+Absolute sections, part 82 of 90:          0x1
+  .bss.noinit        uninit   0xf'ff2c     0x1  Config_COMP0.o [7]
+                            - 0xf'ff2d     0x1
+
+Absolute sections, part 83 of 90:          0x1
+  .bss.noinit        uninit   0xf'ff2e     0x1  Config_PORT.o [12]
+                            - 0xf'ff2f     0x1
+
+Absolute sections, part 84 of 90:          0x1
+  .bss.noinit        uninit   0xf'ff30     0x1  Config_ADC.o [6]
+                            - 0xf'ff31     0x1
+
+Absolute sections, part 85 of 90:          0x1
+  .bss.noinit        uninit   0xf'ff32     0x1  Config_ADC.o [6]
+                            - 0xf'ff33     0x1
+
+Absolute sections, part 86 of 90:          0x4
+  .bss.noinit        uninit   0xf'ff64     0x2  Config_TAU0_2.o [15]
+  .bss.noinit        uninit   0xf'ff66     0x2  Config_TAU0_3.o [16]
+                            - 0xf'ff68     0x4
+
+Absolute sections, part 87 of 90:          0x2
+  .bss.noinit        uninit   0xf'ffa0     0x1  mcu_clocks.o [24]
+  .bss.noinit        uninit   0xf'ffa1     0x1  mcu_clocks.o [24]
+                            - 0xf'ffa2     0x2
+
+Absolute sections, part 88 of 90:          0x1
+  .bss.noinit        uninit   0xf'ffa4     0x1  mcu_clocks.o [24]
+                            - 0xf'ffa5     0x1
+
+Absolute sections, part 89 of 90:          0x1
+  .bss.noinit        uninit   0xf'ffab     0x1  Config_WDT.o [20]
+                            - 0xf'ffac     0x1
+
+Absolute sections, part 90 of 90:         0x20
+  .bss.noinit        uninit   0xf'ffd0     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffd2     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffd4     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffd6     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffd8     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffda     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffdc     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffde     0x2  Config_DALI.o [2]
+  .bss.noinit        uninit   0xf'ffe0     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffe2     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffe4     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffe6     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffe8     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'ffea     0x2  Config_ADC.o [6]
+  .bss.noinit        uninit   0xf'ffec     0x2  Config_UART0.o [19]
+  .bss.noinit        uninit   0xf'ffee     0x2  Config_ADC.o [6]
+                            - 0xf'fff0    0x20
+
+Unused ranges:
+
+      From        To    Size
+      ----        --    ----
+      0xd8    0x1fff  0x1f28
+    0xb97d    0xffff  0x4683
+  0x1'8fec  0x1'ffff  0x7014
+  0xf'd7b8  0xf'fe1f  0x2668
+  0xf'fe62  0xf'fedf    0x7e
+
+
+*******************************************************************************
+*** INIT TABLE
+***
+
+          Address   Size
+          -------   ----
+Zero (___iar_zero_init_near2)
+    3 destination ranges, total size 0x3d4:
+          0xf'd426  0x392
+          0xf'fe20    0x4
+          0xf'fe24   0x3e
+
+Copy/packbits (___iar_packbits_init_near_single2)
+    1 source range, total size 0x72 (14% of destination):
+            0xb90b   0x72
+    1 destination range, total size 0x325:
+          0xf'cf00  0x325
+
+
+
+*******************************************************************************
+*** MODULE SUMMARY
+***
+
+    Module                       ro code  ro data  rw data  rw data
+                                                             (abs)
+    ------                       -------  -------  -------  -------
+command line/config:
+    ---------------------------------------------------------------
+    Total:
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App: [1]
+    r_cg.o                         4'386      329    1'222
+    r_debug.o                        465    1'054        6
+    r_lamp.o                       2'179    3'994       24
+    r_lamp_rgbwaf.o                  763       16        6
+    r_lamp_tc.o                      394                 4
+    r_lamp_xy.o                    1'155                 6
+    r_main.o                          29
+    r_memory_bank.o                  373
+    r_memory_banks.o                 965
+    r_nvm.o                        2'639      306      302
+    r_random.o                       191                 4
+    r_unit0_memory_bank.o                     272
+    ---------------------------------------------------------------
+    Total:                        13'539    5'971    1'574
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver: [2]
+    Config_DALI.o                    310                 6       44
+    Config_DALI_user.o               128                          6
+    r_dali101.o                       58
+    r_dali101_bft.o                  127                 4
+    r_dali101_rx.o                   458                30
+    r_led.o                        1'206        5       24        6
+    r_led1.o                          97        1       20        1
+    r_led2.o                          97                20
+    r_led3.o                          97        1       20        1
+    r_port.o                          28       42                 1
+    r_trng.o                          81                          2
+    ---------------------------------------------------------------
+    Total:                         2'687       49      124       61
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common: [3]
+    r_rfd_common_api.o               207                 3
+    r_rfd_common_control_api.o        54
+    ---------------------------------------------------------------
+    Total:                           261                 3
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash: [4]
+    r_rfd_data_flash_api.o            86
+    ---------------------------------------------------------------
+    Total:                            86
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown: [5]
+    r_rfd_common_userown.o            19        1        1
+    ---------------------------------------------------------------
+    Total:                            19        1        1
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC: [6]
+    Config_ADC.o                     130                         32
+    ---------------------------------------------------------------
+    Total:                           130                         32
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0: [7]
+    Config_COMP0.o                    68                          6
+    Config_COMP0_user.o                1
+    ---------------------------------------------------------------
+    Total:                            69                          6
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1: [8]
+    Config_COMP1.o                    68                          3
+    Config_COMP1_user.o                1
+    ---------------------------------------------------------------
+    Total:                            69                          3
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2: [9]
+    Config_COMP2.o                    68                          4
+    Config_COMP2_user.o                1
+    ---------------------------------------------------------------
+    Total:                            69                          4
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0: [10]
+    Config_DAC0.o                     35                          4
+    Config_DAC0_user.o                 1
+    ---------------------------------------------------------------
+    Total:                            36                          4
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA: [11]
+    Config_PGA.o                      30                          2
+    Config_PGA_user.o                  1
+    ---------------------------------------------------------------
+    Total:                            31                          2
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT: [12]
+    Config_PORT.o                    161                         35
+    ---------------------------------------------------------------
+    Total:                           161                         35
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0: [13]
+    Config_TAU0_0.o                   56                         14
+    Config_TAU0_0_user.o               1
+    ---------------------------------------------------------------
+    Total:                            57                         14
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1: [14]
+    Config_TAU0_1.o                   84                          8
+    Config_TAU0_1_user.o               1
+    ---------------------------------------------------------------
+    Total:                            85                          8
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2: [15]
+    Config_TAU0_2.o                   95                          4
+    Config_TAU0_2_user.o              21
+    ---------------------------------------------------------------
+    Total:                           116                          4
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3: [16]
+    Config_TAU0_3.o                  101                          4
+    Config_TAU0_3_user.o              21
+    ---------------------------------------------------------------
+    Total:                           122                          4
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0: [17]
+    Config_TKB0.o                    165                         27
+    Config_TKB0_user.o                 1
+    ---------------------------------------------------------------
+    Total:                           166                         27
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1: [18]
+    Config_TKB1.o                    142                         23
+    Config_TKB1_user.o                 1
+    ---------------------------------------------------------------
+    Total:                           143                         23
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0: [19]
+    Config_UART0.o                   251                 4       33
+    Config_UART0_user.o               41
+    ---------------------------------------------------------------
+    Total:                           292                 4       33
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT: [20]
+    Config_WDT.o                      14                          1
+    Config_WDT_user.o                  1
+    ---------------------------------------------------------------
+    Total:                            15                          1
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general: [21]
+    r_cg_ad_common.o                                              1
+    r_cg_da_common.o                   8                          1
+    r_cg_pgacomp_common.o             20
+    r_cg_sau_common.o                  8
+    r_cg_systeminit.o                 56                          1
+    r_cg_tau_common.o                 20
+    r_cg_tkb_common.o                 12                          1
+    ---------------------------------------------------------------
+    Total:                           124                          4
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24: [22]
+    hdwinit.o                         11                          1
+    r_bsp_init.o                      24                          4
+    ---------------------------------------------------------------
+    Total:                            35                          5
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all: [23]
+    cstartup.o                        80
+    r_bsp_common.o                              8
+    r_bsp_common_iar.o                12
+    ---------------------------------------------------------------
+    Total:                            92        8
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24: [24]
+    mcu_clocks.o                     195                         13
+    vecttbl.o                                  14
+    ---------------------------------------------------------------
+    Total:                           195       14                13
+
+C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility: [25]
+    r_timer16.o                       49
+    ---------------------------------------------------------------
+    Total:                            49
+
+dbgrlfnf23nd.a: [26]
+    __dbg_abort.o                     12
+    __dbg_break.o                      3
+    __dbg_xxexit.o                    18
+    ---------------------------------------------------------------
+    Total:                            33
+
+dlrlfnf23n.a: [27]
+    cexit.o                            6
+    data_init.o                       65
+    default_handler.o                 20
+    exit.o                             4
+    fadd.o                           621
+    fcmp.o                            77
+    fdiv.o                           376
+    fmex.o                            57
+    fmul.o                           357
+    ftol.o                           107
+    interrupt_vector.o                        126
+    l01.o                             48
+    l02.o                             35
+    l03.o                            567
+    l06.o                             48
+    l09.o                                                4
+    l11.o                             18
+    longlong.o                       994
+    ltof.o                           105
+    memchr.o                          23
+    memcmp.o                          36
+    memset.o                          21
+    near_packbits_single_init.o      188
+    near_zero_init.o                  37
+    sprintf.o                         59
+    strchr.o                          20
+    strlen.o                          12
+    xfail_s.o                         55        5       36
+    xprintfsmall_nomb.o            1'822        4       33
+    xsprout.o                         10
+    ---------------------------------------------------------------
+    Total:                         5'788      135       73
+
+r_dali_102_iar_gen2_v1_01.a: [28]
+    r_dali102.o                      960                 2
+    r_dali102_api.o                1'093
+    r_dali102_cmd.o                6'090      898
+    r_dali102_dt6_if.o                50
+    r_dali102_dt8_if.o                62
+    r_dali102_dtx_if.o               160
+    r_dali102_fade.o                 572      152
+    r_dali102_list.o                 134
+    r_dali102_mb_if.o                225                 2
+    r_dali102_timer.o                168
+    r_dali102_var.o                1'303
+    ---------------------------------------------------------------
+    Total:                        10'817    1'050        4
+
+r_dali_207_iar_gen2_v1_01.a: [29]
+    r_dali207.o                      143      112
+    r_dali207_api.o                  224       60
+    r_dali207_cmd.o                1'355      265
+    r_dali207_var.o                  370
+    ---------------------------------------------------------------
+    Total:                         2'092      437
+
+r_dali_209_iar_gen2_v2_00.a: [30]
+    r_dali209.o                   11'988       16        2
+    r_dali209_api.o                  568       64
+    r_dali209_cmd.o               13'729      923
+    r_dali209_fade.o               1'558
+    r_dali209_var.o                2'350
+    ---------------------------------------------------------------
+    Total:                        30'193    1'003        2
+
+    Gaps                               1        1
+    Linker created                             36      512
+-------------------------------------------------------------------
+    Grand Total:                  67'572    8'705    2'297      283
+
+
+*******************************************************************************
+*** ENTRY LIST
+***
+
+Entry                    Address   Size  Type      Object
+-----                    -------   ----  ----      ------
+.iar.init_table$$Base     0x5452          --   Gb  - Linker created -
+.iar.init_table$$Limit    0x5476          --   Gb  - Linker created -
+.wrkseg$$Base           0xf'fe20          --   Gb  - Linker created -
+.wrkseg$$Limit          0xf'fe24          --   Gb  - Linker created -
+?C_LSH_L01                0x51f7         Code  Gb  l01.o [27]
+?DIVUW_L01                0x5217         Code  Gb  l01.o [27]
+?Div64_int                0x41ae         Code  Gb  longlong.o [27]
+?FCMP_LT                  0x5171         Code  Gb  fcmp.o [27]
+?F_ADD                    0x488e         Code  Gb  fadd.o [27]
+?F_DIV                    0x4d5a         Code  Gb  fdiv.o [27]
+?F_F2SL                   0x504d         Code  Gb  ftol.o [27]
+?F_F2UL                   0x504d         Code  Gb  ftol.o [27]
+?F_MUL                    0x4edf         Code  Gb  fmul.o [27]
+?F_SL2F                   0x50b8         Code  Gb  ltof.o [27]
+?F_SUB                    0x49af         Code  Gb  fadd.o [27]
+?F_UL2F                   0x50cc         Code  Gb  ltof.o [27]
+?I_LSH_L02                0x527f         Code  Gb  l02.o [27]
+?L2LL_RET                 0x40fe         Code  Gb  longlong.o [27]
+?LONG_DIV_L03             0x4c68         Code  Gb  l03.o [27]
+?LONG_LOAD_DIV_MOD_L03    0x4c32         Code  Gb  l03.o [27]
+?LONG_NEGATE2_DIV_MOD_L03
+                          0x4c53         Code  Gb  l03.o [27]
+?LONG_NEGATE_DIV_MOD_L03
+                          0x4c42         Code  Gb  l03.o [27]
+?L_AND_L03                0x4b73         Code  Gb  l03.o [27]
+?L_IOR_L03                0x4b4a         Code  Gb  l03.o [27]
+?L_MUL_FAST_L03           0x4aba         Code  Gb  l03.o [27]
+?L_NEG_L03                0x4c19         Code  Gb  l03.o [27]
+?L_SUB_L03                0x4b21         Code  Gb  l03.o [27]
+?L_XOR_L03                0x4b9c         Code  Gb  l03.o [27]
+?MEMCPY_NEAR              0x52e4         Code  Gb  l11.o [27]
+?MEMCPY_SMALL_NEAR        0x52e8         Code  Gb  l11.o [27]
+?MOVE_LONG_L06            0x5227         Code  Gb  l06.o [27]
+?SI_CMP_L02               0x5296         Code  Gb  l02.o [27]
+?SL_CMP_L03               0x4bc5         Code  Gb  l03.o [27]
+?SL_DIV_L03               0x4add         Code  Gb  l03.o [27]
+?UC_DIV_L01               0x5201         Code  Gb  l01.o [27]
+?UC_DIV_MOD               0x520e         Code  Gb  l01.o [27]
+?UI_RSH_L02               0x528a         Code  Gb  l02.o [27]
+?UL_CMP_L03               0x4bfa         Code  Gb  l03.o [27]
+?WRKSEG_START           0xf'fe20         Data  Gb  l09.o [27]
+?_0mods                   0x4342         Code  Gb  longlong.o [27]
+@cend                     0x5171         Code  Gb  cstartup.o [23]
+@cstart                   0x5121         Code  Gb  cstartup.o [23]
+CSTACK$$Base            0xf'd226          --   Gb  - Linker created -
+CSTACK$$Limit           0xf'd426          --   Gb  - Linker created -
+OPT_BYTE$$Base              0xc0          --   Gb  - Linker created -
+OPT_BYTE$$Limit             0xc4          --   Gb  - Linker created -
+R_DALI102_FADE_GetExFadeTimeMs::extended_fade_time_base
+                        0xf'3fe6   0x10  Data  Lc  r_dali102_fade.o [28]
+R_DALI102_FADE_GetExFadeTimeMs::extended_fade_time_multiplier
+                        0xf'3e8e   0x20  Data  Lc  r_dali102_fade.o [28]
+R_DALI102_FADE_GetFadeTimeMs::fade_time_ms
+                        0xf'39ae   0x40  Data  Lc  r_dali102_fade.o [28]
+R_DALI102_FADE_GetRelativeLevel::fade_rate_steps_per_200ms
+                        0xf'3e6e   0x20  Data  Lc  r_dali102_fade.o [28]
+R_LED_Init::feedback_led
+                        0xf'404c    0x4  Data  Lc  r_led.o [2]
+Region$$Table$$Base       0x5452          --   Gb  - Linker created -
+Region$$Table$$Limit      0x5476          --   Gb  - Linker created -
+SECUR_ID$$Base              0xc4          --   Gb  - Linker created -
+SECUR_ID$$Limit             0xce          --   Gb  - Linker created -
+_A1                     0xf'd1cc    0x4  Data  Gb  r_led.o [2]
+_A2                     0xf'd1d0    0x4  Data  Gb  r_led.o [2]
+_ExitBin64                0x4103         Code  Gb  longlong.o [27]
+_ExitLsr64                0x440f         Code  Gb  longlong.o [27]
+_LoadInt                0x1'4957   0x8b  Code  Lc  xprintfsmall_nomb.o [27]
+_NEAR_CONST_LOCATION {Abs}
+                             0x0         Data  Gb  <internal module>
+_R_CG_Init              0x1'17ca   0xd9  Code  Gb  r_cg.o [1]
+_R_CG_Load              0x1'18a3  0x4e6  Code  Gb  r_cg.o [1]
+_R_CG_Start             0x1'1d89   0x2e  Code  Gb  r_cg.o [1]
+_R_CG_Task              0x1'1db7  0x59e  Code  Gb  r_cg.o [1]
+_R_Config_ADC_Create    0x1'87d4   0x82  Code  Gb  Config_ADC.o [6]
+_R_Config_COMP0_Create  0x1'8b61   0x2d  Code  Gb  Config_COMP0.o [7]
+_R_Config_COMP0_Create_UserInit
+                        0x1'8fde    0x1  Code  Gb  Config_COMP0_user.o [7]
+_R_Config_COMP0_Start   0x1'8b8e   0x17  Code  Gb  Config_COMP0.o [7]
+_R_Config_COMP1_Create  0x1'8ba5   0x2d  Code  Gb  Config_COMP1.o [8]
+_R_Config_COMP1_Create_UserInit
+                        0x1'8fdf    0x1  Code  Gb  Config_COMP1_user.o [8]
+_R_Config_COMP1_Start   0x1'8bd2   0x17  Code  Gb  Config_COMP1.o [8]
+_R_Config_COMP2_Create  0x1'8be9   0x2d  Code  Gb  Config_COMP2.o [9]
+_R_Config_COMP2_Create_UserInit
+                        0x1'8fe0    0x1  Code  Gb  Config_COMP2_user.o [9]
+_R_Config_COMP2_Start   0x1'8c16   0x17  Code  Gb  Config_COMP2.o [9]
+_R_Config_DAC0_Create   0x1'8e74   0x1e  Code  Gb  Config_DAC0.o [10]
+_R_Config_DAC0_Create_UserInit
+                        0x1'8fe1    0x1  Code  Gb  Config_DAC0_user.o [10]
+_R_Config_DAC0_Start    0x1'8e92    0x5  Code  Gb  Config_DAC0.o [10]
+_R_Config_DALI_BPD_ISR  0x1'767a   0x12  Code  Gb  r_dali101_rx.o [2]
+_R_Config_DALI_Create   0x1'7c4a   0x92  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_Create_UserInit
+                        0x1'8fe2    0x1  Code  Gb  Config_DALI_user.o [2]
+_R_Config_DALI_DisableForceActiveState
+                        0x1'7d7b    0x5  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_EnableForceActiveState
+                        0x1'7d74    0x7  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_FED_ISR  0x1'765e   0x1c  Code  Gb  r_dali101_rx.o [2]
+_R_Config_DALI_GetReceivedFrame
+                        0x1'7d3a   0x2f  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_IsBusPowerDown
+                        0x1'7d69    0xb  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_SDD_ISR  0x1'768c   0x11  Code  Gb  r_dali101_rx.o [2]
+_R_Config_DALI_Send8bit
+                        0x1'7d08   0x32  Code  Gb  Config_DALI.o [2]
+_R_Config_DALI_Start    0x1'7cdc   0x2c  Code  Gb  Config_DALI.o [2]
+_R_Config_PGA_Create    0x1'8e97   0x1e  Code  Gb  Config_PGA.o [11]
+_R_Config_PGA_Create_UserInit
+                        0x1'8fe3    0x1  Code  Gb  Config_PGA_user.o [11]
+_R_Config_PORT_Create   0x1'84f0   0xa1  Code  Gb  Config_PORT.o [12]
+_R_Config_TAU0_0_Create
+                        0x1'8d21   0x29  Code  Gb  Config_TAU0_0.o [13]
+_R_Config_TAU0_0_Create_UserInit
+                        0x1'8fe4    0x1  Code  Gb  Config_TAU0_0_user.o [13]
+_R_Config_TAU0_0_Expires
+                        0x1'8d4f    0xa  Code  Gb  Config_TAU0_0.o [13]
+_R_Config_TAU0_0_Start  0x1'8d4a    0x5  Code  Gb  Config_TAU0_0.o [13]
+_R_Config_TAU0_1_Create
+                        0x1'8abc   0x49  Code  Gb  Config_TAU0_1.o [14]
+_R_Config_TAU0_1_Create_UserInit
+                        0x1'8fe5    0x1  Code  Gb  Config_TAU0_1_user.o [14]
+_R_Config_TAU0_1_Start  0x1'8b05    0xb  Code  Gb  Config_TAU0_1.o [14]
+_R_Config_TAU0_2_Create
+                        0x1'8a5d   0x49  Code  Gb  Config_TAU0_2.o [15]
+_R_Config_TAU0_2_Create_UserInit
+                        0x1'8fe6    0x1  Code  Gb  Config_TAU0_2_user.o [15]
+_R_Config_TAU0_2_Isr    0x1'760f   0x4f  Code  Gb  r_dali101_rx.o [2]
+_R_Config_TAU0_2_Start  0x1'8aa6    0xb  Code  Gb  Config_TAU0_2.o [15]
+_R_Config_TAU0_2_Stop   0x1'8ab1    0xb  Code  Gb  Config_TAU0_2.o [15]
+_R_Config_TAU0_3_Create
+                        0x1'88d5   0x4f  Code  Gb  Config_TAU0_3.o [16]
+_R_Config_TAU0_3_Create_UserInit
+                        0x1'8fe7    0x1  Code  Gb  Config_TAU0_3_user.o [16]
+_R_Config_TAU0_3_Isr    0x1'8856    0x8  Code  Gb  r_dali101_bft.o [2]
+_R_Config_TAU0_3_Start  0x1'8924    0xb  Code  Gb  Config_TAU0_3.o [16]
+_R_Config_TAU0_3_Stop   0x1'892f    0xb  Code  Gb  Config_TAU0_3.o [16]
+_R_Config_TKB0_Create   0x1'844b   0x97  Code  Gb  Config_TKB0.o [17]
+_R_Config_TKB0_Create_UserInit
+                        0x1'8fe8    0x1  Code  Gb  Config_TKB0_user.o [17]
+_R_Config_TKB0_Set_BatchOverwriteRequestOn
+                        0x1'84eb    0x5  Code  Gb  Config_TKB0.o [17]
+_R_Config_TKB0_Start    0x1'84e2    0x9  Code  Gb  Config_TKB0.o [17]
+_R_Config_TKB1_Create   0x1'86c0   0x80  Code  Gb  Config_TKB1.o [18]
+_R_Config_TKB1_Create_UserInit
+                        0x1'8fe9    0x1  Code  Gb  Config_TKB1_user.o [18]
+_R_Config_TKB1_Set_BatchOverwriteRequestOn
+                        0x1'8749    0x5  Code  Gb  Config_TKB1.o [18]
+_R_Config_TKB1_Start    0x1'8740    0x9  Code  Gb  Config_TKB1.o [18]
+_R_Config_UART0_Create  0x1'7ea9   0x83  Code  Gb  Config_UART0.o [19]
+_R_Config_UART0_Create_UserInit
+                        0x1'8fea    0x1  Code  Gb  Config_UART0_user.o [19]
+_R_Config_UART0_IsSending
+                        0x1'7f9a    0xa  Code  Gb  Config_UART0.o [19]
+_R_Config_UART0_Receive
+                        0x1'7f7f   0x1b  Code  Gb  Config_UART0.o [19]
+_R_Config_UART0_Send    0x1'7f4e   0x31  Code  Gb  Config_UART0.o [19]
+_R_Config_UART0_Start   0x1'7f2c   0x22  Code  Gb  Config_UART0.o [19]
+_R_Config_WDT_Create    0x1'8f80    0xa  Code  Gb  Config_WDT.o [20]
+_R_Config_WDT_Create_UserInit
+                        0x1'8feb    0x1  Code  Gb  Config_WDT_user.o [20]
+_R_Config_WDT_Restart   0x1'8f8a    0x4  Code  Gb  Config_WDT.o [20]
+_R_DAC_Create           0x1'8fc7    0x8  Code  Gb  r_cg_da_common.o [21]
+_R_DALI101_BFT_Init     0x1'885e   0x11  Code  Gb  r_dali101_bft.o [2]
+_R_DALI101_BFT_Send     0x1'88b0   0x25  Code  Gb  r_dali101_bft.o [2]
+_R_DALI101_BFT_Task     0x1'8876   0x3a  Code  Gb  r_dali101_bft.o [2]
+_R_DALI101_BFT_Tick1ms  0x1'886f    0x7  Code  Gb  r_dali101_bft.o [2]
+_R_DALI101_GetReceivedFrame
+                        0x1'8d15    0x4  Code  Gb  r_dali101.o [2]
+_R_DALI101_Init         0x1'8ce7    0x8  Code  Gb  r_dali101.o [2]
+_R_DALI101_RX_GetReceivedFrame
+                        0x1'7773   0x58  Code  Gb  r_dali101_rx.o [2]
+_R_DALI101_RX_Init      0x1'769d   0x2d  Code  Gb  r_dali101_rx.o [2]
+_R_DALI101_RX_Start     0x1'76ca   0x13  Code  Gb  r_dali101_rx.o [2]
+_R_DALI101_RX_SystemFailureIsDetected
+                        0x1'77cb    0xe  Code  Gb  r_dali101_rx.o [2]
+_R_DALI101_RX_Task      0x1'76dd   0x96  Code  Gb  r_dali101_rx.o [2]
+_R_DALI101_SendBackwardFrame
+                        0x1'8d1d    0x4  Code  Gb  r_dali101.o [2]
+_R_DALI101_Start        0x1'8cef   0x1a  Code  Gb  r_dali101.o [2]
+_R_DALI101_SystemFailureIsDetected
+                        0x1'8d19    0x4  Code  Gb  r_dali101.o [2]
+_R_DALI101_Task         0x1'8d0d    0x8  Code  Gb  r_dali101.o [2]
+_R_DALI101_Tick1ms      0x1'8d09    0x4  Code  Gb  r_dali101.o [2]
+_R_DALI102_CalcActualLevelDuringFade
+                        0x1'6956   0x4f  Code  Gb  r_dali102.o [28]
+_R_DALI102_CalcTargetLevelDirectly
+                        0x1'6b5f   0x54  Code  Gb  r_dali102.o [28]
+_R_DALI102_ClearControlGearFailure
+                        0x1'63d4    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_ClearLampFailure
+                        0x1'63c6    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_ClearLampOn  0x1'63b8    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_ClearLimitError
+                        0x1'6b50    0xf  Code  Gb  r_dali102.o [28]
+_R_DALI102_CommandIsIgnored
+                        0x1'00ae  0x1b5  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_CreateCommand
+                        0x1'647e   0x31  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_DT6_IF_GetFadeTime
+                        0x1'8dd1    0x5  Code  Gb  r_dali102_dt6_if.o [28]
+_R_DALI102_DT6_IF_GetPhysicalMinimumLevel
+                        0x1'8de2    0xc  Code  Gb  r_dali102_dt6_if.o [28]
+_R_DALI102_DT6_IF_Init  0x1'8dc8    0x9  Code  Gb  r_dali102_dt6_if.o [28]
+_R_DALI102_DT6_IF_ReferenceMeasurementIsRunning
+                        0x1'8dee    0xc  Code  Gb  r_dali102_dt6_if.o [28]
+_R_DALI102_DT8_IF_FadeIsRunning
+                        0x1'8c80    0xc  Code  Gb  r_dali102_dt8_if.o [28]
+_R_DALI102_DT8_IF_FadeStopProcess
+                        0x1'8ca0    0xc  Code  Gb  r_dali102_dt8_if.o [28]
+_R_DALI102_DT8_IF_FadeTryStart
+                        0x1'8c77    0x9  Code  Gb  r_dali102_dt8_if.o [28]
+_R_DALI102_DT8_IF_Fading
+                        0x1'8c8c    0x8  Code  Gb  r_dali102_dt8_if.o [28]
+_R_DALI102_DT8_IF_Init  0x1'8c6e    0x9  Code  Gb  r_dali102_dt8_if.o [28]
+_R_DALI102_DTX_IF_ApplicationExtendedCommandIsIgnored
+                        0x1'85e1    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExecuteAdditionalProcess
+                        0x1'8610    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExecuteApplicationExtendedCommand
+                        0x1'861b    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExecutePowerOnProcess
+                        0x1'85b8    0x7  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExecuteReplacementProcess
+                        0x1'85fd    0x7  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExecuteSystemFailureProcess
+                        0x1'85cb    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_ExistsReplacementProcess
+                        0x1'85f2    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_GetDeviceType
+                        0x1'859a    0x8  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_GetExtendedVersionNumber
+                        0x1'85a2    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_Init  0x1'8591    0x9  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_IsReset
+                        0x1'85ad    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_StandardCommandIsIgnored
+                        0x1'85d6    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_DTX_IF_TickTimer
+                        0x1'8626    0xb  Code  Gb  r_dali102_dtx_if.o [28]
+_R_DALI102_ExecuteCommand
+                        0x1'64af   0x9b  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_ExecuteCommandCommonProcess
+                        0x1'0269   0x64  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_FADE_CalcActualLevel
+                        0x1'70f4   0xdd  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_GetExFadeTimeMs
+                        0x1'70d2   0x22  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_GetFadeTimeMs
+                        0x1'70c5    0xd  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_GetRelativeLevel
+                        0x1'70bc    0x9  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_Init    0x1'6fca   0x12  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_IsRequested
+                        0x1'702a   0x16  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_IsRunning
+                        0x1'7027    0x3  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_Set     0x1'708e   0x2e  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_Start   0x1'7040   0x42  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_Stop    0x1'7082    0xc  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FADE_Tick1ms
+                        0x1'6fe5   0x42  Code  Gb  r_dali102_fade.o [28]
+_R_DALI102_FadeIsRunning
+                        0x1'6cbc   0x13  Code  Gb  r_dali102.o [28]
+_R_DALI102_FadeSetAbsoluteProcess
+                        0x1'6a8d   0x71  Code  Gb  r_dali102.o [28]
+_R_DALI102_FadeStopProcess
+                        0x1'6afe   0x43  Code  Gb  r_dali102.o [28]
+_R_DALI102_FadeTryStart
+                        0x1'69a5   0x4f  Code  Gb  r_dali102.o [28]
+_R_DALI102_Fading       0x1'69f4   0x6c  Code  Gb  r_dali102.o [28]
+_R_DALI102_GetActualLevel
+                        0x1'6452   0x1f  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_GetCommandExecuteCondition
+                        0x1'002c    0x9  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_GetCommandFunction
+                        0x1'0035   0x11  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_GetCommandNumber
+                        0x1'0000   0x2c  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_GetFadeTimeMs
+                        0x1'6920   0x36  Code  Gb  r_dali102.o [28]
+_R_DALI102_GetNvm       0x1'6265    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_GetOperatingMode
+                        0x1'6339    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_GetPhysicalMinimumLevel
+                        0x1'6c9c   0x13  Code  Gb  r_dali102.o [28]
+_R_DALI102_GetRandomAddress
+                        0x1'6913    0xd  Code  Gb  r_dali102.o [28]
+_R_DALI102_GetResetState
+                        0x1'6bb3   0x4a  Code  Gb  r_dali102.o [28]
+_R_DALI102_IdentificationIsActive
+                        0x1'6471    0xd  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_InitLibrary  0x1'6105   0x72  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_InitLogicalUnit
+                        0x1'6177   0xc2  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_IsAddressingTarget
+                        0x1'0046   0x68  Code  Gb  r_dali102_cmd.o [28]
+_R_DALI102_IsEqualShortAddress
+                        0x1'6bfd   0x1b  Code  Gb  r_dali102.o [28]
+_R_DALI102_LIST_Add     0x1'8778   0x47  Code  Gb  r_dali102_list.o [28]
+_R_DALI102_LIST_Entry   0x1'875c   0x10  Code  Gb  r_dali102_list.o [28]
+_R_DALI102_LIST_Init    0x1'874e    0xe  Code  Gb  r_dali102_list.o [28]
+_R_DALI102_LIST_Next    0x1'876c    0xc  Code  Gb  r_dali102_list.o [28]
+_R_DALI102_ListContains
+                        0x1'6c18   0x14  Code  Gb  r_dali102.o [28]
+_R_DALI102_MB_IF_CancelWrite
+                        0x1'804b   0x3a  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_MB_IF_Init   0x1'7fa4    0x4  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_MB_IF_Read   0x1'7fbb   0x28  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_MB_IF_Reset  0x1'7fa8   0x13  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_MB_IF_UnlatchRead
+                        0x1'8011   0x3a  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_MB_IF_Write  0x1'7fe3   0x2e  Code  Gb  r_dali102_mb_if.o [28]
+_R_DALI102_NotifySystemFailure
+                        0x1'63db   0x6f  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_NvmIsChanged
+                        0x1'626c    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_NvmIsValid   0x1'6239   0x25  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_PowerOnProcess
+                        0x1'6c2c   0x70  Code  Gb  r_dali102.o [28]
+_R_DALI102_ReferenceMeasurementIsRunning
+                        0x1'6caf    0xd  Code  Gb  r_dali102.o [28]
+_R_DALI102_RegisterCallback
+                        0x1'690f    0x4  Code  Gb  r_dali102.o [28]
+_R_DALI102_SetControlGearFailure
+                        0x1'63cd    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_SetLampFailure
+                        0x1'63bf    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_SetLampOn    0x1'63b1    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_SetLimitError
+                        0x1'6b41    0xf  Code  Gb  r_dali102.o [28]
+_R_DALI102_SetNvm       0x1'625e    0x7  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_SetTargetLevelProcess
+                        0x1'6a60   0x2d  Code  Gb  r_dali102.o [28]
+_R_DALI102_StartPowerOnTimer
+                        0x1'6273   0xc6  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_TIMER16_IsRunning
+                        0x1'83dd    0x9  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER16_Start
+                        0x1'83d4    0x9  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER16_Tick
+                        0x1'83c1   0x13  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER32_Init
+                        0x1'83e6    0x1  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER32_IsRunning
+                        0x1'843d    0xe  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER32_Start
+                        0x1'841c   0x16  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER32_Stop
+                        0x1'8439    0x4  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER32_Tick
+                        0x1'83ed   0x2f  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER8_IsRunning
+                        0x1'83b9    0x8  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER8_Start
+                        0x1'83b1    0x8  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_TIMER8_Tick  0x1'83a3    0xe  Code  Gb  r_dali102_timer.o [28]
+_R_DALI102_Tick1ms      0x1'6340   0x71  Code  Gb  r_dali102_api.o [28]
+_R_DALI102_VAR_AddGearGroups
+                        0x1'5c0d   0x20  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ClearControlGearFailure
+                        0x1'5b91    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ClearLampFailure
+                        0x1'5ba7    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ClearLampOn
+                        0x1'5bbf    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ClearLimitError
+                        0x1'5bd7    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ClearPowerCycleSeen
+                        0x1'5bef    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_ControlGearIsFailure
+                        0x1'5b98    0x8  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GearGroupIsContained
+                        0x1'5c53    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetActualLevel
+                        0x1'5a63    0x6  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetExtendedFadeTime
+                        0x1'5b22    0x6  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetNvm   0x1'59d0   0x83  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetOperatingMode
+                        0x1'5b86    0x4  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetPhm   0x1'5c7b    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetRandomAddress
+                        0x1'5b71    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetScene
+                        0x1'5c75    0x6  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_GetSearchAddress
+                        0x1'5b4a    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_Init     0x1'576b   0x7b  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_IsReset  0x1'5879   0x6a  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_LampIsFailure
+                        0x1'5bae    0xa  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_LampIsOn
+                        0x1'5bc6    0xa  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_LimitIsError
+                        0x1'5bde    0xa  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_NvmIsChanged
+                        0x1'5a53    0x9  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_NvmIsValid
+                        0x1'58e3   0x6a  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_PowerCycleIsSeen
+                        0x1'5bf6    0xa  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_RemoveGearGroups
+                        0x1'5c2d   0x26  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_Reset    0x1'57e6   0x93  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetActualLevel
+                        0x1'5a5c    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetControlGearFailure
+                        0x1'5b8a    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetExtendedFadeTime
+                        0x1'5acb   0x3c  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetFadeRate
+                        0x1'5aaf    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetFadeTime
+                        0x1'5abd    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetGearGroups
+                        0x1'5c00    0xd  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetLampFailure
+                        0x1'5ba0    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetLampOn
+                        0x1'5bb8    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetLastLightLevel
+                        0x1'5a69    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetLimitError
+                        0x1'5bd0    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetMaxLevel
+                        0x1'5aa1    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetMinLevel
+                        0x1'5a93    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetNvm   0x1'594d   0x83  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetOperatingMode
+                        0x1'5b78    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetPowerCycleSeen
+                        0x1'5be8    0x7  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetPowerOnLevel
+                        0x1'5a77    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetRandomAddress
+                        0x1'5b51   0x20  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetScene
+                        0x1'5c61   0x14  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetSearchAddress
+                        0x1'5b40    0xa  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetShortAddress
+                        0x1'5b32    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI102_VAR_SetSystemFailureLevel
+                        0x1'5a85    0xe  Code  Gb  r_dali102_var.o [28]
+_R_DALI207_ApplicationExtendedCommandIsIgnored
+                        0x1'523c   0x2f  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_ExecuteAdditionalProcess
+                        0x1'5270   0x1d  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_ExecuteApplicationExtendedCommand
+                        0x1'528d   0x18  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_ExecutePowerOnProcess
+                        0x1'8646    0x1  Code  Gb  r_dali207.o [29]
+_R_DALI207_ExecuteReplacementProcess
+                        0x1'526d    0x3  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_ExecuteSystemFailureProcess
+                        0x1'8647    0x1  Code  Gb  r_dali207.o [29]
+_R_DALI207_ExistsReplacementProcess
+                        0x1'526b    0x2  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_FinishReferenceMeasurement
+                        0x1'815e    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_GetDeviceType
+                        0x1'8631    0x7  Code  Gb  r_dali207.o [29]
+_R_DALI207_GetDimmingCurve
+                        0x1'8150    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_GetExtendedVersionNumber
+                        0x1'8638    0x7  Code  Gb  r_dali207.o [29]
+_R_DALI207_GetFadeTime  0x1'864f   0x48  Code  Gb  r_dali207.o [29]
+_R_DALI207_GetNvm       0x1'8107    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_GetPhysicalMinimumLevel
+                        0x1'8697   0x22  Code  Gb  r_dali207.o [29]
+_R_DALI207_GetStatus    0x1'811c   0x34  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_InitLogicalUnit
+                        0x1'8085   0x7b  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_IsReset      0x1'863f    0x7  Code  Gb  r_dali207.o [29]
+_R_DALI207_NvmIsChanged
+                        0x1'8115    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_NvmIsValid   0x1'810e    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_ReferenceMeasurementIsRunning
+                        0x1'86b9    0x7  Code  Gb  r_dali207.o [29]
+_R_DALI207_SetFailureStatus
+                        0x1'8157    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_SetNvm       0x1'8100    0x7  Code  Gb  r_dali207_api.o [29]
+_R_DALI207_StandardCommandIsIgnored
+                        0x1'5220   0x1c  Code  Gb  r_dali207_cmd.o [29]
+_R_DALI207_TickTimer    0x1'8648    0x7  Code  Gb  r_dali207.o [29]
+_R_DALI207_VAR_AddFailureStatus
+                        0x1'7be4    0x1  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_CurrentProtectorIsEnabled
+                        0x1'7c39    0xa  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_DisableCurrentProtector
+                        0x1'7c2d    0xc  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_EnableCurrentProtector
+                        0x1'7c1c   0x11  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetDeviceType
+                        0x1'7c19    0x3  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetDimmingCurve
+                        0x1'7c13    0x4  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetExtendedVersionNumber
+                        0x1'7c17    0x2  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetFeatures
+                        0x1'7bd8    0x7  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetGearType
+                        0x1'7bca    0x7  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetMinFastFadeTime
+                        0x1'7bb6    0x6  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetNvm   0x1'7b50   0x34  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetOperatingMode
+                        0x1'7bf2    0xf  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetPhm   0x1'7c43    0x7  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_GetPossibleOperatingModes
+                        0x1'7bd1    0x7  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_Init     0x1'7ad8   0x23  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_IsReset  0x1'7b0a    0xf  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_NvmIsChanged
+                        0x1'7baa    0xc  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_NvmIsValid
+                        0x1'7b84   0x26  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_RemoveFailureStatus
+                        0x1'7bea    0x8  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_Reset    0x1'7afb    0xf  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_SetDimmingCurve
+                        0x1'7c01   0x12  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_SetFailureStatus
+                        0x1'7bdf    0x5  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_SetFastFadeTime
+                        0x1'7bbc    0xe  Code  Gb  r_dali207_var.o [29]
+_R_DALI207_VAR_SetNvm   0x1'7b19   0x30  Code  Gb  r_dali207_var.o [29]
+_R_DALI209_ActivateOnRgbwafSpace
+                          0xa265  0x14f  Code  Gb  r_dali209.o [30]
+_R_DALI209_ActivateOnTcSpace
+                          0xa001  0x10b  Code  Gb  r_dali209.o [30]
+_R_DALI209_ActivateOnXySpace
+                          0xa10c  0x159  Code  Gb  r_dali209.o [30]
+_R_DALI209_ApplicationExtendedCommandIsIgnored
+                          0x5498   0x83  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_CalcInRangeColour
+                          0x8ee8  0x7a2  Code  Gb  r_dali209.o [30]
+_R_DALI209_CalcLightOutputRgbwaf
+                          0x968a  0x3f1  Code  Gb  r_dali209.o [30]
+_R_DALI209_CalcTriangleCenterPointForXy
+                          0x8a6f   0x98  Code  Gb  r_dali209.o [30]
+_R_DALI209_CanJudgeColourIsAttainable
+                          0x8a53   0x1c  Code  Gb  r_dali209.o [30]
+_R_DALI209_CanTranslateToLightOutput
+                          0x8a3b   0x18  Code  Gb  r_dali209.o [30]
+_R_DALI209_CheckSupportedColourType
+                          0x9a7b  0x48c  Code  Gb  r_dali209.o [30]
+_R_DALI209_ColourTypeChangeToRgbwaf
+                          0xb09a   0xed  Code  Gb  r_dali209.o [30]
+_R_DALI209_ColourTypeChangeToTc
+                          0xae9a  0x103  Code  Gb  r_dali209.o [30]
+_R_DALI209_ColourTypeChangeToXy
+                          0xaf9d   0xfd  Code  Gb  r_dali209.o [30]
+_R_DALI209_ColourValueChangeFromTc
+                          0xb187   0xf2  Code  Gb  r_dali209.o [30]
+_R_DALI209_ExecuteAdditionalProcess
+                          0x5579   0x3b  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_ExecuteApplicationExtendedCommand
+                          0x55b4   0x26  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_ExecutePowerOnProcess
+                          0xa3c1  0x32b  Code  Gb  r_dali209.o [30]
+_R_DALI209_ExecuteReplacementProcess
+                          0x5535   0x39  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_ExecuteSystemFailureProcess
+                          0xa6ec  0x1a6  Code  Gb  r_dali209.o [30]
+_R_DALI209_ExistsReplacementProcess
+                          0x551b   0x1a  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_FADE_CalcActualColourValue
+                        0x1'4e04  0x314  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_GetTargetColourValue
+                        0x1'512c   0xbf  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_Init    0x1'4c0a   0x34  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_IsRequested
+                        0x1'4c80   0x16  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_Set     0x1'4ceb  0x119  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_Start   0x1'4c96   0x42  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_Stop    0x1'4cd8    0x5  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FADE_Tick1ms
+                        0x1'4c3e   0x42  Code  Gb  r_dali209_fade.o [30]
+_R_DALI209_FadeIsRunning
+                          0xa8c2   0x1f  Code  Gb  r_dali209.o [30]
+_R_DALI209_FadeStopProcess
+                          0xaa2a  0x18c  Code  Gb  r_dali209.o [30]
+_R_DALI209_FadeTryStart
+                          0xa893   0x2f  Code  Gb  r_dali209.o [30]
+_R_DALI209_Fading         0xa8e1  0x149  Code  Gb  r_dali209.o [30]
+_R_DALI209_GetActiveColourSpace
+                        0x1'7359    0x6  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_GetActiveColourType
+                          0x9fbb   0x46  Code  Gb  r_dali209.o [30]
+_R_DALI209_GetActualColourValueRgbwaf
+                        0x1'73ca   0x74  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_GetActualColourValueTc
+                        0x1'735f   0x29  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_GetActualColourValueXy
+                        0x1'7388   0x42  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_GetDeviceType
+                          0xa3b4    0x3  Code  Gb  r_dali209.o [30]
+_R_DALI209_GetExtendedVersionNumber
+                          0xa3b7    0x3  Code  Gb  r_dali209.o [30]
+_R_DALI209_GetNvm       0x1'734b    0x7  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_GetSupportedColourType
+                          0x9f07   0x32  Code  Gb  r_dali209.o [30]
+_R_DALI209_InitLibrary  0x1'7206    0xd  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_InitLogicalUnit
+                        0x1'7213  0x121  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_IsReset        0xa3ba    0x7  Code  Gb  r_dali209.o [30]
+_R_DALI209_NvmIsChanged
+                        0x1'7352    0x7  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_NvmIsValid   0x1'7334    0x7  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_RegisterCallback
+                          0x8a37    0x4  Code  Gb  r_dali209.o [30]
+_R_DALI209_SetActiveColourType
+                          0x9f39   0x82  Code  Gb  r_dali209.o [30]
+_R_DALI209_SetNvm       0x1'733b   0x10  Code  Gb  r_dali209_api.o [30]
+_R_DALI209_SetPrimaryCoordinateForCrossJudge
+                          0x8b07  0x3e1  Code  Gb  r_dali209.o [30]
+_R_DALI209_StandardCommandIsIgnored
+                          0x5496    0x2  Code  Gb  r_dali209_cmd.o [30]
+_R_DALI209_TickTimer      0xa892    0x1  Code  Gb  r_dali209.o [30]
+_R_DALI209_UpdateActualColourValue
+                          0xabb6  0x2e4  Code  Gb  r_dali209.o [30]
+_R_DALI209_VAR_AutomaticActivationIsActive
+                        0x1'3bb1    0x3  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearAutomaticActivation
+                        0x1'3baa    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearColourTypeRgbwafActive
+                        0x1'3c24    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearColourTypeTcActive
+                        0x1'3c0c    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearColourTypeXyActive
+                        0x1'3bf4    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearTcOutOfRange
+                        0x1'3bdf    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ClearXyOutOfRange
+                        0x1'3bca    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ColourTypeRgbwafIsActive
+                        0x1'3c2b    0xa  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ColourTypeTcIsActive
+                        0x1'3c13    0xa  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_ColourTypeXyIsActive
+                        0x1'3bfb    0xa  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetColourTypeFeatures
+                        0x1'3c3c    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetLastActiveColourValueRgbwaf
+                        0x1'3a09    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetLastActiveColourValueXy
+                        0x1'39e6    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetNvm   0x1'3843   0xac  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPowerOnColourValueRgbwaf
+                        0x1'3b2e    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPowerOnColourValueXy
+                        0x1'3b13    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPowerRatio
+                        0x1'3c35    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPrimaryBlueXyCoordinate
+                        0x1'3c62    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPrimaryGreenXyCoordinate
+                        0x1'3c50    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetPrimaryRedXyCoordinate
+                        0x1'3c49    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetReportLightOutputRgbwaf
+                        0x1'39a0    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetReportRgbwafDimlevel
+                        0x1'397f    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetReportXyCoordinate
+                        0x1'3914    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetRgbwafChannelsPresent
+                        0x1'3c42    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetRgbwafDimlevel
+                        0x1'3993    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSceneColourRgbwafControl
+                        0x1'3ad6    0xb  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSceneColourType
+                        0x1'3a31    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSceneColourValueRgbwaf
+                        0x1'3aad   0x12  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSceneColourValueTc
+                        0x1'3a4f    0xb  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSceneColourValueXy
+                        0x1'3a74    0xb  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSystemFailureColourValueRgbwaf
+                        0x1'3b8f    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetSystemFailureColourValueXy
+                        0x1'3b74    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetTemporaryRgbwafDimlevel
+                        0x1'3972    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetTemporaryXyCoordinate
+                        0x1'38fe    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_GetXyCoordinate
+                        0x1'3922    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_Init     0x1'333b  0x177  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_IsReset  0x1'3652   0xae  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_NvmIsChanged
+                        0x1'38ef    0x9  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_NvmIsValid
+                        0x1'3700   0x98  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_Reset    0x1'34d0  0x170  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetAutomaticActivation
+                        0x1'3ba3    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTemperatureTcCoolest
+                        0x1'3929    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTemperatureTcPhysicalCoolest
+                        0x1'3943    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTemperatureTcPhysicalWarmest
+                        0x1'3950    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTemperatureTcStepIncrement
+                        0x1'395d    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTemperatureTcWarmest
+                        0x1'3936    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTypeRgbwafActive
+                        0x1'3c1d    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTypeTcActive
+                        0x1'3c05    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetColourTypeXyActive
+                        0x1'3bed    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetEnabledChannels
+                        0x1'39a6    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetLastActiveColourRgbwafControl
+                        0x1'3a0f    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetLastActiveColourType
+                        0x1'39b4    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetLastActiveColourValueRgbwaf
+                        0x1'39f5   0x14  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetLastActiveColourValueTc
+                        0x1'39c2    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetLastActiveColourValueXy
+                        0x1'39cf   0x17  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetNvm   0x1'3798   0xab  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetPowerOnColourRgbwafControl
+                        0x1'3b34    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetPowerOnColourType
+                        0x1'3ae1    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetPowerOnColourValueRgbwaf
+                        0x1'3b1a   0x14  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetPowerOnColourValueTc
+                        0x1'3aef    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetPowerOnColourValueXy
+                        0x1'3afc   0x17  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetReportLightOutputRgbwaf
+                        0x1'3999    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetReportRgbwafDimlevel
+                        0x1'3978    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetReportXyCoordinate
+                        0x1'3904    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetRgbwafDimlevel
+                        0x1'3985    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSceneColourRgbwafControl
+                        0x1'3abf   0x17  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSceneColourType
+                        0x1'3a1d   0x14  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSceneColourValueRgbwaf
+                        0x1'3a8b   0x22  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSceneColourValueTc
+                        0x1'3a37   0x18  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSceneColourValueXy
+                        0x1'3a5a   0x1a  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSystemFailureColourRgbwafControl
+                        0x1'3b95    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSystemFailureColourType
+                        0x1'3b42    0xe  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSystemFailureColourValueRgbwaf
+                        0x1'3b7b   0x14  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSystemFailureColourValueTc
+                        0x1'3b50    0xd  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetSystemFailureColourValueXy
+                        0x1'3b5d   0x17  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetTcOutOfRange
+                        0x1'3bd8    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetTemporaryRgbwafDimlevel
+                        0x1'396b    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetTemporaryXyCoordinate
+                        0x1'38f8    0x6  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetXyCoordinate
+                        0x1'391b    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_SetXyOutOfRange
+                        0x1'3bc3    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_TcIsOutOfRange
+                        0x1'3be6    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_TcPhysicalLimitIsReadOnly
+                        0x1'3bb9    0x3  Code  Gb  r_dali209_var.o [30]
+_R_DALI209_VAR_XyIsOutOfRange
+                        0x1'3bd1    0x7  Code  Gb  r_dali209_var.o [30]
+_R_DEBUG_ChangeStatus   0x1'7452  0x1a9  Code  Gb  r_debug.o [1]
+_R_DEBUG_ClearChangeFlag
+                        0x1'7442    0x4  Code  Gb  r_debug.o [1]
+_R_DEBUG_GetControlGearStatus
+                        0x1'75fb    0x4  Code  Gb  r_debug.o [1]
+_R_DEBUG_GetFailureProcedure
+                        0x1'75ff    0x4  Code  Gb  r_debug.o [1]
+_R_DEBUG_GetNvm         0x1'744c    0x6  Code  Gb  r_debug.o [1]
+_R_DEBUG_NvmIsChanged   0x1'743e    0x4  Code  Gb  r_debug.o [1]
+_R_DEBUG_ReferenceMeasurementIsFinished
+                        0x1'7603    0xc  Code  Gb  r_debug.o [1]
+_R_DEBUG_SetNvm         0x1'7446    0x6  Code  Gb  r_debug.o [1]
+_R_LAMP_CalculateForLinerRgbFromXy
+                        0x1'5ed4  0x231  Code  Gb  r_lamp_xy.o [1]
+_R_LAMP_ColourIsAttainable
+                        0x1'3f12    0x2  Code  Gb  r_lamp.o [1]
+_R_LAMP_DimmingFlashRgbwaf
+                        0x1'6cda   0xcb  Code  Gb  r_lamp_rgbwaf.o [1]
+_R_LAMP_DimmingFlashTc  0x1'77e1   0x7f  Code  Gb  r_lamp_tc.o [1]
+_R_LAMP_DimmingFlashXy  0x1'5c8d   0xaf  Code  Gb  r_lamp_xy.o [1]
+_R_LAMP_DimmingRgbwaf   0x1'6da5  0x225  Code  Gb  r_lamp_rgbwaf.o [1]
+_R_LAMP_DimmingTc       0x1'7860  0x103  Code  Gb  r_lamp_tc.o [1]
+_R_LAMP_DimmingXy       0x1'5d3c  0x198  Code  Gb  r_lamp_xy.o [1]
+_R_LAMP_DisableCurrentProtector
+                        0x1'44e8    0x4  Code  Gb  r_lamp.o [1]
+_R_LAMP_DisableFlashing
+                        0x1'44dd    0x7  Code  Gb  r_lamp.o [1]
+_R_LAMP_EnableCurrentProtector
+                        0x1'44e4    0x4  Code  Gb  r_lamp.o [1]
+_R_LAMP_EnableFlashing  0x1'44c8   0x15  Code  Gb  r_lamp.o [1]
+_R_LAMP_GetDimmingRate  0x1'3ef6   0x1c  Code  Gb  r_lamp.o [1]
+_R_LAMP_Init            0x1'3c69   0x33  Code  Gb  r_lamp.o [1]
+_R_LAMP_InitColourTypeRgbwaf
+                        0x1'6ccf    0xb  Code  Gb  r_lamp_rgbwaf.o [1]
+_R_LAMP_InitColourTypeTc
+                        0x1'77d9    0x8  Code  Gb  r_lamp_tc.o [1]
+_R_LAMP_InitColourTypeXy
+                        0x1'5c82    0xb  Code  Gb  r_lamp_xy.o [1]
+_R_LAMP_IsFailure       0x1'3df3   0x3c  Code  Gb  r_lamp.o [1]
+_R_LAMP_IsFailureSpecified
+                        0x1'3e2f   0x46  Code  Gb  r_lamp.o [1]
+_R_LAMP_IsOn            0x1'3d9d   0x56  Code  Gb  r_lamp.o [1]
+_R_LAMP_IsStartup       0x1'3e75    0x7  Code  Gb  r_lamp.o [1]
+_R_LAMP_SetActiveColourSpace
+                        0x1'3ec4    0x4  Code  Gb  r_lamp.o [1]
+_R_LAMP_SetDimmingCurve
+                        0x1'3ec8    0x4  Code  Gb  r_lamp.o [1]
+_R_LAMP_SetDimmingLevelRgbwaf
+                        0x1'3ee0   0x16  Code  Gb  r_lamp.o [1]
+_R_LAMP_SetDimmingLevelTc
+                        0x1'3ecc    0x8  Code  Gb  r_lamp.o [1]
+_R_LAMP_SetDimmingLevelXy
+                        0x1'3ed4    0xc  Code  Gb  r_lamp.o [1]
+_R_LAMP_Start           0x1'3c9c    0x4  Code  Gb  r_lamp.o [1]
+_R_LAMP_Startup         0x1'3e7c   0x48  Code  Gb  r_lamp.o [1]
+_R_LAMP_Task            0x1'3cae   0xef  Code  Gb  r_lamp.o [1]
+_R_LAMP_Tick1ms         0x1'3ca0    0xe  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueRGBtoTC
+                        0x1'3fbc  0x1ec  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueRGBtoXY
+                        0x1'4366  0x162  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueTCtoRGB
+                        0x1'3f14   0xa8  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueTCtoXY
+                        0x1'41c0   0x57  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueXYtoRGB
+                        0x1'42f3   0x73  Code  Gb  r_lamp.o [1]
+_R_LAMP_TranslateColourValueXYtoTC
+                        0x1'4217   0xdc  Code  Gb  r_lamp.o [1]
+_R_LED1_Init            0x1'893a   0x1b  Code  Gb  r_led1.o [2]
+_R_LED1_IsFailed        0x1'8992    0x9  Code  Gb  r_led1.o [2]
+_R_LED1_SetLevel        0x1'8955   0x3d  Code  Gb  r_led1.o [2]
+_R_LED2_Init            0x1'899b   0x1b  Code  Gb  r_led2.o [2]
+_R_LED2_IsFailed        0x1'89f3    0x9  Code  Gb  r_led2.o [2]
+_R_LED2_SetLevel        0x1'89b6   0x3d  Code  Gb  r_led2.o [2]
+_R_LED3_Init            0x1'89fc   0x1b  Code  Gb  r_led3.o [2]
+_R_LED3_IsFailed        0x1'8a54    0x9  Code  Gb  r_led3.o [2]
+_R_LED3_SetLevel        0x1'8a17   0x3d  Code  Gb  r_led3.o [2]
+_R_LED_Init             0x1'7d80   0x78  Code  Gb  r_led.o [2]
+_R_LED_IsFailed         0x1'7e48   0x1f  Code  Gb  r_led.o [2]
+_R_LED_IsOn             0x1'7e2d   0x1b  Code  Gb  r_led.o [2]
+_R_LED_SetLevel         0x1'7e14   0x19  Code  Gb  r_led.o [2]
+_R_LED_Start            0x1'7df8   0x1c  Code  Gb  r_led.o [2]
+_R_MemoryBank_GetLastAccessibleLocation
+                        0x1'7ad2    0x6  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBank_Init      0x1'7963   0x42  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBank_IsImplemented
+                        0x1'7ac9    0x9  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBank_Read      0x1'7a05   0x35  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBank_Reset     0x1'79a5   0x60  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBank_Write     0x1'7a3a   0x8f  Code  Gb  r_memory_bank.o [1]
+_R_MemoryBanks_CancelWrite
+                        0x1'68fa   0x15  Code  Gb  r_memory_banks.o [1]
+_R_MemoryBanks_Init     0x1'654a   0x6c  Code  Gb  r_memory_banks.o [1]
+_R_MemoryBanks_Read     0x1'65dd  0x175  Code  Gb  r_memory_banks.o [1]
+_R_MemoryBanks_Reset    0x1'65b6   0x27  Code  Gb  r_memory_banks.o [1]
+_R_MemoryBanks_UnlatchRead
+                        0x1'68e5   0x15  Code  Gb  r_memory_banks.o [1]
+_R_MemoryBanks_Write    0x1'6752  0x193  Code  Gb  r_memory_banks.o [1]
+_R_NVM_Init             0x1'28ec  0x1c1  Code  Gb  r_nvm.o [1]
+_R_NVM_Open             0x1'2aad    0x5  Code  Gb  r_nvm.o [1]
+_R_NVM_Read             0x1'2f23  0x235  Code  Gb  r_nvm.o [1]
+_R_NVM_Task             0x1'2ab2  0x471  Code  Gb  r_nvm.o [1]
+_R_NVM_Write            0x1'3158   0x28  Code  Gb  r_nvm.o [1]
+_R_PGACOMP_Create       0x1'8f32   0x14  Code  Gb  r_cg_pgacomp_common.o [21]
+_R_PORT_PinRead         0x1'8ed2   0x1c  Code  Gb  r_port.o [2]
+_R_RANDOM_Generate      0x1'8251   0x6b  Code  Gb  r_random.o [1]
+_R_RANDOM_IncrementSeed
+                        0x1'82bc   0x2b  Code  Gb  r_random.o [1]
+_R_RANDOM_Init          0x1'8228   0x29  Code  Gb  r_random.o [1]
+_R_RFD_BlankCheckDataFlashReq
+                          0x53fc   0x1f  Code  Gb  r_rfd_data_flash_api.o [4]
+_R_RFD_CheckCFDFSeqEndStep1
+                          0x541b   0x17  Code  Gb  r_rfd_common_control_api.o [3]
+_R_RFD_CheckCFDFSeqEndStep2
+                          0x5432    0xd  Code  Gb  r_rfd_common_control_api.o [3]
+_R_RFD_CheckFlashMemoryMode
+                          0x538e   0x24  Code  Gb  r_rfd_common_api.o [3]
+_R_RFD_ClearSeqRegister
+                          0x5447    0xa  Code  Gb  r_rfd_common_control_api.o [3]
+_R_RFD_EraseDataFlashReq
+                          0x53c5   0x1f  Code  Gb  r_rfd_data_flash_api.o [4]
+_R_RFD_GetSeqErrorStatus
+                          0x543f    0x8  Code  Gb  r_rfd_common_control_api.o [3]
+_R_RFD_HOOK_EnterCriticalSection
+                          0x5476    0x9  Code  Gb  r_rfd_common_userown.o [5]
+_R_RFD_HOOK_ExitCriticalSection
+                          0x547f    0xa  Code  Gb  r_rfd_common_userown.o [5]
+_R_RFD_Init               0x52f6   0x27  Code  Gb  r_rfd_common_api.o [3]
+_R_RFD_SetDataFlashAccessMode
+                          0x531d    0xe  Code  Gb  r_rfd_common_api.o [3]
+_R_RFD_SetFlashMemoryMode
+                          0x532b   0x63  Code  Gb  r_rfd_common_api.o [3]
+_R_RFD_WriteDataFlashReq
+                          0x53e4   0x18  Code  Gb  r_rfd_data_flash_api.o [4]
+_R_SAU0_Create          0x1'8fcf    0x8  Code  Gb  r_cg_sau_common.o [21]
+_R_Systeminit           0x1'8d59   0x38  Code  Gb  r_cg_systeminit.o [21]
+_R_TAU0_Create          0x1'8f46   0x14  Code  Gb  r_cg_tau_common.o [21]
+_R_TIMER16_Expires      0x1'8e22    0x9  Code  Gb  r_timer16.o [25]
+_R_TIMER16_Init         0x1'8dfa    0x1  Code  Gb  r_timer16.o [25]
+_R_TIMER16_IsRunning    0x1'8e16    0xc  Code  Gb  r_timer16.o [25]
+_R_TIMER16_Start        0x1'8e0e    0x4  Code  Gb  r_timer16.o [25]
+_R_TIMER16_Stop         0x1'8e12    0x4  Code  Gb  r_timer16.o [25]
+_R_TIMER16_Tick         0x1'8e01    0xd  Code  Gb  r_timer16.o [25]
+_R_TKB_Create           0x1'8f8e    0xc  Code  Gb  r_cg_tkb_common.o [21]
+_R_TRNG_Create          0x1'8b10    0x5  Code  Gb  r_trng.o [2]
+_R_TRNG_GenerateRandomNumber
+                        0x1'8b15    0x5  Code  Gb  r_trng.o [2]
+_R_TRNG_GetRandomNumber
+                        0x1'8b21   0x40  Code  Gb  r_trng.o [2]
+_R_TRNG_WaitCompletion  0x1'8b1a    0x7  Code  Gb  r_trng.o [2]
+__A_ADCR0               0xf'0020    0x2  Data  Wk  Config_ADC.o [6]
+__A_ADINTCTL            0xf'0028    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADINTST             0xf'0029    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADLL                0xf'0012    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADM0                0xf'ff30    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADM1                0xf'ff32    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADM2                0xf'0010    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADM3                0xf'0014    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADS0                0xf'0015    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADSCTL              0xf'0019    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADTR0               0xf'001a    0x1  Data  Wk  Config_ADC.o [6]
+__A_ADUL                0xf'0011    0x1  Data  Wk  Config_ADC.o [6]
+__A_BTVTHR1             0xf'04c0    0x2  Data  Wk  Config_DALI.o [2]
+__A_BTVTHR2             0xf'04c2    0x2  Data  Wk  Config_DALI.o [2]
+__A_BTVTHR3             0xf'04c4    0x2  Data  Wk  Config_DALI.o [2]
+__A_BTVTHR4             0xf'04c6    0x2  Data  Wk  Config_DALI.o [2]
+__A_CCDE                0xf'02a8    0x1  Data  Wk  Config_PORT.o [12]
+__A_CKC                 0xf'ffa4    0x1  Data  Wk  mcu_clocks.o [24]
+__A_CMC                 0xf'ffa0    0x1  Data  Wk  mcu_clocks.o [24]
+__A_CMP0SEL             0xf'034a    0x1  Data  Wk  Config_COMP0.o [7]
+__A_CMP1SEL             0xf'034b    0x1  Data  Wk  Config_COMP1.o [8]
+__A_CMP2SEL             0xf'034c    0x1  Data  Wk  Config_COMP2.o [9]
+__A_CNFR1               0xf'04d2    0x2  Data  Wk  Config_DALI.o [2]
+__A_CNFR2               0xf'04d4    0x2  Data  Wk  Config_DALI.o [2]
+__A_COMPFIR0            0xf'0341    0x1  Data  Wk  Config_COMP0.o [7]
+__A_COMPFIR1            0xf'0345    0x1  Data  Wk  Config_COMP2.o [9]
+__A_COMPMDR0            0xf'0340    0x1  Data  Wk  Config_COMP0.o [7]
+__A_COMPMDR1            0xf'0344    0x1  Data  Wk  Config_COMP2.o [9]
+__A_COMPOCR0            0xf'0342    0x1  Data  Wk  Config_COMP0.o [7]
+__A_COMPOCR1            0xf'0346    0x1  Data  Wk  Config_COMP2.o [9]
+__A_CSC                 0xf'ffa1    0x1  Data  Wk  mcu_clocks.o [24]
+__A_CTR1                0xf'04e6    0x2  Data  Wk  Config_DALI.o [2]
+__A_DACS0               0xf'0334    0x2  Data  Wk  Config_DAC0.o [10]
+__A_DAM0                0xf'0330    0x1  Data  Wk  Config_DAC0.o [10]
+__A_DAM1                0xf'0331    0x1  Data  Wk  Config_DAC0.o [10]
+__A_DSCCTL              0xf'02e5    0x1  Data  Wk  mcu_clocks.o [24]
+__A_FECR1               0xf'04fa    0x2  Data  Wk  Config_DALI.o [2]
+__A_FLMODE              0xf'00aa    0x1  Data  Wk  mcu_clocks.o [24]
+__A_FLMWRP              0xf'00ab    0x1  Data  Wk  mcu_clocks.o [24]
+__A_FTDC0               0xf'04e4    0x2  Data  Wk  Config_DALI.o [2]
+__A_HOCODIV             0xf'00a8    0x1  Data  Wk  mcu_clocks.o [24]
+__A_HSCLKSEL            0xf'0219    0x1  Data  Wk  mcu_clocks.o [24]
+__A_IAWCTL              0xf'0078    0x1  Data  Wk  hdwinit.o [22]
+__A_IF0                 0xf'ffe0    0x2  Data  Wk  Config_ADC.o [6]
+__A_IF1                 0xf'ffe2    0x2  Data  Wk  Config_ADC.o [6]
+__A_IF2                 0xf'ffd0    0x2  Data  Wk  Config_DALI.o [2]
+__A_IF3                 0xf'ffd2    0x2  Data  Wk  Config_ADC.o [6]
+__A_MCKC                0xf'02e6    0x1  Data  Wk  mcu_clocks.o [24]
+__A_MK0                 0xf'ffe4    0x2  Data  Wk  Config_ADC.o [6]
+__A_MK1                 0xf'ffe6    0x2  Data  Wk  Config_ADC.o [6]
+__A_MK2                 0xf'ffd4    0x2  Data  Wk  Config_DALI.o [2]
+__A_MK3                 0xf'ffd6    0x2  Data  Wk  Config_ADC.o [6]
+__A_NFEN0               0xf'0070    0x1  Data  Wk  Config_UART0.o [19]
+__A_OSMC                0xf'00f3    0x1  Data  Wk  mcu_clocks.o [24]
+__A_P0                  0xf'ff00    0x1  Data  Wk  Config_DALI.o [2]
+__A_P1                  0xf'ff01    0x1  Data  Wk  Config_PORT.o [12]
+__A_P12                 0xf'ff0c    0x1  Data  Wk  r_port.o [2]
+__A_P13                 0xf'ff0d    0x1  Data  Wk  Config_PORT.o [12]
+__A_P14                 0xf'ff0e    0x1  Data  Wk  Config_PORT.o [12]
+__A_P2                  0xf'ff02    0x1  Data  Wk  Config_PORT.o [12]
+__A_P3                  0xf'ff03    0x1  Data  Wk  Config_PORT.o [12]
+__A_P4                  0xf'ff04    0x1  Data  Wk  Config_PORT.o [12]
+__A_P5                  0xf'ff05    0x1  Data  Wk  Config_PORT.o [12]
+__A_P6                  0xf'ff06    0x1  Data  Wk  Config_PORT.o [12]
+__A_P7                  0xf'ff07    0x1  Data  Wk  Config_PORT.o [12]
+__A_PCKC                0xf'0098    0x1  Data  Wk  mcu_clocks.o [24]
+__A_PDIDIS0             0xf'02b0    0x1  Data  Wk  Config_PORT.o [12]
+__A_PDIDIS1             0xf'02b1    0x1  Data  Wk  Config_PORT.o [12]
+__A_PDIDIS13            0xf'02bd    0x1  Data  Wk  Config_PORT.o [12]
+__A_PDIDIS3             0xf'02b3    0x1  Data  Wk  Config_PORT.o [12]
+__A_PDIDIS5             0xf'02b5    0x1  Data  Wk  Config_PORT.o [12]
+__A_PDIDIS7             0xf'02b7    0x1  Data  Wk  Config_PORT.o [12]
+__A_PER0                0xf'00f0    0x1  Data  Wk  Config_ADC.o [6]
+__A_PER1                0xf'00fa    0x1  Data  Wk  Config_DALI.o [2]
+__A_PER2                0xf'00fc    0x1  Data  Wk  r_cg_tkb_common.o [21]
+__A_PFBER               0xf'007c    0x1  Data  Wk  mcu_clocks.o [24]
+__A_PGACTL              0xf'0347    0x1  Data  Wk  Config_PGA.o [11]
+__A_PGAINS              0xf'0348    0x1  Data  Wk  Config_PGA.o [11]
+__A_PIM0                0xf'0040    0x1  Data  Wk  Config_PORT.o [12]
+__A_PIM1                0xf'0041    0x1  Data  Wk  Config_PORT.o [12]
+__A_PIOR0               0xf'0077    0x1  Data  Wk  r_bsp_init.o [22]
+__A_PIOR1               0xf'02ad    0x1  Data  Wk  r_bsp_init.o [22]
+__A_PIOR2               0xf'02ae    0x1  Data  Wk  r_bsp_init.o [22]
+__A_PIOR3               0xf'02af    0x1  Data  Wk  r_bsp_init.o [22]
+__A_PM0                 0xf'ff20    0x1  Data  Wk  Config_COMP1.o [8]
+__A_PM1                 0xf'ff21    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM12                0xf'ff2c    0x1  Data  Wk  Config_COMP0.o [7]
+__A_PM14                0xf'ff2e    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM2                 0xf'ff22    0x1  Data  Wk  Config_ADC.o [6]
+__A_PM3                 0xf'ff23    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM4                 0xf'ff24    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM5                 0xf'ff25    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM6                 0xf'ff26    0x1  Data  Wk  Config_PORT.o [12]
+__A_PM7                 0xf'ff27    0x1  Data  Wk  Config_PORT.o [12]
+__A_PMCA0               0xf'0060    0x1  Data  Wk  Config_COMP1.o [8]
+__A_PMCA1               0xf'0061    0x1  Data  Wk  Config_PORT.o [12]
+__A_PMCA12              0xf'006c    0x1  Data  Wk  Config_COMP0.o [7]
+__A_PMCA14              0xf'006e    0x1  Data  Wk  Config_PORT.o [12]
+__A_PMCA2               0xf'0062    0x1  Data  Wk  Config_ADC.o [6]
+__A_POM0                0xf'0050    0x1  Data  Wk  Config_PORT.o [12]
+__A_POM1                0xf'0051    0x1  Data  Wk  Config_PORT.o [12]
+__A_POM3                0xf'0053    0x1  Data  Wk  Config_PORT.o [12]
+__A_POM5                0xf'0055    0x1  Data  Wk  Config_PORT.o [12]
+__A_POM7                0xf'0057    0x1  Data  Wk  Config_PORT.o [12]
+__A_PR00                0xf'ffe8    0x2  Data  Wk  Config_UART0.o [19]
+__A_PR01                0xf'ffea    0x2  Data  Wk  Config_ADC.o [6]
+__A_PR02                0xf'ffd8    0x2  Data  Wk  Config_DALI.o [2]
+__A_PR03                0xf'ffda    0x2  Data  Wk  Config_DALI.o [2]
+__A_PR10                0xf'ffec    0x2  Data  Wk  Config_UART0.o [19]
+__A_PR11                0xf'ffee    0x2  Data  Wk  Config_ADC.o [6]
+__A_PR12                0xf'ffdc    0x2  Data  Wk  Config_DALI.o [2]
+__A_PR13                0xf'ffde    0x2  Data  Wk  Config_DALI.o [2]
+__A_PRR0                0xf'00f1    0x1  Data  Wk  r_cg_ad_common.o [21]
+__A_PRR1                0xf'00fb    0x1  Data  Wk  r_cg_da_common.o [21]
+__A_PRR2                0xf'00fd    0x1  Data  Wk  r_cg_systeminit.o [21]
+__A_PU1                 0xf'0031    0x1  Data  Wk  Config_PORT.o [12]
+__A_PU12                0xf'003c    0x1  Data  Wk  Config_PORT.o [12]
+__A_PU14                0xf'003e    0x1  Data  Wk  Config_PORT.o [12]
+__A_RDR1H               0xf'04ee    0x2  Data  Wk  Config_DALI_user.o [2]
+__A_RDR1L               0xf'04f0    0x2  Data  Wk  Config_DALI_user.o [2]
+__A_RXWR1               0xf'04d8    0x2  Data  Wk  Config_DALI.o [2]
+__A_SCR00               0xf'0118    0x2  Data  Wk  Config_UART0.o [19]
+__A_SCR01               0xf'011a    0x2  Data  Wk  Config_UART0.o [19]
+__A_SDR00               0xf'ff10    0x2  Data  Wk  Config_UART0.o [19]
+__A_SDR01               0xf'ff12    0x2  Data  Wk  Config_UART0.o [19]
+__A_SIR01               0xf'010a    0x2  Data  Wk  Config_UART0.o [19]
+__A_SMR00               0xf'0110    0x2  Data  Wk  Config_UART0.o [19]
+__A_SMR01               0xf'0112    0x2  Data  Wk  Config_UART0.o [19]
+__A_SO0                 0xf'0128    0x2  Data  Wk  Config_UART0.o [19]
+__A_SOE0                0xf'012a    0x2  Data  Wk  Config_UART0.o [19]
+__A_SOL0                0xf'0134    0x2  Data  Wk  Config_UART0.o [19]
+__A_SPS0                0xf'0126    0x2  Data  Wk  Config_UART0.o [19]
+__A_SS0                 0xf'0122    0x2  Data  Wk  Config_UART0.o [19]
+__A_SSR01               0xf'0102    0x2  Data  Wk  Config_UART0.o [19]
+__A_ST0                 0xf'0124    0x2  Data  Wk  Config_UART0.o [19]
+__A_STR1                0xf'04f2    0x2  Data  Wk  Config_DALI.o [2]
+__A_STR2                0xf'04f4    0x2  Data  Wk  Config_DALI_user.o [2]
+__A_TDR00               0xf'ff18    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TDR01               0xf'ff1a    0x2  Data  Wk  Config_TAU0_1.o [14]
+__A_TDR02               0xf'ff64    0x2  Data  Wk  Config_TAU0_2.o [15]
+__A_TDR03               0xf'ff66    0x2  Data  Wk  Config_TAU0_3.o [16]
+__A_TDR1L               0xf'04e0    0x2  Data  Wk  Config_DALI.o [2]
+__A_TKBCR00             0xf'0740    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBCR01             0xf'0742    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBCR02             0xf'0744    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBCR03             0xf'0746    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBCR10             0xf'0780    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBCR11             0xf'0782    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBCR12             0xf'0784    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBCR13             0xf'0786    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBCRLD00           0xf'0754    0x2  Data  Wk  r_led.o [2]
+__A_TKBCRLD01           0xf'0756    0x2  Data  Wk  r_led.o [2]
+__A_TKBCRLD10           0xf'0794    0x2  Data  Wk  r_led.o [2]
+__A_TKBCTL00            0xf'0762    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBCTL01            0xf'0769    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBCTL10            0xf'07a2    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBCTL11            0xf'07a9    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBDNR00            0xf'074e    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBDNR01            0xf'0750    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBDNR10            0xf'078e    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBIOC00            0xf'0766    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBIOC01            0xf'0768    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBIOC10            0xf'07a6    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBIOC11            0xf'07a8    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBPACTL00          0xf'0770    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBPACTL01          0xf'0772    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBPACTL02          0xf'0777    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBPACTL03          0xf'0778    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBPACTL04          0xf'0779    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBPACTL10          0xf'07b0    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBPACTL12          0xf'07b7    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBPACTL13          0xf'07b8    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBPACTL14          0xf'07b9    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBPAFLG0           0xf'0776    0x1  Data  Wk  r_led1.o [2]
+__A_TKBPAFLG1           0xf'07b6    0x1  Data  Wk  r_led3.o [2]
+__A_TKBTCTL0            0xf'0490    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBTCTL1            0xf'0492    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TKBTGCR0            0xf'0748    0x2  Data  Wk  Config_TKB0.o [17]
+__A_TKBTGCR1            0xf'0788    0x2  Data  Wk  Config_TKB1.o [18]
+__A_TKBTRG0             0xf'0752    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TKBTRG1             0xf'0792    0x1  Data  Wk  Config_TKB1.o [18]
+__A_TMR00               0xf'0190    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TMR01               0xf'0192    0x2  Data  Wk  Config_TAU0_1.o [14]
+__A_TMR02               0xf'0194    0x2  Data  Wk  Config_TAU0_2.o [15]
+__A_TMR03               0xf'0196    0x2  Data  Wk  Config_TAU0_3.o [16]
+__A_TO0                 0xf'01b8    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TOE0                0xf'01ba    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TOL0                0xf'01bc    0x2  Data  Wk  Config_TAU0_1.o [14]
+__A_TOM0                0xf'01be    0x2  Data  Wk  Config_TAU0_1.o [14]
+__A_TPS0                0xf'01b6    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TPS2                0xf'0373    0x1  Data  Wk  Config_TKB0.o [17]
+__A_TRNGSCR0            0xf'0542    0x1  Data  Wk  r_trng.o [2]
+__A_TRNGSDR             0xf'0540    0x1  Data  Wk  r_trng.o [2]
+__A_TRSTR1              0xf'04e2    0x2  Data  Wk  Config_DALI.o [2]
+__A_TS0                 0xf'01b2    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TT0                 0xf'01b4    0x2  Data  Wk  Config_TAU0_0.o [13]
+__A_TXDCTR1             0xf'04e8    0x2  Data  Wk  Config_DALI.o [2]
+__A_TXWR1               0xf'04d6    0x2  Data  Wk  Config_DALI.o [2]
+__A_WDTE                0xf'ffab    0x1  Data  Wk  Config_WDT.o [20]
+__A_WKUPMD              0xf'0215    0x1  Data  Wk  mcu_clocks.o [24]
+__Add64                   0x4113         Code  Gb  longlong.o [27]
+__Asr64                   0x4420         Code  Gb  longlong.o [27]
+__COM_divui               0x5217         Code  Gb  l01.o [27]
+__COM_fadd                0x488e         Code  Gb  fadd.o [27]
+__COM_fdiv                0x4d5a         Code  Gb  fdiv.o [27]
+__COM_fmul                0x4edf         Code  Gb  fmul.o [27]
+__COM_fsub                0x49af         Code  Gb  fadd.o [27]
+__COM_ftosl               0x504d         Code  Gb  ftol.o [27]
+__COM_ftoul               0x504d         Code  Gb  ftol.o [27]
+__COM_sldiv               0x4add         Code  Gb  l03.o [27]
+__COM_sltof               0x50b8         Code  Gb  ltof.o [27]
+__COM_ucdiv               0x5201         Code  Gb  l01.o [27]
+__COM_ultof               0x50cc         Code  Gb  ltof.o [27]
+__Cmp64s                  0x4477         Code  Gb  longlong.o [27]
+__Cmp64u                  0x448a         Code  Gb  longlong.o [27]
+__CmpGes64                0x44b0         Code  Gb  longlong.o [27]
+__CmpGeu64                0x44b8         Code  Gb  longlong.o [27]
+__CmpLts64                0x44a9         Code  Gb  longlong.o [27]
+__Constant_0_0          0xf'400e         Data  Wk  r_bsp_common.o [23]
+__Constant_1388_0       0xf'4016         Data  Wk  r_lamp_rgbwaf.o [1]
+__Constant_1_0          0xf'4026         Data  Gb  r_dali102_fade.o [28]
+__Constant_2710_0       0xf'401e         Data  Wk  r_lamp_rgbwaf.o [1]
+__Constant_3e8_0        0xf'4036         Data  Wk  r_dali209.o [30]
+__Constant_fb_0         0xf'402e         Data  Wk  r_dali209.o [30]
+__Divs64                  0x4340         Code  Gb  longlong.o [27]
+__Divu64                  0x41ac         Code  Gb  longlong.o [27]
+__INIT_WRKSEG             0x515a         Code  Gb  cstartup.o [23]
+__L2LLS                   0x40f0         Code  Gb  longlong.o [27]
+__L2LLU                   0x40e4         Code  Gb  longlong.o [27]
+__LC                    0x1'44ec    0x3  Code  Lc  xprintfsmall_nomb.o [27]
+__LLS2L                   0x40de         Code  Gb  longlong.o [27]
+__LLU2L                   0x40de         Code  Gb  longlong.o [27]
+__LitobSmallNoMb        0x1'4a2a  0x174  Code  Lc  xprintfsmall_nomb.o [27]
+__Lsl64                   0x43b5         Code  Gb  longlong.o [27]
+__Modu64                  0x41a8         Code  Gb  longlong.o [27]
+__Mul64                   0x413b         Code  Gb  longlong.o [27]
+__Neg64                   0x4393         Code  Gb  longlong.o [27]
+__PrintfSmallNoMb       0x1'44ef  0x45a  Code  Gb  xprintfsmall_nomb.o [27]
+__PutcharSmallNoMb      0x1'4b9e   0x28  Code  Lc  xprintfsmall_nomb.o [27]
+__PutcharsSmallNoMb     0x1'4bc6   0x44  Code  Lc  xprintfsmall_nomb.o [27]
+__Rolc64                  0x43b7         Code  Gb  longlong.o [27]
+__SProut                0x1'8fbd    0xa  Code  Gb  xsprout.o [27]
+__WRKSEG_0              0xf'fe20         Data  Gb  l09.o [27]
+__WRKSEG_1              0xf'fe21         Data  Gb  l09.o [27]
+__WRKSEG_2              0xf'fe22         Data  Gb  l09.o [27]
+__WRKSEG_3              0xf'fe23         Data  Gb  l09.o [27]
+___DebugBreak           0x1'8fdb    0x3  Code  Gb  __dbg_break.o [26]
+___exit                 0x1'8f6e   0x12  Code  Gb  __dbg_xxexit.o [26]
+___iar_Fail_s           0x1'8d91   0x2c  Code  Gb  xfail_s.o [27]
+___iar_Memchr           0x1'8f06   0x13  Code  Gb  memchr.o [27]
+___iar_Strchr           0x1'8f5a   0x10  Code  Gb  strchr.o [27]
+___iar_data_init2       0x1'8c2d   0x41  Code  Gb  data_init.o [27]
+___iar_default_interrupt_handler
+                          0x52ca   0x14  Code  Lc  default_handler.o [27]
+___iar_fmex               0x51be         Code  Gb  fmex.o [27]
+___iar_land               0x4b73         Code  Gb  l03.o [27]
+___iar_lior               0x4b4a         Code  Gb  l03.o [27]
+___iar_lsub               0x4b21         Code  Gb  l03.o [27]
+___iar_lxor               0x4b9c         Code  Gb  l03.o [27]
+___iar_packbits_init_near_single2
+                        0x1'82e7   0xbc  Code  Gb  near_packbits_single_init.o [27]
+___iar_zero_init_near2  0x1'8e2b   0x25  Code  Gb  near_zero_init.o [27]
+___interrupt_0x00         0x5121         Code  Gb  cstartup.o [23]
+___interrupt_0x1E         0x5257         Code  Gb  Config_UART0_user.o [19]
+___interrupt_0x2E         0x44c0         Code  Gb  r_led.o [2]
+___interrupt_0x30         0x52a2         Code  Gb  Config_TAU0_2_user.o [15]
+___interrupt_0x32         0x52b6         Code  Gb  Config_TAU0_3_user.o [16]
+___interrupt_0x44         0x4fce         Code  Gb  Config_DALI_user.o [2]
+___interrupt_0x64         0x4ffd         Code  Gb  Config_DALI_user.o [2]
+___interrupt_0x66         0x4fe9         Code  Gb  Config_DALI_user.o [2]
+__exit                    0x52f0         Code  Gb  cexit.o [27]
+__iar_exit_end            0x52f6         Code  Gb  cexit.o [27]
+__iar_fsub                0x49bc         Code  Gb  fadd.o [27]
+__iar_norm_arg            0x4e69         Code  Gb  fmul.o [27]
+__iar_program_start       0x5121         Code  Gb  cstartup.o [23]
+__link_file_version_2 {Abs}
+                             0x1         Data  Gb  <internal module>
+__program_end             0x5171         Code  Gb  cstartup.o [23]
+_abort                  0x1'8fa6    0xc  Code  Gb  __dbg_abort.o [26]
+_adc_ads0_execute       0x1'7e87   0x22  Code  Lc  r_led.o [2]
+_bsp_init_hardware      0x1'8f02    0x4  Code  Gb  r_bsp_init.o [22]
+_bsp_init_system        0x1'8eee   0x14  Code  Gb  r_bsp_init.o [22]
+_clear_report_setting     0x893d   0x88  Code  Lc  r_dali209_cmd.o [30]
+_clear_temporary_setting
+                          0x89c5   0x72  Code  Lc  r_dali209_cmd.o [30]
+_cmd_activate             0x742b  0x274  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_dapc             0x55da  0x255  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_down             0x5bbf  0x22f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_go_to_scene      0x65f9  0x31f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_off              0x5834  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_on_and_step_up
+                          0x64a7  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_query_power_on_level
+                          0x6f94   0xd3  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_query_scene_level
+                          0x714d   0xf2  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_query_system_failure_level
+                          0x7067   0xcf  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_recall_max_level
+                          0x6092  0x14e  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_recall_min_level
+                          0x61eb  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_remove_from_scene
+                          0x6f7f   0x15  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_reset            0x6918    0xa  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_step_down        0x5f40  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_step_down_and_off
+                          0x6343  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_step_up          0x5dee  0x152  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_store_actual_level_in_the_dtr0
+                          0x6922   0xcf  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_store_the_dtr_as_power_on_level
+                          0x6bb4  0x1c3  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_store_the_dtr_as_scene
+                          0x6d8e  0x1ea  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_store_the_dtr_as_system_failure_level
+                          0x69f1  0x1c3  Code  Lc  r_dali209_cmd.o [30]
+_cmd_add_to_group       0x1'0d52   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_add_up               0x5986  0x22f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_application_extended_command
+                        0x1'13e5    0x7  Code  Lc  r_dali102_cmd.o [28]
+_cmd_colour_temperature_tc_step_cooler
+                          0x7aae   0xd0  Code  Lc  r_dali209_cmd.o [30]
+_cmd_colour_temperature_tc_step_warmer
+                          0x7b83   0xd8  Code  Lc  r_dali209_cmd.o [30]
+_cmd_compare            0x1'14c4   0x35  Code  Lc  r_dali102_cmd.o [28]
+_cmd_copy_report_to_temporary
+                          0x7e82   0xbe  Code  Lc  r_dali209_cmd.o [30]
+_cmd_dapc               0x1'02cd   0x9f  Code  Lc  r_dali102_cmd.o [28]
+_cmd_disable_current_protector
+                        0x1'5324   0x31  Code  Lc  r_dali207_cmd.o [29]
+_cmd_down               0x1'04b7  0x10e  Code  Lc  r_dali102_cmd.o [28]
+_cmd_dtr0               0x1'1442   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_dtr1               0x1'16d2   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_dtr2               0x1'16f6   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_enable_current_protector
+                        0x1'52f3   0x31  Code  Lc  r_dali207_cmd.o [29]
+_cmd_enable_dapc_sequence
+                        0x1'088e   0x28  Code  Lc  r_dali102_cmd.o [28]
+_cmd_enable_device_type
+                        0x1'1661   0x71  Code  Lc  r_dali102_cmd.o [28]
+_cmd_enable_write_memory
+                        0x1'0dda   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_go_to_last_active_level
+                        0x1'08b6   0x7a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_go_to_scene        0x1'0935   0x9e  Code  Lc  r_dali102_cmd.o [28]
+_cmd_identify_device    0x1'0aca   0x20  Code  Lc  r_dali102_cmd.o [28]
+_cmd_initialise         0x1'1466   0x3a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_off                0x1'036c   0x34  Code  Lc  r_dali102_cmd.o [28]
+_cmd_on_and_step_up     0x1'0828   0x66  Code  Lc  r_dali102_cmd.o [28]
+_cmd_ping               0x1'1518    0x3  Code  Lc  r_dali102_cmd.o [28]
+_cmd_program_short_address
+                        0x1'15d6   0x38  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_actual_level
+                        0x1'1102   0x41  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_colour_status
+                          0x833f   0x71  Code  Lc  r_dali209_cmd.o [30]
+_cmd_query_colour_type_features
+                          0x83b0   0x1f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_query_colour_value
+                          0x83d6  0x545  Code  Lc  r_dali209_cmd.o [30]
+_cmd_query_content_dtr0
+                        0x1'0f85   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_content_dtr1
+                        0x1'1024   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_content_dtr2
+                        0x1'1041   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_control_gear_failure
+                        0x1'12a3   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_control_gear_present
+                        0x1'0e98   0x14  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_current_protector_active
+                        0x1'5603   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_current_protector_enabled
+                        0x1'56e3   0x28  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_device_type  0x1'0fa2   0x42  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_dimming_curve
+                        0x1'54ce   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_extended_fade_time
+                        0x1'1286   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_extended_version_number
+                        0x1'13ec   0x2f  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_fade_time_fade_rate
+                        0x1'11b7   0x34  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_failure_status
+                        0x1'552b   0x1b  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_fast_fade_time
+                        0x1'572a   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_features     0x1'550c   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_gear_features_status
+                          0x8304   0x3b  Code  Lc  r_dali209_cmd.o [30]
+_cmd_query_gear_type    0x1'54af   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_groups_0_7   0x1'12ee   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_groups_8_15  0x1'130b   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_lamp_failure
+                        0x1'0eac   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_lamp_power_on
+                        0x1'0ed2   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_light_source_type
+                        0x1'107c   0x86  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_limit_error  0x1'0ef8   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_load_decrease
+                        0x1'55a7   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_load_increase
+                        0x1'55d5   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_manufacturer_specific_mode
+                        0x1'11eb   0x27  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_max_level    0x1'1143   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_min_fast_fade_time
+                        0x1'5749   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_min_level    0x1'1160   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_missing_short_address
+                        0x1'0f41   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_next_device_type
+                        0x1'1212   0x74  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_open_circuit
+                        0x1'5579   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_operating_mode
+                        0x1'105e   0x19  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_operating_modes
+                        0x1'570b   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_physical_minimum
+                        0x1'0fe4   0x1a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_possible_operating_modes
+                        0x1'54ed   0x1f  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_power_failure
+                        0x1'0ffe   0x26  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_power_on_level
+                        0x1'117d   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_random_address_h
+                        0x1'132e   0x1e  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_random_address_l
+                        0x1'1369   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_random_address_m
+                        0x1'134c   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_reference_measurement_failed
+                        0x1'56b5   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_reference_running
+                        0x1'568d   0x28  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_reset_state  0x1'0f1e   0x23  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_rgbwaf_control
+                          0x891b   0x1f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_query_scene_level  0x1'12c9   0x25  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_short_address
+                        0x1'1638   0x29  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_short_circuit
+                        0x1'554b   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_status       0x1'0df7   0xa1  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_system_failure_level
+                        0x1'119a   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_query_thermal_overload
+                        0x1'565f   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_thermal_shut_down
+                        0x1'5631   0x2e  Code  Lc  r_dali207_cmd.o [29]
+_cmd_query_version_number
+                        0x1'0f67   0x1e  Code  Lc  r_dali102_cmd.o [28]
+_cmd_randomise          0x1'14a0   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_read_memory_location
+                        0x1'1386   0x5f  Code  Lc  r_dali102_cmd.o [28]
+_cmd_recall_max_level   0x1'06bf   0x83  Code  Lc  r_dali102_cmd.o [28]
+_cmd_recall_min_level   0x1'0742   0x83  Code  Lc  r_dali102_cmd.o [28]
+_cmd_reference_system_power
+                        0x1'52a5   0x49  Code  Lc  r_dali207_cmd.o [29]
+_cmd_remove_from_group  0x1'0d7d   0x24  Code  Lc  r_dali102_cmd.o [28]
+_cmd_remove_from_scene  0x1'0d1b   0x17  Code  Lc  r_dali102_cmd.o [28]
+_cmd_rep_query_actual_level
+                          0x723f  0x118  Code  Lc  r_dali209_cmd.o [30]
+_cmd_reserved           0x1'17c7    0x3  Code  Lc  r_dali102_cmd.o [28]
+_cmd_reserved           0x1'5768    0x3  Code  Lc  r_dali207_cmd.o [29]
+_cmd_reserved             0x893a    0x3  Code  Lc  r_dali209_cmd.o [30]
+_cmd_reset              0x1'09d3   0x1d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_reset_memory_bank  0x1'0a6b   0x58  Code  Lc  r_dali102_cmd.o [28]
+_cmd_save_persistent_variables
+                        0x1'0a17   0x1a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_searchaddrh        0x1'151b   0x32  Code  Lc  r_dali102_cmd.o [28]
+_cmd_searchaddrl        0x1'15a2   0x34  Code  Lc  r_dali102_cmd.o [28]
+_cmd_searchaddrm        0x1'156e   0x34  Code  Lc  r_dali102_cmd.o [28]
+_cmd_select_dimming_curve
+                        0x1'5355   0xfd  Code  Lc  r_dali207_cmd.o [29]
+_cmd_set_extended_fade_time
+                        0x1'0cc1   0x2c  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_fade_rate      0x1'0c8e   0x33  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_fade_time      0x1'0c61   0x2d  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_max_level      0x1'0aea   0x85  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_min_level      0x1'0b6f   0x99  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_operating_mode
+                        0x1'0a31   0x3a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_power_on_level
+                        0x1'0c2f   0x27  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_scene          0x1'0ced   0x1b  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_short_address  0x1'0da1   0x39  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_system_failure_level
+                        0x1'0c08   0x27  Code  Lc  r_dali102_cmd.o [28]
+_cmd_set_temporary_colour_temperature_tc
+                          0x7a3c   0x6d  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_primary_n_dimlevel
+                          0x7c5b   0x21  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_rgb_dimlevel
+                          0x7c7c   0xbf  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_rgbwaf_control
+                          0x7e23   0x5f  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_waf_dimlevel
+                          0x7d56   0xc7  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_x_coordinate
+                          0x7357   0x6a  Code  Lc  r_dali209_cmd.o [30]
+_cmd_set_temporary_y_coordinate
+                          0x73c1   0x6a  Code  Lc  r_dali209_cmd.o [30]
+_cmd_step_down          0x1'0644   0x7b  Code  Lc  r_dali102_cmd.o [28]
+_cmd_step_down_and_off  0x1'07c5   0x63  Code  Lc  r_dali102_cmd.o [28]
+_cmd_step_up            0x1'05c5   0x7f  Code  Lc  r_dali102_cmd.o [28]
+_cmd_store_actual_level_in_dtr0
+                        0x1'09f0   0x27  Code  Lc  r_dali102_cmd.o [28]
+_cmd_store_colour_temperature_tc_limit
+                          0x7f86  0x263  Code  Lc  r_dali209_cmd.o [30]
+_cmd_store_colour_temperature_tc_step_increment
+                          0x7f40   0x41  Code  Lc  r_dali209_cmd.o [30]
+_cmd_store_dtr_as_fast_fade_time
+                        0x1'5457   0x52  Code  Lc  r_dali207_cmd.o [29]
+_cmd_store_enabled_channels
+                          0x8226   0xde  Code  Lc  r_dali209_cmd.o [30]
+_cmd_store_gear_features_status
+                          0x81e9   0x3d  Code  Lc  r_dali209_cmd.o [30]
+_cmd_terminate          0x1'141b   0x27  Code  Lc  r_dali102_cmd.o [28]
+_cmd_up                 0x1'03a0  0x10c  Code  Lc  r_dali102_cmd.o [28]
+_cmd_verify_short_address
+                        0x1'160e   0x2a  Code  Lc  r_dali102_cmd.o [28]
+_cmd_withdraw           0x1'14f9   0x1f  Code  Lc  r_dali102_cmd.o [28]
+_cmd_write_memory_location
+                        0x1'171a   0x5b  Code  Lc  r_dali102_cmd.o [28]
+_cmd_write_memory_location_no_reply
+                        0x1'1775   0x52  Code  Lc  r_dali102_cmd.o [28]
+_cmd_x_coordinate_step_down
+                          0x7783   0xe4  Code  Lc  r_dali209_cmd.o [30]
+_cmd_x_coordinate_step_up
+                          0x769f   0xe4  Code  Lc  r_dali209_cmd.o [30]
+_cmd_y_coordinate_step_down
+                          0x7956   0xdd  Code  Lc  r_dali209_cmd.o [30]
+_cmd_y_coordinate_step_up
+                          0x7872   0xdd  Code  Lc  r_dali209_cmd.o [30]
+_delay_wait               0x548a         Code  Gb  r_bsp_common_iar.o [23]
+_df_handler             0x1'331f   0x1c  Code  Lc  r_nvm.o [1]
+_df_write_handler       0x1'32d3   0x4c  Code  Lc  r_nvm.o [1]
+_division               0x1'71d1   0x35  Code  Lc  r_dali102_fade.o [28]
+_division               0x1'51eb   0x35  Code  Lc  r_dali209_fade.o [30]
+_erase_task             0x1'3180  0x139  Code  Lc  r_nvm.o [1]
+_exit                   0x1'8fd7    0x4  Code  Gb  exit.o [27]
+_force_stop             0x1'7e67   0x20  Code  Lc  r_led.o [2]
+_g_dali209_general_callback
+                        0xf'3e4e   0x20  Data  Gb  r_lamp.o [1]
+_g_dimming_rate         0xf'2c00  0x200  Data  Gb  r_lamp.o [1]
+_g_dimming_table        0xf'2000  0xc00  Data  Gb  r_lamp.o [1]
+_g_led1_duty            0xf'fe24    0x4  Data  Gb  r_led1.o [2]
+_g_led1_err             0xf'fe28    0x4  Data  Gb  r_led1.o [2]
+_g_led1_fb_ad           0xf'fe4c    0x2  Data  Gb  r_led1.o [2]
+_g_led1_fb_ad_old       0xf'fe4e    0x2  Data  Gb  r_led1.o [2]
+_g_led1_feedback_is_enabled
+                        0xf'd1d4    0x1  Data  Gb  r_led1.o [2]
+_g_led1_offset          0xf'fe50    0x2  Data  Gb  r_led1.o [2]
+_g_led1_vr              0xf'fe4a    0x2  Data  Gb  r_led1.o [2]
+_g_led2_duty            0xf'fe2c    0x4  Data  Gb  r_led2.o [2]
+_g_led2_err             0xf'fe30    0x4  Data  Gb  r_led2.o [2]
+_g_led2_fb_ad           0xf'fe54    0x2  Data  Gb  r_led2.o [2]
+_g_led2_fb_ad_old       0xf'fe56    0x2  Data  Gb  r_led2.o [2]
+_g_led2_feedback_is_enabled
+                        0xf'd1d8    0x1  Data  Gb  r_led2.o [2]
+_g_led2_offset          0xf'fe58    0x2  Data  Gb  r_led2.o [2]
+_g_led2_vr              0xf'fe52    0x2  Data  Gb  r_led2.o [2]
+_g_led3_duty            0xf'fe34    0x4  Data  Gb  r_led3.o [2]
+_g_led3_err             0xf'fe38    0x4  Data  Gb  r_led3.o [2]
+_g_led3_fb_ad           0xf'fe5c    0x2  Data  Gb  r_led3.o [2]
+_g_led3_fb_ad_old       0xf'fe5e    0x2  Data  Gb  r_led3.o [2]
+_g_led3_feedback_is_enabled
+                        0xf'd1dc    0x1  Data  Gb  r_led3.o [2]
+_g_led3_offset          0xf'fe60    0x2  Data  Gb  r_led3.o [2]
+_g_led3_vr              0xf'fe5a    0x2  Data  Gb  r_led3.o [2]
+_g_rx_frame_data        0xf'd784    0x4  Data  Gb  Config_DALI.o [2]
+_g_rx_frame_exists      0xf'd783    0x1  Data  Gb  Config_DALI.o [2]
+_g_rx_frame_length      0xf'd782    0x1  Data  Gb  Config_DALI.o [2]
+_g_u08_change_interrupt_vector_flag
+                        0xf'd221    0x1  Data  Gb  r_rfd_common_api.o [3]
+_g_u08_cpu_frequency    0xf'd222    0x1  Data  Gb  r_rfd_common_api.o [3]
+_g_u08_fset_cpu_frequency
+                        0xf'd223    0x1  Data  Gb  r_rfd_common_api.o [3]
+_g_uart0_tx_count       0xf'd79c    0x2  Data  Gb  Config_UART0.o [19]
+_g_unit0_memory_bank_info_list
+                        0xf'405a    0x2  Data  Gb  r_unit0_memory_bank.o [1]
+_get_crossed_point        0xb4a1  0x46a  Code  Lc  r_dali209.o [30]
+_get_cur_container      0x1'87bf   0x15  Code  Lc  r_dali102_list.o [28]
+_gp_uart0_tx_address    0xf'd79a    0x2  Data  Gb  Config_UART0.o [19]
+_gs_active_time_us      0xf'd77e    0x4  Data  Lc  r_dali101_rx.o [2]
+_gs_additional_process  0xf'322a  0x158  Data  Lc  r_dali209_cmd.o [30]
+_gs_auto_save_timer     0xf'd730    0x2  Data  Lc  r_cg.o [1]
+_gs_backward            0xf'd7a2    0x2  Data  Lc  r_dali101_bft.o [2]
+_gs_blue_level          0xf'd792    0x2  Data  Lc  r_lamp_rgbwaf.o [1]
+_gs_bus_timer_mode      0xf'd778    0x1  Data  Lc  r_dali101_rx.o [2]
+_gs_colour_report_timer
+                        0xf'd732    0x2  Data  Lc  r_cg.o [1]
+_gs_command_execute_condition
+                        0xf'36be   0xac  Data  Lc  r_dali102_cmd.o [28]
+_gs_command_execute_condition
+                        0xf'38d6   0x56  Data  Lc  r_dali207_cmd.o [29]
+_gs_command_execute_extended_condition
+                        0xf'3a2a   0x32  Data  Lc  r_dali209_cmd.o [30]
+_gs_convert_tc_to_xy_table
+                        0xf'2e00  0x17a  Data  Lc  r_lamp.o [1]
+_gs_cooler_level        0xf'd7a6    0x2  Data  Lc  r_lamp_tc.o [1]
+_gs_dali102_general_callback
+                        0xf'3fb8    0x4  Data  Lc  r_cg.o [1]
+_gs_dali102_mb_if_callback
+                        0xf'3fbc   0x14  Data  Lc  r_cg.o [1]
+_gs_debug               0xf'd788    0x6  Data  Lc  r_debug.o [1]
+_gs_df                  0xf'd76c    0xc  Data  Lc  r_nvm.o [1]
+_gs_dt6_sc              0xf'3a1e    0xc  Data  Lc  r_dali207_api.o [29]
+_gs_dt8_sc              0xf'399e   0x10  Data  Lc  r_dali209_api.o [30]
+_gs_dtx_sc              0xf'39ee   0x30  Data  Lc  r_dali207_api.o [29]
+_gs_dtx_sc              0xf'396e   0x30  Data  Lc  r_dali209_api.o [30]
+_gs_ex_command_execute_condition
+                        0xf'3eae   0x20  Data  Lc  r_dali207_cmd.o [29]
+_gs_execute_application_extended_command
+                        0xf'376a   0x80  Data  Lc  r_dali209_cmd.o [30]
+_gs_execute_command     0xf'2f7a  0x158  Data  Lc  r_dali102_cmd.o [28]
+_gs_execute_extended_cmd
+                        0xf'37ea   0x7c  Data  Lc  r_dali207_cmd.o [29]
+_gs_extended_command_num
+                        0xf'3ece   0x20  Data  Lc  r_dali209_cmd.o [30]
+_gs_feedback            0xf'd1ca    0x1  Data  Lc  r_led.o [2]
+_gs_frame               0xf'd74c    0xa  Data  Lc  r_dali101_rx.o [2]
+_gs_get_value           0xf'fe3c    0x2  Data  Lc  r_led.o [2]
+_gs_green_level         0xf'd790    0x2  Data  Lc  r_lamp_rgbwaf.o [1]
+_gs_idle_time_us        0xf'd77a    0x4  Data  Lc  r_dali101_rx.o [2]
+_gs_lamp                0xf'd734   0x18  Data  Lc  r_lamp.o [1]
+_gs_last_frame          0xf'd756    0xa  Data  Lc  r_dali101_rx.o [2]
+_gs_led_current_level   0xf'd1d6    0x2  Data  Lc  r_led1.o [2]
+_gs_led_current_level   0xf'd1da    0x2  Data  Lc  r_led2.o [2]
+_gs_led_current_level   0xf'd1de    0x2  Data  Lc  r_led3.o [2]
+_gs_memory_map0         0xf'34b0  0x10e  Data  Lc  r_unit0_memory_bank.o [1]
+_gs_red_level           0xf'd78e    0x2  Data  Lc  r_lamp_rgbwaf.o [1]
+_gs_replacement_command
+                        0xf'30d2  0x158  Data  Lc  r_dali209_cmd.o [30]
+_gs_seed                0xf'd7aa    0x4  Data  Lc  r_random.o [1]
+_gs_send_timer          0xf'd7a4    0x2  Data  Lc  r_dali101_bft.o [2]
+_gs_special_command_num
+                        0xf'3bf0   0x2c  Data  Lc  r_dali102_cmd.o [28]
+_gs_standard_command_num
+                        0xf'35be  0x100  Data  Lc  r_dali102_cmd.o [28]
+_gs_storage             0xf'd700   0x1c  Data  Lc  r_nvm.o [1]
+_gs_storage0            0xf'd760    0xc  Data  Lc  r_cg.o [1]
+_gs_storage1            0xf'd62c   0xd4  Data  Lc  r_cg.o [1]
+_gs_system_failure      0xf'd72e    0x1  Data  Lc  r_cg.o [1]
+_gs_system_failure_is_detected
+                        0xf'd779    0x1  Data  Lc  r_dali101_rx.o [2]
+_gs_task                0xf'd426  0x106  Data  Lc  r_nvm.o [1]
+_gs_unit                0xf'cf00  0x2ca  Data  Lc  r_cg.o [1]
+_gs_warmer_level        0xf'd7a8    0x2  Data  Lc  r_lamp_tc.o [1]
+_gs_xy_blue_level       0xf'd798    0x2  Data  Lc  r_lamp_xy.o [1]
+_gs_xy_green_level      0xf'd796    0x2  Data  Lc  r_lamp_xy.o [1]
+_gs_xy_red_level        0xf'd794    0x2  Data  Lc  r_lamp_xy.o [1]
+_gsp_callback           0xf'd7b4    0x2  Data  Lc  r_dali102_mb_if.o [28]
+_gsp_gen_callback       0xf'd7b2    0x2  Data  Lc  r_dali102.o [28]
+_gsp_gen_callback       0xf'd7b6    0x2  Data  Lc  r_dali209.o [30]
+_hdwinit                0x1'8fb2    0xb  Code  Gb  hdwinit.o [22]
+_interrupt_vector_table
+                             0x0         Data  Gb  interrupt_vector.o [27]
+_lines_is_crossed         0xb279  0x228  Code  Lc  r_dali209.o [30]
+_main                   0x1'8eb5   0x1d  Code  Gb  r_main.o [1]
+_mcu_clock_setup        0x1'8165   0xc3  Code  Gb  mcu_clocks.o [24]
+_memchr                 0x1'8f19    0x4  Code  Gb  memchr.o [27]
+_memcmp                 0x1'8e50   0x24  Code  Gb  memcmp.o [27]
+_memory_bank_cancel_write
+                        0x1'28dd    0xf  Code  Lc  r_cg.o [1]
+_memory_bank_read       0x1'288e   0x1a  Code  Lc  r_cg.o [1]
+_memory_bank_reset      0x1'2878   0x16  Code  Lc  r_cg.o [1]
+_memory_bank_unlatch_read
+                        0x1'28ce    0xf  Code  Lc  r_cg.o [1]
+_memory_bank_write      0x1'28a8   0x26  Code  Lc  r_cg.o [1]
+_memset                 0x1'8f1d   0x15  Code  Gb  memset.o [27]
+_opbyte0                    0xc0    0x1  Data  Gb  vecttbl.o [24]
+_opbyte1                    0xc1    0x1  Data  Gb  vecttbl.o [24]
+_opbyte2                    0xc2    0x1  Data  Gb  vecttbl.o [24]
+_opbyte3                    0xc3    0x1  Data  Gb  vecttbl.o [24]
+_pad                    0x1'49ea   0x40  Code  Lc  xprintfsmall_nomb.o [27]
+_r_Config_DALI_interrupt_falling_edge_detection
+                          0x4fe9   0x14  Code  Lc  Config_DALI_user.o [2]
+_r_Config_DALI_interrupt_power_down_detection
+                          0x4fce   0x1b  Code  Lc  Config_DALI_user.o [2]
+_r_Config_DALI_interrupt_stop_bit_detection
+                          0x4ffd   0x50  Code  Lc  Config_DALI_user.o [2]
+_r_Config_TAU0_2_interrupt
+                          0x52a2   0x14  Code  Lc  Config_TAU0_2_user.o [15]
+_r_Config_TAU0_3_interrupt
+                          0x52b6   0x14  Code  Lc  Config_TAU0_3_user.o [16]
+_r_Config_UART0_interrupt_send
+                          0x5257   0x28  Code  Lc  Config_UART0_user.o [19]
+_r_rfd_wait_count         0x53b2   0x13  Code  Gb  r_rfd_common_api.o [3]
+_r_tau0_channel1_isr      0x44c0  0x38d  Code  Lc  r_led.o [2]
+_ramsar_init              0x5121         Code  Gb  cstartup.o [23]
+_sec_hand               0xf'd7ae    0x4  Data  Lc  xfail_s.o [27]
+_secuid                     0xc4    0xa  Data  Gb  vecttbl.o [24]
+_sg_u08_psw_ie_state    0xf'd224    0x1  Data  Lc  r_rfd_common_userown.o [5]
+_sprintf                0x1'8cac   0x3b  Code  Gb  sprintf.o [27]
+_strchr                 0x1'8f6a    0x4  Code  Gb  strchr.o [27]
+_strlen                 0x1'8f9a    0xc  Code  Gb  strlen.o [27]
+_swap_valid_block       0x1'32b9   0x1a  Code  Lc  r_nvm.o [1]
+_update_storage0        0x1'2355   0xc2  Code  Lc  r_cg.o [1]
+_update_storage1        0x1'2417  0x461  Code  Lc  r_cg.o [1]
+colour_report::msg      0xf'd52c  0x100  Data  Lc  r_cg.o [1]
+colour_report::pre_level
+                        0xf'd79e    0x1  Data  Lc  r_cg.o [1]
+colour_report::pre_rgbwaf
+                        0xf'd71c    0xe  Data  Lc  r_cg.o [1]
+colour_report::pre_tc   0xf'd7a0    0x2  Data  Lc  r_cg.o [1]
+colour_report::pre_xy   0xf'd72a    0x4  Data  Lc  r_cg.o [1]
+get_fast_fade_time_ms::fast_fade_time_ms
+                        0xf'3866   0x70  Data  Lc  r_dali207.o [29]
+get_port_address::port_addr
+                        0xf'3cc4   0x2a  Data  Lc  r_port.o [2]
+led1_feedback_operation::temp11
+                        0xf'fe3e    0x2  Data  Lc  r_led.o [2]
+led1_feedback_operation::temp12
+                        0xf'fe40    0x2  Data  Lc  r_led.o [2]
+led2_feedback_operation::temp21
+                        0xf'fe42    0x2  Data  Lc  r_led.o [2]
+led2_feedback_operation::temp22
+                        0xf'fe44    0x2  Data  Lc  r_led.o [2]
+led3_feedback_operation::temp31
+                        0xf'fe46    0x2  Data  Lc  r_led.o [2]
+led3_feedback_operation::temp32
+                        0xf'fe48    0x2  Data  Lc  r_led.o [2]
+
+
+[1] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\App
+[2] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Driver
+[3] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\common
+[4] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\source\dataflash
+[5] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Library\RFD\userown
+[6] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_ADC
+[7] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP0
+[8] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP1
+[9] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_COMP2
+[10] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_DAC0
+[11] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PGA
+[12] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_PORT
+[13] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_0
+[14] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_1
+[15] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_2
+[16] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TAU0_3
+[17] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB0
+[18] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_TKB1
+[19] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_UART0
+[20] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\Config_WDT
+[21] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\general
+[22] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\board\generic_rl78_g24
+[23] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\all
+[24] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Renesas_SC\smc_gen\r_bsp\mcu\rl78_g24
+[25] = C:\work\workspace\runtime-lighting.product\qwq\qeLighting_gen\solution\Release\Obj\Utility
+[26] = dbgrlfnf23nd.a
+[27] = dlrlfnf23n.a
+[28] = r_dali_102_iar_gen2_v1_01.a
+[29] = r_dali_207_iar_gen2_v1_01.a
+[30] = r_dali_209_iar_gen2_v2_00.a
+
+  67'572 bytes of readonly  code memory
+   8'705 bytes of readonly  data memory
+   2'297 bytes of readwrite data memory (+ 283 absolute)
+
+Errors: none
+Warnings: 3

--- a/smc/src/main/java/com/tlcsdm/smc/codeDev/ecm/AbstractU2XFamilyScript.java
+++ b/smc/src/main/java/com/tlcsdm/smc/codeDev/ecm/AbstractU2XFamilyScript.java
@@ -118,6 +118,9 @@ public abstract sealed class AbstractU2XFamilyScript extends AbstractEcmScript p
      * errorSource 数据后续处理
      */
     protected void handlerErrorSourceMap(Map<String, Object> errorSource, String product, int optErrortIndex) {
+        if(product.startsWith("RH850U2C2") && errorSource.get("categoryId").equals("OSTM")){
+            return;
+        }
         GroovyUtil.invokeMethod(getGroovyPath(), "handlerErrorSourceMap", errorSource, product, optErrortIndex);
     }
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Introduce a new test for parsing IAR map files and enhance error source map handling in AbstractU2XFamilyScript.

Enhancements:
- Update AbstractU2XFamilyScript to skip error source map handling for products starting with 'RH850U2C2' and category 'OSTM'.

Tests:
- Add a new test method 'readIarMap' in MemoryMappingTest to handle parsing of IAR map files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在 `MemoryMappingTest` 类中添加了 `readIarMap()` 方法，以支持处理新的 `iar.map` 文件格式。
  
- **变更**
  - 在 `AbstractU2XFamilyScript` 类中修改了 `handlerErrorSourceMap` 方法，增加了对特定产品和类别组合的处理逻辑，优化了控制流。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->