### PR TITLE
ci: Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,20 +36,18 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                deleteDir()
                 copyArtifacts filter: '*linux*17*,*mac*17*,*windows*17*', fingerprintArtifacts: true, projectName: 'JRE', selector: lastSuccessful()
                 archiveArtifacts 'OpenJDK17*'
-                timeout(time: 3, unit: 'MINUTES') {
-                    git 'git@github.com:unknowIfGuestInDream/javafxTool.git'
-                }
                 sh "$M2_HOME/bin/mvn -version"
             }
             post {
                 failure {
                     buildDescription '构建 Prepare 失败'
+                    cleanWs()
                 }
                 aborted {
                     buildDescription '构建取消'
+                    cleanWs()
                 }
             }
         }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Update the Jenkinsfile to modify the 'Prepare' stage by removing the initial workspace deletion and adding workspace cleanup in the 'failure' and 'aborted' post conditions.

CI:
- Remove the deletion of the workspace directory at the start of the 'Prepare' stage in the Jenkins pipeline.
- Add workspace cleanup steps in the 'failure' and 'aborted' post conditions of the 'Prepare' stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- 更新了Jenkins管道配置，优化了工作区清理和错误处理机制。
- **修复**
	- 在构建失败或中止时，确保工作区在后处理阶段得到清理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->