### PR TITLE
test: Improve MemoryMappingTest

### DIFF
--- a/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
+++ b/qe/src/test/java/com/tlcsdm/qe/MemoryMappingTest.java
@@ -29,6 +29,7 @@ package com.tlcsdm.qe;
 
 import cn.hutool.core.io.resource.ResourceUtil;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -49,7 +50,6 @@ public class MemoryMappingTest {
     private final String endFlag = "*** ";
     private final String globalVarFlag = "data ,g";
     List<String> sections = new ArrayList<>();
-    List<String> varContent = new ArrayList<>();
     List<Symbol> symbols = new ArrayList<>();
     private boolean inOptions = false;
     private boolean inSymbol = false;
@@ -59,6 +59,7 @@ public class MemoryMappingTest {
     public void read() throws IOException {
         File file = new File(ResourceUtil.getResource("cs+.map").getPath());
         List<String> content = FileUtils.readLines(file, StandardCharsets.UTF_8);
+        String previousLine = "";
         for (String line : content) {
             if (!inOptions && !inSymbol && line.equals(optionsFlag)) {
                 inOptions = true;
@@ -86,10 +87,8 @@ public class MemoryMappingTest {
                 } else if (inRomSectionFlag) {
                     if (line.contains(globalVarFlag)) {
                         String[] data = line.split("\\s+");
-                        symbols.add(new Symbol(varContent.get(varContent.size() - 1).trim(), data[1],
+                        symbols.add(new Symbol(previousLine.trim(), data[1],
                             Integer.parseInt(data[2])));
-                    } else {
-                        varContent.add(line);
                     }
                 }
                 if (line.startsWith(endFlag) && !line.equals(symbolFlag)) {
@@ -97,11 +96,14 @@ public class MemoryMappingTest {
                     break;
                 }
             }
+            previousLine = line;
         }
-        varContent = null;
         sections = null;
         content = null;
         System.out.println(symbols);
+        Assertions.assertEquals(
+            "[Symbol[name=_g_send_busy_flg, address=000fd3d7, size=1], Symbol[name=_g_run_ack_flg, address=000fd3d8, size=1], Symbol[name=_g_variable_flg, address=000fd3d9, size=1], Symbol[name=_request_flag, address=000fd3da, size=1], Symbol[name=_A1, address=000fd3ee, size=4], Symbol[name=_A2, address=000fd3f2, size=4], Symbol[name=_g_led1_feedback_is_enabled, address=000fd3f8, size=1], Symbol[name=_g_led2_feedback_is_enabled, address=000fd3fc, size=1], Symbol[name=_g_led3_feedback_is_enabled, address=000fd400, size=1], Symbol[name=_count, address=000fd404, size=2], Symbol[name=_maxCount, address=000fd406, size=2], Symbol[name=_timer_flag, address=000fd408, size=1], Symbol[name=_g_tx_end_flag, address=000fd40a, size=1], Symbol[name=_g_rx_end_flag, address=000fd40b, size=1], Symbol[name=_g_u08_change_interrupt_vector_flag, address=000fde30, size=1], Symbol[name=_g_u08_cpu_frequency, address=000fde31, size=1], Symbol[name=_g_u08_fset_cpu_frequency, address=000fde32, size=1], Symbol[name=_g_led1_vr, address=000ffe22, size=2], Symbol[name=_g_led1_fb_ad, address=000ffe24, size=2], Symbol[name=_g_led1_fb_ad_old, address=000ffe26, size=2], Symbol[name=_g_led1_offset, address=000ffe28, size=2], Symbol[name=_g_led1_duty, address=000ffe2a, size=4], Symbol[name=_g_led1_err, address=000ffe2e, size=4], Symbol[name=_g_led2_vr, address=000ffe32, size=2], Symbol[name=_g_led2_fb_ad, address=000ffe34, size=2], Symbol[name=_g_led2_fb_ad_old, address=000ffe36, size=2], Symbol[name=_g_led2_offset, address=000ffe38, size=2], Symbol[name=_g_led2_duty, address=000ffe3a, size=4], Symbol[name=_g_led2_err, address=000ffe3e, size=4], Symbol[name=_g_led3_vr, address=000ffe42, size=2], Symbol[name=_g_led3_fb_ad, address=000ffe44, size=2], Symbol[name=_g_led3_fb_ad_old, address=000ffe46, size=2], Symbol[name=_g_led3_offset, address=000ffe48, size=2], Symbol[name=_g_led3_duty, address=000ffe4a, size=4], Symbol[name=_g_led3_err, address=000ffe4e, size=4]]",
+            symbols.toString());
     }
 
     private final String iarSymbolFlag = "*** ENTRY LIST";


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Tests:
- Improve the MemoryMappingTest by removing the varContent list and using a previousLine variable to track the last line read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 优化了符号添加逻辑，改用`previousLine`变量以提高准确性。
	- 增加了对`symbols`列表输出的断言，确保结果符合预期。

- **Refactor**
	- 移除了不必要的`varContent`列表，简化了代码结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->