### PR TITLE
feat(common): Hidden some ControlPanel

### DIFF
--- a/common/src/main/java/com/tlcsdm/jfxcommon/code/ColorCode.java
+++ b/common/src/main/java/com/tlcsdm/jfxcommon/code/ColorCode.java
@@ -129,6 +129,11 @@ public class ColorCode extends CommonSample {
         return ImageViewHelper.get("rgb");
     }
 
+    @Override
+    public boolean hasControlPanel() {
+        return false;
+    }
+
     public static void main(String[] args) {
         launch(args);
     }

--- a/common/src/main/java/com/tlcsdm/jfxcommon/tools/escape/AbstractEscape.java
+++ b/common/src/main/java/com/tlcsdm/jfxcommon/tools/escape/AbstractEscape.java
@@ -122,6 +122,11 @@ public abstract class AbstractEscape extends CommonSample {
         return "1.0.1";
     }
 
+    @Override
+    public boolean hasControlPanel() {
+        return false;
+    }
+
     protected abstract String escape(String original);
 
     protected abstract String unescape(String original);

--- a/common/src/main/java/com/tlcsdm/jfxcommon/tools/image/ImageSplit.java
+++ b/common/src/main/java/com/tlcsdm/jfxcommon/tools/image/ImageSplit.java
@@ -106,6 +106,11 @@ public class ImageSplit extends CommonSample {
     }
 
     @Override
+    public boolean hasControlPanel() {
+        return false;
+    }
+
+    @Override
     public Node getPanel(Stage stage) {
         FXMLLoader fxmlLoader = FxmlUtil.loadFxmlFromResource(
             ImageSplit.class.getResource("/com/tlcsdm/jfxcommon/fxml/imageSplit.fxml"),


### PR DESCRIPTION
Close #2010

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Hides the ControlPanel for ColorCode, AbstractEscape, and ImageSplit.

Chores:
- Hides the ControlPanel for ColorCode.
- Hides the ControlPanel for AbstractEscape.
- Hides the ControlPanel for ImageSplit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
	- 经过更新后，多项核心模块现已统一禁用控制面板功能，为用户带来更连贯一致的界面体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->