### PR TITLE
build: Add javadoc options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1281,6 +1281,11 @@
                 <configuration>
                     <doctitle>${project.name} Documentation (Version ${project.version})</doctitle>
                     <windowtitle>${project.name} Documentation (Version ${project.version})</windowtitle>
+                    <!-- Used by javadoc:test-javadoc goal -->
+                    <testDoctitle>Test Documentation for ${project.name} (Version ${project.version})</testDoctitle>
+                    <testWindowtitle>Test Documentation for ${project.name} (Version ${project.version})
+                    </testWindowtitle>
+                    <!-- Used by javadoc:test-javadoc goal -->
                     <show>private</show>
                     <quiet>true</quiet>
                     <failOnError>false</failOnError>
@@ -1301,6 +1306,18 @@
                     <additionalJOptions>
                         <additionalJOption>-Xdoclint:none</additionalJOption>
                     </additionalJOptions>
+                    <tags>
+                        <tag>
+                            <name>todo</name>
+                            <placement>a</placement>
+                            <head>To do something:</head>
+                        </tag>
+                        <tag>
+                            <name>Author</name>
+                            <placement>t</placement>
+                            <head>Author:</head>
+                        </tag>
+                    </tags>
                 </configuration>
                 <executions>
                     <execution>
@@ -2014,7 +2031,7 @@ Changelog of {{repoName}}.
                                     https://javadoc.io/doc/io.github.java-diff-utils/java-diff-utils/${java-diff-utils.version}/
                                 </link>
                                 <link>https://javadoc.io/static/org.apache.pdfbox/pdfbox/${pdfbox.version}/</link>
-                                <link>https://javadoc.io/doc/org.fxmisc.richtext/richtextfx/${richtextfx.version}/
+                                <link>https://javadoc.io/doc/org.fxmisc.richtext/richtextfx/latest/
                                 </link>
                                 <link>https://docs.groovy-lang.org/${groovy.version}/html/gapi/</link>
                             </links>


### PR DESCRIPTION
Closes #1871

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Build:
- Add Javadoc options to the Maven POM file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 增强了文档生成能力，新增了测试文档标题配置。
  - 添加了自定义标签功能，以便在Javadoc注释中使用。

- **文档**
  - 更新了`richtextfx`依赖的链接，确保文档指向最新的API文档。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->