### PR TITLE
build: Add git-changelog-maven-plugin

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -78,7 +78,9 @@ jobs:
           mkdir -p ${result_path}
           mvn --file ${{ matrix.mod }}/pom.xml -DskipTests -Duser.name='Github Action' -Djavafx.platform=${{ matrix.buildos }} -Pjavadoc-with-links package
           cp ${{ matrix.mod }}/target/javafxTool-${{ matrix.mod }}.jar ${result_path}/javafxTool-${{ matrix.mod }}.jar
-          cp ${{ matrix.mod }}/target/CHANGELOG_with-unreleased.md ${result_path}/CHANGELOG_with-unreleased.md
+          if [ -f "${{ matrix.mod }}/target/CHANGELOG_with-unreleased.md" ]; then
+              cp ${{ matrix.mod }}/target/CHANGELOG_with-unreleased.md ${result_path}/CHANGELOG_with-unreleased.md
+          fi
           cp -r ${{ matrix.mod }}/target/lib ${result_path}/lib
           cp -r docs ${result_path}/docs
           cp -r ${{ matrix.mod }}/target/reports/apidocs ${result_path}/apidocs

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -78,6 +78,7 @@ jobs:
           mkdir -p ${result_path}
           mvn --file ${{ matrix.mod }}/pom.xml -DskipTests -Duser.name='Github Action' -Djavafx.platform=${{ matrix.buildos }} -Pjavadoc-with-links package
           cp ${{ matrix.mod }}/target/javafxTool-${{ matrix.mod }}.jar ${result_path}/javafxTool-${{ matrix.mod }}.jar
+          cp ${{ matrix.mod }}/target/CHANGELOG_with-unreleased.md ${result_path}/CHANGELOG_with-unreleased.md
           cp -r ${{ matrix.mod }}/target/lib ${result_path}/lib
           cp -r docs ${result_path}/docs
           cp -r ${{ matrix.mod }}/target/reports/apidocs ${result_path}/apidocs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,12 +95,14 @@ pipeline {
             steps {
                 sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
+cp smc/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
 cp -r smc/target/license license
 zip -r smcTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-smc.jar lib apidocs license
 zip -uj smcTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/win/smc/*
 rm javafxTool-smc.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -123,12 +125,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
+cp qe/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
 cp -r qe/target/license license
 zip -r qeTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-qe.jar lib apidocs license
 zip -uj qeTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/win/qe/*
 rm javafxTool-qe.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -151,12 +155,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=win -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
+cp cg/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs
 cp -r cg/target/license license
 zip -r cgTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-cg.jar lib apidocs license
 zip -uj cgTool-win_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/win/cg/*
 rm javafxTool-cg.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -187,12 +193,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
+cp smc/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
 cp -r smc/target/license license
 zip -r smcTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-smc.jar lib apidocs license
 zip -uj smcTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/mac/smc/*
 rm javafxTool-smc.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -215,12 +223,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
+cp qe/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
 cp -r qe/target/license license
 zip -r qeTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-qe.jar lib apidocs license
 zip -uj qeTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/mac/qe/*
 rm javafxTool-qe.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -243,12 +253,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=mac -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
+cp cg/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs
 cp -r cg/target/license license
 zip -r cgTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-cg.jar lib apidocs license
 zip -uj cgTool-mac_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/mac/cg/*
 rm javafxTool-cg.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -279,12 +291,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f smc/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp smc/target/javafxTool-smc.jar javafxTool-smc.jar
+cp smc/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r smc/target/lib lib
 cp -r smc/target/reports/apidocs apidocs
 cp -r smc/target/license license
 zip -r smcTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-smc.jar lib apidocs license
 zip -uj smcTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/linux/smc/*
 rm javafxTool-smc.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -307,12 +321,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f qe/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp qe/target/javafxTool-qe.jar javafxTool-qe.jar
+cp qe/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r qe/target/lib lib
 cp -r qe/target/reports/apidocs apidocs
 cp -r qe/target/license license
 zip -r qeTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-qe.jar lib apidocs license
 zip -uj qeTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/linux/qe/*
 rm javafxTool-qe.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''
@@ -335,12 +351,14 @@ rm -r license'''
             steps {
                 sh "$M2_HOME/bin/mvn -f cg/pom.xml -s $M2_HOME/conf/settings.xml -Duser.name=${USER_NAME} -Djavafx.platform=linux -Dmaven.test.skip=true -DworkEnv=ci -Pjavadoc-with-links package"
                 sh '''cp cg/target/javafxTool-cg.jar javafxTool-cg.jar
+cp cg/target/CHANGELOG_with-unreleased.md CHANGELOG_with-unreleased.md
 cp -r cg/target/lib lib
 cp -r cg/target/reports/apidocs apidocs
 cp -r cg/target/license license
 zip -r cgTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip docs javafxTool-cg.jar lib apidocs license
 zip -uj cgTool-linux_b${BUILD_NUMBER}_$(date +%Y%m%d).zip jenkins/linux/cg/*
 rm javafxTool-cg.jar
+rm CHANGELOG_with-unreleased.md
 rm -r lib
 rm -r apidocs
 rm -r license'''

--- a/cg/pom.xml
+++ b/cg/pom.xml
@@ -160,12 +160,25 @@
                 <executions>
                     <execution>
                         <!-- Default configuration for running with: mvn clean javafx:run -->
-                        <id>default-cli</id>
+                        <id>cg-cli</id>
                         <configuration>
                             <mainClass>com.tlcsdm.cg/com.tlcsdm.cg.CgSampler</mainClass>
+                            <options>
+                                <option>-DworkEnv=prod</option>
+                            </options>
+                            <launcher>app</launcher>
+                            <jlinkZipName>app</jlinkZipName>
+                            <jlinkImageName>app</jlinkImageName>
+                            <noManPages>true</noManPages>
+                            <stripDebug>true</stripDebug>
+                            <noHeaderFiles>true</noHeaderFiles>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.gitchangelog</groupId>
+                <artifactId>git-changelog-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1870,37 +1870,64 @@
                             <configuration>
                                 <templateContent>
                                     <![CDATA[
-# CHANGELOG
+# {{repoName}} changelog
+
+Changelog of {{repoName}}.
 
 {{#tags}}
-{{#ifReleaseTag .}}
-## [{{name}}](https://github.com/unknowIfGuestInDream/javafxTool/{{name}}) ({{tagDate .}})
+## {{name}} ({{tagDate .}})
 
-  {{#ifContainsType commits type='feat'}}
+{{#ifContainsBreaking commits}}
+### Breaking changes
+
+{{#commits}}
+{{#ifCommitBreaking .}}
+- {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}}) {{#eachCommitRefs .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitRefs}} {{#eachCommitFixes .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitFixes}}
+{{/ifCommitBreaking}}
+{{/commits}}
+
+{{/ifContainsBreaking}}
+{{#ifContainsType commits type='feat'}}
 ### Features
 
-    {{#commits}}
-      {{#ifCommitType . type='feat'}}
- - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/unknowIfGuestInDream/javafxTool/commit/{{hashFull}}))
-      {{/ifCommitType}}
-    {{/commits}}
-  {{/ifContainsType}}
+{{#commits}}
+{{#ifCommitType . type='feat'}}
+- {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}}) {{#eachCommitRefs .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitRefs}} {{#eachCommitFixes .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitFixes}}
+{{/ifCommitType}}
+{{/commits}}
 
-  {{#ifContainsType commits type='fix'}}
+{{/ifContainsType}}
+{{#ifContainsType commits type='fix'}}
 ### Bug Fixes
 
-    {{#commits}}
-      {{#ifCommitType . type='fix'}}
- - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/unknowIfGuestInDream/javafxTool/commit/{{hashFull}}))
-      {{/ifCommitType}}
-    {{/commits}}
-  {{/ifContainsType}}
+{{#commits}}
+{{#ifCommitType . type='fix'}}
+- {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}}) {{#eachCommitRefs .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitRefs}} {{#eachCommitFixes .}}{{#ifMatches . "^#[0-9]+"}} [{{.}}](https://github.com/{{ownerName}}/{{repoName}}/issues/{{subString . 1}}) {{/ifMatches}}{{/eachCommitFixes}}
+{{/ifCommitType}}
+{{/commits}}
 
-{{/ifReleaseTag}}
+{{/ifContainsType}}
+{{#ifContainsType commits type='^($|(?!fix|feat|breaking|ci|bot))'}}
+### Other changes
+
+{{#commits}}
+{{#ifCommitType . type='^$'}}
+**{{{messageTitle}}}**
+
+{{#messageBodyItems}}
+* {{.}}
+{{/messageBodyItems}}
+
+[{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
+
+{{/ifCommitType}}
+{{/commits}}
+
+{{/ifContainsType}}
 {{/tags}}
 ]]>
                                 </templateContent>
-                                <file>target/CHANGELOG_inline.md</file>
+                                <file>target/CHANGELOG_with-unreleased.md</file>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
         <launch4j-maven-plugin.version>2.5.2</launch4j-maven-plugin.version>
         <xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
+        <git-changelog-maven-plugin.version>2.2.0</git-changelog-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <!--  if you update the checkstyle version make sure you update the google_checks.xml inside the repository -->
         <checkstyle.version>10.21.0</checkstyle.version>
@@ -209,6 +210,7 @@
     </licenses>
     <scm>
         <connection>scm:git:git://github.com/unknowIfGuestInDream/javafxTool.git</connection>
+        <developerConnection>scm:git:git://github.com/unknowIfGuestInDream/javafxTool.git</developerConnection>
         <url>https://github.com/unknowIfGuestInDream/javafxTool</url>
     </scm>
     <organization>
@@ -1845,6 +1847,63 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
                     <version>${xml-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>se.bjurr.gitchangelog</groupId>
+                    <artifactId>git-changelog-maven-plugin</artifactId>
+                    <version>${git-changelog-maven-plugin.version}</version>
+                    <dependencies>
+                        <!-- This dependency is only needed if you add your own javascript-helpers //-->
+                        <dependency>
+                            <groupId>org.openjdk.nashorn</groupId>
+                            <artifactId>nashorn-core</artifactId>
+                            <version>15.4</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>GenerateGitChangelog</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>git-changelog</goal>
+                            </goals>
+                            <configuration>
+                                <templateContent>
+                                    <![CDATA[
+# CHANGELOG
+
+{{#tags}}
+{{#ifReleaseTag .}}
+## [{{name}}](https://github.com/unknowIfGuestInDream/javafxTool/{{name}}) ({{tagDate .}})
+
+  {{#ifContainsType commits type='feat'}}
+### Features
+
+    {{#commits}}
+      {{#ifCommitType . type='feat'}}
+ - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/unknowIfGuestInDream/javafxTool/commit/{{hashFull}}))
+      {{/ifCommitType}}
+    {{/commits}}
+  {{/ifContainsType}}
+
+  {{#ifContainsType commits type='fix'}}
+### Bug Fixes
+
+    {{#commits}}
+      {{#ifCommitType . type='fix'}}
+ - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/unknowIfGuestInDream/javafxTool/commit/{{hashFull}}))
+      {{/ifCommitType}}
+    {{/commits}}
+  {{/ifContainsType}}
+
+{{/ifReleaseTag}}
+{{/tags}}
+]]>
+                                </templateContent>
+                                <file>target/CHANGELOG_inline.md</file>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/qe/pom.xml
+++ b/qe/pom.xml
@@ -187,12 +187,25 @@
                 <executions>
                     <execution>
                         <!-- Default configuration for running with: mvn clean javafx:run -->
-                        <id>default-cli</id>
+                        <id>qe-cli</id>
                         <configuration>
                             <mainClass>com.tlcsdm.qe/com.tlcsdm.qe.QeSampler</mainClass>
+                            <options>
+                                <option>-DworkEnv=prod</option>
+                            </options>
+                            <launcher>app</launcher>
+                            <jlinkZipName>app</jlinkZipName>
+                            <jlinkImageName>app</jlinkImageName>
+                            <noManPages>true</noManPages>
+                            <stripDebug>true</stripDebug>
+                            <noHeaderFiles>true</noHeaderFiles>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.gitchangelog</groupId>
+                <artifactId>git-changelog-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -203,12 +203,25 @@
                 <executions>
                     <execution>
                         <!-- Default configuration for running with: mvn clean javafx:run -->
-                        <id>default-cli</id>
+                        <id>smc-cli</id>
                         <configuration>
                             <mainClass>com.tlcsdm.smc/com.tlcsdm.smc.SmcSampler</mainClass>
+                            <options>
+                                <option>-DworkEnv=prod</option>
+                            </options>
+                            <launcher>app</launcher>
+                            <jlinkZipName>app</jlinkZipName>
+                            <jlinkImageName>app</jlinkImageName>
+                            <noManPages>true</noManPages>
+                            <stripDebug>true</stripDebug>
+                            <noHeaderFiles>true</noHeaderFiles>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>se.bjurr.gitchangelog</groupId>
+                <artifactId>git-changelog-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1865

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Build:
- Add git-changelog-maven-plugin to the build configuration to automate changelog generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 集成了 `git-changelog-maven-plugin`，支持基于 Git 提交历史生成变更日志。
  - 更新了 JavaFX 应用程序的构建配置，增强了执行环境和依赖管理。

- **改进**
  - 更新了 JavaFX 插件的执行 ID 以优化构建流程。
  - 添加了多个新配置选项，以提升 JavaFX 应用的构建过程。
  - 在构建工作流中增加了对变更日志文件的处理，确保其包含在最终打包的工件中。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->