### PR TITLE
fix(core): beanutils升级后兼容问题

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>commons-beanutils</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!--   require by  commons-beanutils  -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -40,6 +40,7 @@ module com.tlcsdm.core {
     requires org.apache.commons.lang3;
     requires javafx.controls;
     requires org.apache.commons.configuration2;
+    requires org.apache.commons.beanutils;
     requires org.controlsfx.controls;
     requires cn.hutool.log;
     requires cn.hutool.core;

--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,13 @@
         <slf4j-api.version>2.0.17</slf4j-api.version>
         <commons-io.version>2.19.0</commons-io.version>
         <commons-configuration2.version>2.12.0</commons-configuration2.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-beanutils.version>1.10.1</commons-beanutils.version>
         <commons-csv.version>1.14.0</commons-csv.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <commons-exec.version>1.4.0</commons-exec.version>
         <commons-text.version>1.13.1</commons-text.version>
         <commons-email.version>1.6.0</commons-email.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-crypto.version>1.2.0</commons-crypto.version>
@@ -142,7 +143,7 @@
         <dom4j.version>2.1.4</dom4j.version>
         <jexl.version>3.5.0</jexl.version>
         <pdfbox.version>3.0.4</pdfbox.version>
-        <pdfviewfx.version>3.1.1</pdfviewfx.version>
+        <pdfviewfx.version>3.1.0</pdfviewfx.version>
         <jackson.version>2.19.0</jackson.version>
         <testfx.version>4.0.18</testfx.version>
         <assertj.version>3.27.3</assertj.version>
@@ -167,7 +168,7 @@
         <jython.version>2.7.4</jython.version>
         <violations.version>1.157.3</violations.version>
         <asm.version>9.8</asm.version>
-        <pmd.version>7.13.0</pmd.version>
+        <pmd.version>7.12.0</pmd.version>
         <bytebuddy.version>1.17.5</bytebuddy.version>
         <tess4j.version>5.15.0</tess4j.version>
         <hikariCP.version>6.3.0</hikariCP.version>
@@ -390,6 +391,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-email</artifactId>
                 <version>${commons-email.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Close #2001

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Upgrade commons-beanutils library and add its required dependencies to resolve compatibility issues

New Features:
- Added commons-collections dependency to support commons-beanutils upgrade

Chores:
- Updated module-info.java to include commons-beanutils module requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **杂项**
  - 升级了 commons-beanutils 依赖版本，并新增 commons-collections 依赖。
  - 降级了 pdfviewfx 和 pmd 的版本。
  - 优化了模块依赖配置，增加了对 Apache Commons BeanUtils 的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->