### PR TITLE
feat(core): Add SkipBootAnimation Config

### DIFF
--- a/.idea/artifacts/javafxTool_qe_mac_jar.xml
+++ b/.idea/artifacts/javafxTool_qe_mac_jar.xml
@@ -1,70 +1,78 @@
 <component name="ArtifactManager">
-  <artifact type="jar" name="javafxTool-qe-mac:jar">
-    <output-path>$PROJECT_DIR$/out/artifacts/javafxTool_qe_mac_jar</output-path>
-    <root id="archive" name="javafxTool-qe.jar">
-      <element id="module-output" name="javafxTool-qe" />
-      <element id="module-output" name="javafxTool-frame" />
-      <element id="module-output" name="javafxTool-core" />
-      <element id="module-output" name="javafxTool-common" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.5.17/logback-classic-1.5.17.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.5.17/logback-core-1.5.17.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-core/5.8.36/hutool-core-5.8.36.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-crypto/5.8.36/hutool-crypto-5.8.36.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-log/5.8.36/hutool-log-5.8.36.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-poi/5.8.36/hutool-poi-5.8.36.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.18.3/jackson-annotations-2.18.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.18.3/jackson-core-2.18.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.18.3/jackson-databind-2.18.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/virtuald/curvesapi/1.08/curvesapi-1.08.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/zaxxer/SparseBitSet/1.3/SparseBitSet-1.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-io/commons-io/2.18.0/commons-io-2.18.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/fr/brouillard/oss/cssfx/11.5.1/cssfx-11.5.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/io/github/java-diff-utils/java-diff-utils/4.15/java-diff-utils-4.15.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/jaxen/jaxen/2.0.0/jaxen-2.0.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/coobird/thumbnailator/0.4.20/thumbnailator-0.4.20.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/jonathangiles/tools/teenyhttpd/1.0.5/teenyhttpd-1.0.5.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-configuration2/2.11.0/commons-configuration2-2.11.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-imaging/1.0.0-alpha5/commons-imaging-1.0.0-alpha5.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-text/1.13.0/commons-text-1.13.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-api/2.24.3/log4j-api-2.24.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml-lite/5.4.0/poi-ooxml-lite-5.4.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml/5.4.0/poi-ooxml-5.4.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi/5.4.0/poi-5.4.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/xmlbeans/xmlbeans/5.2.1/xmlbeans-5.2.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/3.49.1/checker-qual-3.49.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/controlsfx/controlsfx/11.2.1/controlsfx-11.2.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/dom4j/dom4j/2.1.4/dom4j-2.1.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/freemarker/freemarker/2.3.34/freemarker-2.3.34.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/flowless/flowless/0.7.3/flowless-0.7.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/richtext/richtextfx/0.11.4/richtextfx-0.11.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/undo/undofx/2.1.1/undofx-2.1.1.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/wellbehaved/wellbehavedfx/0.3.3/wellbehavedfx-0.3.3.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4-mac-aarch64.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.4/javafx-controls-21.0.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.4/javafx-controls-21.0.4-mac-aarch64.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.4/javafx-fxml-21.0.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.4/javafx-fxml-21.0.4-mac-aarch64.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.4/javafx-graphics-21.0.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.4/javafx-graphics-21.0.4-mac-aarch64.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-swing/21.0.4/javafx-swing-21.0.4.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-swing/21.0.4/javafx-swing-21.0.4-mac-aarch64.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/reactfx/reactfx/2.0-M5/reactfx-2.0-M5.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/reflections/reflections/0.10.2/reflections-0.10.2.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/log4j-over-slf4j/2.0.17/log4j-over-slf4j-2.0.17.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/rhino/js/1.7R2/js-1.7R2.jar" path-in-jar="/" />
-    </root>
-  </artifact>
+    <artifact type="jar" name="javafxTool-qe-mac:jar">
+        <output-path>$PROJECT_DIR$/out/artifacts/javafxTool_qe_mac_jar</output-path>
+        <root id="archive" name="javafxTool-qe.jar">
+            <element id="module-output" name="javafxTool-qe" />
+            <element id="module-output" name="javafxTool-frame" />
+            <element id="module-output" name="javafxTool-core" />
+            <element id="module-output" name="javafxTool-common" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.5.17/logback-classic-1.5.17.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.5.17/logback-core-1.5.17.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-core/5.8.36/hutool-core-5.8.36.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-crypto/5.8.36/hutool-crypto-5.8.36.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-log/5.8.36/hutool-log-5.8.36.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-poi/5.8.36/hutool-poi-5.8.36.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/dlsc/formsfx/formsfx-core/11.6.0/formsfx-core-11.6.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/dlsc/preferencesfx/preferencesfx-core/11.17.0/preferencesfx-core-11.17.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.18.3/jackson-annotations-2.18.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.18.3/jackson-core-2.18.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.18.3/jackson-databind-2.18.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/gino0631/clove-io/0.2/clove-io-0.2.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/gino0631/icns-core/1.2/icns-core-1.2.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/virtuald/curvesapi/1.08/curvesapi-1.08.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/zaxxer/SparseBitSet/1.3/SparseBitSet-1.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-io/commons-io/2.18.0/commons-io-2.18.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/fr/brouillard/oss/cssfx/11.5.1/cssfx-11.5.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/io/github/java-diff-utils/java-diff-utils/4.15/java-diff-utils-4.15.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/jaxen/jaxen/2.0.0/jaxen-2.0.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/coobird/thumbnailator/0.4.20/thumbnailator-0.4.20.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/ifok/image/image4j/0.7.2/image4j-0.7.2.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/jonathangiles/tools/teenyhttpd/1.0.5/teenyhttpd-1.0.5.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-configuration2/2.11.0/commons-configuration2-2.11.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-imaging/1.0.0-alpha5/commons-imaging-1.0.0-alpha5.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-text/1.13.0/commons-text-1.13.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-api/2.24.3/log4j-api-2.24.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml-lite/5.4.0/poi-ooxml-lite-5.4.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml/5.4.0/poi-ooxml-5.4.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi/5.4.0/poi-5.4.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/xmlbeans/xmlbeans/5.3.0/xmlbeans-5.3.0.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/3.49.1/checker-qual-3.49.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/controlsfx/controlsfx/11.2.1/controlsfx-11.2.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/dom4j/dom4j/2.1.4/dom4j-2.1.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/freemarker/freemarker/2.3.34/freemarker-2.3.34.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/flowless/flowless/0.7.3/flowless-0.7.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/richtext/richtextfx/0.11.4/richtextfx-0.11.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/undo/undofx/2.1.1/undofx-2.1.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/wellbehaved/wellbehavedfx/0.3.3/wellbehavedfx-0.3.3.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-core/12.3.1/ikonli-core-12.3.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-javafx/12.3.1/ikonli-javafx-12.3.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-material-pack/12.3.1/ikonli-material-pack-12.3.1.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4-mac.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.4/javafx-controls-21.0.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.4/javafx-controls-21.0.4-mac.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.4/javafx-fxml-21.0.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-fxml/21.0.4/javafx-fxml-21.0.4-mac.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.4/javafx-graphics-21.0.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-graphics/21.0.4/javafx-graphics-21.0.4-mac.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-smacg/21.0.4/javafx-swing-21.0.4.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-swing/21.0.4/javafx-swing-21.0.4-mac.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/reactfx/reactfx/2.0-M5/reactfx-2.0-M5.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/reflections/reflections/0.10.2/reflections-0.10.2.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/log4j-over-slf4j/2.0.17/log4j-over-slf4j-2.0.17.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar" path-in-jar="/" />
+            <element id="extracted-dir" path="$MAVEN_REPOSITORY$/rhino/js/1.7R2/js-1.7R2.jar" path-in-jar="/" />
+        </root>
+    </artifact>
 </component>

--- a/.idea/artifacts/javafxTool_qe_win_jar.xml
+++ b/.idea/artifacts/javafxTool_qe_win_jar.xml
@@ -12,9 +12,13 @@
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-crypto/5.8.36/hutool-crypto-5.8.36.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-log/5.8.36/hutool-log-5.8.36.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/cn/hutool/hutool-poi/5.8.36/hutool-poi-5.8.36.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/dlsc/formsfx/formsfx-core/11.6.0/formsfx-core-11.6.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/dlsc/preferencesfx/preferencesfx-core/11.17.0/preferencesfx-core-11.17.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.18.3/jackson-annotations-2.18.3.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.18.3/jackson-core-2.18.3.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.18.3/jackson-databind-2.18.3.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/gino0631/clove-io/0.2/clove-io-0.2.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/gino0631/icns-core/1.2/icns-core-1.2.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/github/virtuald/curvesapi/1.08/curvesapi-1.08.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.jar" path-in-jar="/" />
@@ -27,6 +31,7 @@
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/io/github/java-diff-utils/java-diff-utils/4.15/java-diff-utils-4.15.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/jaxen/jaxen/2.0.0/jaxen-2.0.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/coobird/thumbnailator/0.4.20/thumbnailator-0.4.20.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/ifok/image/image4j/0.7.2/image4j-0.7.2.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/jonathangiles/tools/teenyhttpd/1.0.5/teenyhttpd-1.0.5.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar" path-in-jar="/" />
@@ -40,7 +45,7 @@
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml-lite/5.4.0/poi-ooxml-lite-5.4.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi-ooxml/5.4.0/poi-ooxml-5.4.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/poi/poi/5.4.0/poi-5.4.0.jar" path-in-jar="/" />
-      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/xmlbeans/xmlbeans/5.2.1/xmlbeans-5.2.1.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/xmlbeans/xmlbeans/5.3.0/xmlbeans-5.3.0.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/checkerframework/checker-qual/3.49.1/checker-qual-3.49.1.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/controlsfx/controlsfx/11.2.1/controlsfx-11.2.1.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/dom4j/dom4j/2.1.4/dom4j-2.1.4.jar" path-in-jar="/" />
@@ -50,6 +55,9 @@
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/undo/undofx/2.1.1/undofx-2.1.1.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/fxmisc/wellbehaved/wellbehavedfx/0.3.3/wellbehavedfx-0.3.3.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/javassist/javassist/3.30.2-GA/javassist-3.30.2-GA.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-core/12.3.1/ikonli-core-12.3.1.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-javafx/12.3.1/ikonli-javafx-12.3.1.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/kordamp/ikonli/ikonli-material-pack/12.3.1/ikonli-material-pack-12.3.1.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-base/21.0.4/javafx-base-21.0.4-win.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/openjfx/javafx-controls/21.0.4/javafx-controls-21.0.4.jar" path-in-jar="/" />

--- a/cg/src/main/java/com/tlcsdm/cg/provider/CgMenubarConfigrationProvider.java
+++ b/cg/src/main/java/com/tlcsdm/cg/provider/CgMenubarConfigrationProvider.java
@@ -87,7 +87,7 @@ public class CgMenubarConfigrationProvider implements MenubarConfigration {
 
     private final Action exit = FxAction.exit(actionEvent -> FXSampler.doExit());
 
-    private final Action systemSetting = FxAction.systemSetting(Keys.ScreenshotHideWindow);
+    private final Action systemSetting = FxAction.systemSetting(Keys.ScreenshotHideWindow, Keys.SkipBootAnimation);
 
     private final Action pathWatch = FxAction.pathWatch();
 

--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
@@ -60,6 +60,7 @@ public class PreferencesView extends StackPane {
     BooleanProperty screenColorPickerHideWindow = new SimpleBooleanProperty(true);
     BooleanProperty useDevMode = new SimpleBooleanProperty(false);
     BooleanProperty useEasterEgg = new SimpleBooleanProperty(true);
+    BooleanProperty skipBootAnimation = new SimpleBooleanProperty(false);
 
     // VisibilityProperty
     BooleanProperty supExitShowAlert = new SimpleBooleanProperty(true);
@@ -69,6 +70,7 @@ public class PreferencesView extends StackPane {
     BooleanProperty supScreenColorPickerHideWindow = new SimpleBooleanProperty(true);
     BooleanProperty supUseDevMode = new SimpleBooleanProperty(true);
     BooleanProperty supUseEasterEgg = new SimpleBooleanProperty(true);
+    BooleanProperty supSkipBootAnimation = new SimpleBooleanProperty(true);
 
     /**
      * 资源初始化.
@@ -91,6 +93,7 @@ public class PreferencesView extends StackPane {
         if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
             supUseEasterEgg.setValue(false);
         }
+
         for (Keys key : excludeKeys) {
             switch (key) {
                 case ConfirmExit -> supExitShowAlert.setValue(false);
@@ -100,6 +103,7 @@ public class PreferencesView extends StackPane {
                 case ScreenColorPickerHideWindow -> supScreenColorPickerHideWindow.setValue(false);
                 case UseDevMode -> supUseDevMode.setValue(false);
                 case UseEasterEgg -> supUseEasterEgg.setValue(false);
+                case SkipBootAnimation -> supSkipBootAnimation.setValue(false);
                 default -> {
                     // Do nothing
                 }
@@ -125,7 +129,9 @@ public class PreferencesView extends StackPane {
                                 Setting.of("core.dialog.systemSetting.check.useDevMode", useDevMode,
                                     VisibilityProperty.of(supUseDevMode)),
                                 Setting.of("core.dialog.systemSetting.check.useEasterEgg", useEasterEgg,
-                                    VisibilityProperty.of(supUseEasterEgg)))
+                                    VisibilityProperty.of(supUseEasterEgg)),
+                                Setting.of("core.dialog.systemSetting.check.skipBootAnimation", skipBootAnimation,
+                                    VisibilityProperty.of(supSkipBootAnimation)))
                             .description("core.menubar.setting.systemSetting")),
                     Category.of("core.menubar.tool",
                         VisibilityProperty.of(supScreenshotHideWindow.or(supScreenColorPickerHideWindow)),

--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
@@ -58,6 +58,7 @@ public class SystemSettingController extends AbstractSystemSettingView {
         screenColorPickerHideWindowCheckBox.setSelected(Config.getBoolean(Keys.ScreenColorPickerHideWindow, true));
         useDevModeCheckBox.setSelected(Config.getBoolean(Keys.UseDevMode, false));
         useEasterEggCheckBox.setSelected(Config.getBoolean(Keys.UseEasterEgg, true));
+        useSkipBootAnimation.setSelected(Config.getBoolean(Keys.SkipBootAnimation, false));
     }
 
     /**
@@ -78,6 +79,7 @@ public class SystemSettingController extends AbstractSystemSettingView {
                 case ScreenColorPickerHideWindow -> disableNode(screenColorPickerHideWindowCheckBox);
                 case UseDevMode -> disableNode(useDevModeCheckBox);
                 case UseEasterEgg -> disableNode(useEasterEggCheckBox);
+                case SkipBootAnimation -> disableNode(useSkipBootAnimation);
                 default -> {
                     // Do nothing
                 }
@@ -104,6 +106,7 @@ public class SystemSettingController extends AbstractSystemSettingView {
         Config.set(Keys.ScreenColorPickerHideWindow, screenColorPickerHideWindowCheckBox.isSelected());
         Config.set(Keys.UseDevMode, useDevModeCheckBox.isSelected());
         Config.set(Keys.UseEasterEgg, useEasterEggCheckBox.isSelected());
+        Config.set(Keys.SkipBootAnimation, useSkipBootAnimation.isSelected());
         EventBus.getDefault().post(new ConfigRefreshEvent());
     }
 }

--- a/core/src/main/java/com/tlcsdm/core/javafx/util/Keys.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/util/Keys.java
@@ -57,7 +57,8 @@ public enum Keys {
     PreferenceWindowWidth("preference.windowWidth"),
     PreferenceWindowHeight("preference.windowHeight"),
     PreferenceWindowPosX("preference.windowPosX"),
-    PreferenceWindowPosY("preference.windowPosY");
+    PreferenceWindowPosY("preference.windowPosY"),
+    SkipBootAnimation("skipBootAnimation");
 
     private final String keyName;
 

--- a/core/src/main/java/com/tlcsdm/core/javafx/view/AbstractSystemSettingView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/view/AbstractSystemSettingView.java
@@ -59,4 +59,6 @@ public abstract class AbstractSystemSettingView implements Initializable {
     public CheckBox useDevModeCheckBox;
     @FXML
     public CheckBox useEasterEggCheckBox;
+    @FXML
+    public CheckBox useSkipBootAnimation;
 }

--- a/core/src/main/resources/com/tlcsdm/core/fxml/SystemSetting.fxml
+++ b/core/src/main/resources/com/tlcsdm/core/fxml/SystemSetting.fxml
@@ -55,4 +55,6 @@
               text="%core.dialog.systemSetting.check.useDevMode"/>
     <CheckBox fx:id="useEasterEggCheckBox"
               text="%core.dialog.systemSetting.check.useEasterEgg"/>
+    <CheckBox fx:id="useSkipBootAnimation"
+              text="%core.dialog.systemSetting.check.skipBootAnimation"/>
 </VBox>

--- a/core/src/main/resources/com/tlcsdm/core/i18n/messages_en.properties
+++ b/core/src/main/resources/com/tlcsdm/core/i18n/messages_en.properties
@@ -57,6 +57,7 @@ core.dialog.systemSetting.check.screenshotHideWindow=Minimize window when taking
 core.dialog.systemSetting.check.screenColorPickerHideWindow=Minimize window when taking screenColorPicker
 core.dialog.systemSetting.check.useDevMode=Use development mode
 core.dialog.systemSetting.check.useEasterEgg=Use Easter eggs
+core.dialog.systemSetting.check.skipBootAnimation=Skip boot animation
 core.dialog.systemSetting.check.theme=Themes
 core.dialog.webBrowser.title=Web Browser
 core.menubar.file=File

--- a/core/src/main/resources/com/tlcsdm/core/i18n/messages_ja.properties
+++ b/core/src/main/resources/com/tlcsdm/core/i18n/messages_ja.properties
@@ -57,6 +57,7 @@ core.dialog.systemSetting.check.screenshotHideWindow=\u30B9\u30AF\u30EA\u30FC\u3
 core.dialog.systemSetting.check.screenColorPickerHideWindow=\u753B\u9762\u306E\u30AB\u30E9\u30FC\u30D4\u30C3\u30AB\u30FC\u3092\u53D6\u5F97\u3059\u308B\u969B\u306B\u30A6\u30A3\u30F3\u30C9\u30A6\u3092\u6700\u5C0F\u5316\u3059\u308B
 core.dialog.systemSetting.check.useDevMode=\u958B\u767A\u30E2\u30FC\u30C9\u3092\u4F7F\u7528\u3059\u308B
 core.dialog.systemSetting.check.useEasterEgg=\u30A4\u30FC\u30B9\u30BF\u30FC\u30A8\u30C3\u30B0\u3092\u4F7F\u7528\u3059\u308B
+core.dialog.systemSetting.check.skipBootAnimation=\u8D77\u52D5\u30A2\u30CB\u30E1\u30FC\u30B7\u30E7\u30F3\u3092\u30B9\u30AD\u30C3\u30D7
 core.dialog.systemSetting.check.theme=\u30C6\u30FC\u30DE
 core.dialog.webBrowser.title=\u30A6\u30A7\u30D6\u30D6\u30E9\u30A6\u30B6
 core.menubar.file=\u30D5\u30A1\u30A4\u30EB

--- a/core/src/main/resources/com/tlcsdm/core/i18n/messages_zh.properties
+++ b/core/src/main/resources/com/tlcsdm/core/i18n/messages_zh.properties
@@ -57,6 +57,7 @@ core.dialog.systemSetting.check.screenshotHideWindow=\u622A\u5C4F\u65F6\u6700\u5
 core.dialog.systemSetting.check.screenColorPickerHideWindow=\u989C\u8272\u63D0\u53D6\u65F6\u6700\u5C0F\u5316\u7A97\u53E3
 core.dialog.systemSetting.check.useDevMode=\u4F7F\u7528\u5F00\u53D1\u6A21\u5F0F
 core.dialog.systemSetting.check.useEasterEgg=\u4F7F\u7528\u5F69\u86CB
+core.dialog.systemSetting.check.skipBootAnimation=\u8DF3\u8FC7\u542F\u52A8\u52A8\u753B
 core.dialog.systemSetting.check.theme=\u4E3B\u9898
 core.dialog.webBrowser.title=\u7F51\u9875\u6D4F\u89C8\u5668
 core.menubar.file=\u6587\u4EF6

--- a/pom.xml
+++ b/pom.xml
@@ -807,6 +807,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/qe/pom.xml
+++ b/qe/pom.xml
@@ -144,6 +144,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.dlsc.preferencesfx</groupId>
+            <artifactId>preferencesfx-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
             <scope>test</scope>

--- a/qe/src/main/java/com/tlcsdm/qe/provider/QeMenubarConfigrationProvider.java
+++ b/qe/src/main/java/com/tlcsdm/qe/provider/QeMenubarConfigrationProvider.java
@@ -86,7 +86,7 @@ public class QeMenubarConfigrationProvider implements MenubarConfigration {
 
     private final Action exit = FxAction.exit(actionEvent -> FXSampler.doExit());
 
-    private final Action systemSetting = FxAction.systemSetting();
+    private final Action systemSetting = FxAction.preferences();
 
     private final Action pathWatch = FxAction.pathWatch();
 

--- a/qe/src/main/java/com/tlcsdm/qe/provider/QeSplashProvider.java
+++ b/qe/src/main/java/com/tlcsdm/qe/provider/QeSplashProvider.java
@@ -28,6 +28,8 @@
 package com.tlcsdm.qe.provider;
 
 import com.tlcsdm.core.eventbus.EventBus;
+import com.tlcsdm.core.javafx.util.Config;
+import com.tlcsdm.core.javafx.util.Keys;
 import com.tlcsdm.frame.event.SplashAnimFinishedEvent;
 import com.tlcsdm.frame.service.SplashScreen;
 import javafx.animation.FadeTransition;
@@ -103,6 +105,9 @@ public class QeSplashProvider implements SplashScreen {
         SequentialTransition animation = new SequentialTransition(fadeTransition, pathTransition, scaleTransition);
         animation.setInterpolator(Interpolator.EASE_IN);
         animation.setOnFinished(event -> EventBus.getDefault().post(new SplashAnimFinishedEvent()));
+        if (Config.getBoolean(Keys.SkipBootAnimation, true)) {
+            animation.setRate(10);
+        }
         animation.play();
 
         return pane;

--- a/qe/src/main/java/com/tlcsdm/qe/util/QeConstant.java
+++ b/qe/src/main/java/com/tlcsdm/qe/util/QeConstant.java
@@ -96,7 +96,7 @@ public class QeConstant {
      */
     public static final List<String> DEPENDENCY_LIST = List.of("poi", "freemarker", "dom4j", "java-diff-utils",
         "richtextfx", "thumbnailator", "jackson", "yuicompressor", "teenyhttpd", "image4j", "commons-imaging",
-        "icns-core");
+        "icns-core", "preferencesfx");
 
     private QeConstant() {
     }

--- a/qe/src/main/java/module-info.java
+++ b/qe/src/main/java/module-info.java
@@ -70,6 +70,7 @@ module com.tlcsdm.qe {
     requires org.apache.commons.imaging;
     requires image4j;
     requires icns.core;
+    requires com.dlsc.preferencesfx;
 
     exports com.tlcsdm.qe;
     exports com.tlcsdm.qe.provider to com.tlcsdm.core, com.tlcsdm.frame, com.tlcsdm.login;

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -127,12 +127,6 @@
             <groupId>com.dlsc.preferencesfx</groupId>
             <artifactId>preferencesfx-core</artifactId>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/smc/src/main/java/com/tlcsdm/smc/provider/SmcMenubarConfigrationProvider.java
+++ b/smc/src/main/java/com/tlcsdm/smc/provider/SmcMenubarConfigrationProvider.java
@@ -42,6 +42,7 @@ import com.tlcsdm.core.javafx.helper.LayoutHelper;
 import com.tlcsdm.core.javafx.richtext.hyperlink.TextHyperlinkArea;
 import com.tlcsdm.core.javafx.util.FxXmlHelper;
 import com.tlcsdm.core.javafx.util.JavaFxSystemUtil;
+import com.tlcsdm.core.javafx.util.Keys;
 import com.tlcsdm.core.util.CoreUtil;
 import com.tlcsdm.core.util.DependencyInfo;
 import com.tlcsdm.core.util.DependencyInfo.Dependency;
@@ -85,7 +86,7 @@ public class SmcMenubarConfigrationProvider implements MenubarConfigration {
 
     private final Action exit = FxAction.exit(actionEvent -> FXSampler.doExit());
 
-    private final Action preferences = FxAction.preferences();
+    private final Action preferences = FxAction.preferences(Keys.SkipBootAnimation);
 
     private final Action pathWatch = FxAction.pathWatch();
 


### PR DESCRIPTION
Close #2017

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Adds a configuration option to skip the boot animation, and modifies the animation speed based on the configuration.

New Features:
- Adds a new configuration option to skip the boot animation.
- Adds a new setting in the preferences to control whether to skip the boot animation.
- Modifies the animation speed based on the skip boot animation configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 新增“跳过启动动画”选项，可在系统设置和偏好设置中启用，实现更快的启动体验。该选项已在多个界面展现，并支持英文、日文及中文本地化显示。

- **其他调整**
  - 优化了部分依赖管理和构建配置，进一步提升了应用稳定性和模块兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->