### PR TITLE
docs: Add javadoc link

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,1 +1,2 @@
 * [❤️❤️ 首页](/)
+* [Javadoc](https://javafxtool.tlcsdm.com/apidocs/ ':target=_blank')


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Documentation:
- Add a link to the Javadoc in the navigation bar of the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在文档导航栏中新增“Javadoc”链接，提供直接访问Javadoc文档的选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->