### PR TITLE
ci: Update jenkins change check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,14 +36,13 @@ pipeline {
     stages {
         stage('Check change') {
             steps {
-                echo "${currentBuild.getBuildCauses()}"
                 echo "Previous successful commit: ${GIT_PREVIOUS_SUCCESSFUL_COMMIT}"
                 echo "Current commit: ${GIT_COMMIT}"
                 script {
                     if (GIT_PREVIOUS_SUCCESSFUL_COMMIT == GIT_COMMIT) {
                         echo "no change，skip build"
-                        currentBuild.result = 'NOT_BUILT'
-                        return
+                        currentBuild.getRawBuild().getExecutor().interrupt(Result.NOT_BUILT)
+                        sleep(1)
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

CI:
- Modify the Jenkins pipeline to use 'getRawBuild().getExecutor().interrupt(Result.NOT_BUILT)' instead of setting 'currentBuild.result' to 'NOT_BUILT' when there is no change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修改了构建管道的控制流，确保在当前提交与上一个成功提交匹配时，构建被中断而非简单标记为未构建。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->