### PR TITLE
ci: Add action-languagetool check

### DIFF
--- a/.github/workflows/languagetool.yaml
+++ b/.github/workflows/languagetool.yaml
@@ -1,0 +1,41 @@
+name: 'Languagetool check'
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'README.md'
+      - 'README_jp.md'
+      - 'README_zh.md'
+      - '**/i18n/*.properties'
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check English style
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          language: 'en'
+          patterns: 'README.md **/i18n/messages_en.properties'
+      - name: Check Chinese style
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          language: 'zh-CN'
+          patterns: 'README_zh.md **/i18n/messages_zh.properties'
+      - name: Check Japanese style
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          language: 'ja-JP'
+          patterns: 'README_jp.md **/i18n/messages_ja.properties'

--- a/.github/workflows/languagetool.yaml
+++ b/.github/workflows/languagetool.yaml
@@ -13,29 +13,25 @@ on:
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language_configs:
+          - language: 'en'
+            name: "English style"
+            patterns: 'README.md **/i18n/messages_en.properties'
+          - language: 'zh-CN'
+            name: "Chinese style"
+            patterns: 'README_zh.md **/i18n/messages_zh.properties'
+          - language: 'ja-JP'
+            name: "Japanese style"
+            patterns: 'README_jp.md **/i18n/messages_jp.properties'
     steps:
       - uses: actions/checkout@v4
-      - name: Check English style
+      - name: Check ${{ matrix.language_configs.name }}
         uses: reviewdog/action-languagetool@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           level: info
-          language: 'en'
-          patterns: 'README.md **/i18n/messages_en.properties'
-      - name: Check Chinese style
-        uses: reviewdog/action-languagetool@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          level: info
-          language: 'zh-CN'
-          patterns: 'README_zh.md **/i18n/messages_zh.properties'
-      - name: Check Japanese style
-        uses: reviewdog/action-languagetool@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          level: info
-          language: 'ja-JP'
-          patterns: 'README_jp.md **/i18n/messages_ja.properties'
+          language: ${{ matrix.language_configs.language }}
+          patterns: ${{ matrix.language_configs.patterns }}


### PR DESCRIPTION
Close #2058

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

CI:
- Implement a new GitHub Actions workflow that uses LanguageTool to check spelling, grammar, and style across README files and internationalization message files for multiple languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 引入自动化语言风格检测工作流，针对拉取请求自动检查英文、中文和日文内容，实时反馈文本质量信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->