### PR TITLE
build: Add maven-antrun-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2024 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 pipeline {
     agent any
     options {
@@ -59,14 +86,14 @@ pipeline {
         stage('Prepare Windows Build') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
-                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' clean -T 1C install"
+                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' -DworkEnv=ci clean -T 1C install"
                 }
             }
         }
 
         stage('Build smc-windows') {
             steps {
-                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
@@ -94,7 +121,7 @@ rm -r license'''
 
         stage('Build qe-windows') {
             steps {
-                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
@@ -122,7 +149,7 @@ rm -r license'''
 
         stage('Build cg-windows') {
             steps {
-                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs
@@ -151,14 +178,14 @@ rm -r license'''
         stage('Prepare Mac Build') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
-                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=mac -Dmaven.test.skip=true -Dmaven.javadoc.skip=true clean -T 1C install"
+                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=mac -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -DworkEnv=ci clean -T 1C install"
                 }
             }
         }
 
         stage('Build smc-mac') {
             steps {
-                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
@@ -186,7 +213,7 @@ rm -r license'''
 
         stage('Build qe-mac') {
             steps {
-                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
@@ -214,7 +241,7 @@ rm -r license'''
 
         stage('Build cg-mac') {
             steps {
-                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs
@@ -243,14 +270,14 @@ rm -r license'''
         stage('Prepare Linux Build') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
-                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=linux -Dmaven.test.skip=true -Dmaven.javadoc.skip=true clean -T 1C install"
+                    sh "$M2_HOME/bin/mvn -f pom.xml -s $M2_HOME/conf/settings.xml -Djavafx.platform=linux -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -DworkEnv=ci clean -T 1C install"
                 }
             }
         }
 
         stage('Build smc-linux') {
             steps {
-                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
@@ -278,7 +305,7 @@ rm -r license'''
 
         stage('Build qe-linux') {
             steps {
-                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
@@ -306,7 +333,7 @@ rm -r license'''
 
         stage('Build cg-linux') {
             steps {
-                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -Pjavadoc-with-links package"
+                sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+        <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <license-maven-plugin.version>2.5.0</license-maven-plugin.version>
         <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
@@ -1403,7 +1405,7 @@
                     <verbose>false</verbose>
                     <skip>false</skip>
                     <prefix>jfx-git</prefix>
-                    <dotGitDirectory>$${project.basedir}/../.git</dotGitDirectory>
+                    <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>target/git.properties
                     </generateGitPropertiesFilename>
@@ -1528,6 +1530,24 @@
                     </additionalConfig>
                     <wtpversion>2.0</wtpversion>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <phase>test</phase>
+                        <configuration>
+                            <target unless="workEnv">
+                                <echo message="You need to set -DworkEnv=ci in CI, otherwise it defaults to dev in the development environment."/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 
@@ -1712,6 +1732,25 @@
                                 </resources>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>copy-mf-licence</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>copy-resources</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${project.build.directory}/classes/META-INF</outputDirectory>
+                                <resources>
+                                    <resource>
+                                        <directory>${basedir}/../</directory>
+                                        <includes>
+                                            <include>LICENSE</include>
+                                        </includes>
+                                        <filtering>true</filtering>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -1790,6 +1829,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>${maven-project-info-reports-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven-antrun-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${buildnumber-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1946,6 +1995,35 @@
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>md5</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-md5</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <checksum algorithm="md5"
+                                                  file="${project.build.directory}/${project.build.finalName}.jar"
+                                                  property="md5.checksum"/>
+                                        <!--suppress UnresolvedMavenProperty -->
+                                        <echo file="${project.build.directory}/MD5" message="${md5.checksum}"/>
+                                    </target>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1540,7 +1540,7 @@
                         <phase>test</phase>
                         <configuration>
                             <target unless="workEnv">
-                                <echo message="You need to set -DworkEnv=ci in CI, otherwise it defaults to dev in the development environment."/>
+                                <echo message="You need to set -DworkEnv=ci in CI, otherwise it defaults to dev in the development environment and when started from a jar the value is prod."/>
                             </target>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -2021,7 +2021,8 @@
                                                   file="${project.build.directory}/${project.build.finalName}.jar"
                                                   property="md5.checksum"/>
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo file="${project.build.directory}/MD5" message="${md5.checksum}"/>
+                                        <echo file="${project.build.directory}/${project.build.finalName}.jar.MD5"
+                                              message="${md5.checksum}"/>
                                     </target>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1540,7 +1540,7 @@
                         <phase>test</phase>
                         <configuration>
                             <target unless="workEnv">
-                                <echo message="You need to set -DworkEnv=ci in CI, otherwise it defaults to dev in the development environment and when started from a jar the value is prod."/>
+                                <echo message="You need to set -DworkEnv=ci in CI to skip some test cases, otherwise it defaults to dev in the development environment and when started from a jar the value is prod."/>
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Integrate maven-antrun-plugin and buildnumber-maven-plugin into the build system to enhance build customization and management.

Build:
- Add maven-antrun-plugin to the build configuration for executing custom tasks during the build lifecycle.
- Introduce buildnumber-maven-plugin to manage build numbers in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 引入了新的构建插件以增强构建配置。
	- 添加了环境变量检查功能，确保在CI环境中正确设置。
	- 更新了许可证文件的复制流程，确保其包含在构建输出中。
	- 在多个构建阶段中一致地应用了新的构建参数 `-DworkEnv=ci`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->