### PR TITLE
ci: 新增对dependabot的阿里云依赖检查

### DIFF
--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -54,8 +54,8 @@ jobs:
             const core = require('@actions/core');
 
             try {
-              const buildType = '${{ steps.detect-build.outputs.build_type }}';
-              const changes = '${{ steps.detect-build.outputs.changes }}';
+              const buildType = '${{ steps.get-changes.outputs.build_type }}';
+              const changes = '${{ steps.get-changes.outputs.changes }}';
               const dependencies = [];
 
               if (buildType === 'gradle') {
@@ -122,7 +122,7 @@ jobs:
           script: |
             const { execSync } = require('child_process');
             const core = require('@actions/core');
-            const github = require('@actions/github');
+            const { context, getOctokit } = require('@actions/github');
 
             try {
               const dependencies = JSON.parse('${{ steps.parse-deps.outputs.dependencies }}');
@@ -144,7 +144,7 @@ jobs:
               if (results.length > 0) {
                 const commentBody = `### 阿里云 Maven 依赖检查结果\n\n${results.join('\n')}`;
 
-                const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+                const octokit = getOctokit(process.env.GITHUB_TOKEN);
                 await octokit.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -1,0 +1,96 @@
+name: Check Aliyun Maven Dependencies
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize ]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+    # 只在dependabot的PR上运行
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Check Aliyun Maven availability
+        id: check-aliyun
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const core = require('@actions/core');
+            const github = require('@actions/github');
+
+            try {
+              // 获取变更的依赖
+              const diffOutput = execSync('git diff origin/${{ github.event.pull_request.base.ref }} -- build.gradle || git diff origin/${{ github.event.pull_request.base.ref }} -- pom.xml').toString();
+
+              // 解析依赖变更
+              const dependencies = [];
+              const regex = /([+-])\s*(implementation|api|compile|testImplementation|runtimeOnly)\s*['"]([^'"]+)['"]/g;
+              let match;
+
+              while ((match = regex.exec(diffOutput)) !== null) {
+                if (match[1] === '+') { // 只关心新增的依赖
+                  const depParts = match[3].split(':');
+                  if (depParts.length === 3) {
+                    dependencies.push({
+                      group: depParts[0],
+                      artifact: depParts[1],
+                      version: depParts[2]
+                    });
+                  }
+                }
+              }
+
+              if (dependencies.length === 0) {
+                core.setOutput('result', 'No dependency changes found');
+                return 'No dependency changes to check';
+              }
+
+              // 检查阿里云Maven是否有这些依赖
+              const results = [];
+              const aliMavenUrl = 'https://maven.aliyun.com/repository/public';
+
+              for (const dep of dependencies) {
+                const artifactPath = dep.group.replace(/\./g, '/') + '/' + dep.artifact + '/' + dep.version;
+                const pomUrl = `${aliMavenUrl}/${artifactPath}/${dep.artifact}-${dep.version}.pom`;
+
+                try {
+                  execSync(`curl -I -s -o /dev/null -w "%{http_code}" ${pomUrl} | grep 200`);
+                  results.push(`✅ ${dep.group}:${dep.artifact}:${dep.version} - 可用`);
+                } catch (e) {
+                  results.push(`❌ ${dep.group}:${dep.artifact}:${dep.version} - 不可用`);
+                }
+              }
+
+              const commentBody = `### 阿里云 Maven 依赖检查结果\n\n${results.join('\n')}`;
+              core.setOutput('result', commentBody);
+
+              // 添加PR评论
+              const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+              await octokit.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              });
+
+              return commentBody;
+            } catch (error) {
+              core.setFailed(`Action failed with error: ${error}`);
+            }
+
+      - name: Output result
+        run: echo "${{ steps.check-aliyun.outputs.result }}"

--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Check Aliyun Maven availability
         if: steps.parse-deps.outputs.dependencies != '[]'
         id: check-aliyun
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -4,6 +4,12 @@ on:
   pull_request_target:
     types: [ opened, synchronize ]
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # 每天UTC时间午夜（北京时间早上8点）
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-dependencies:

--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types: [ opened, synchronize ]
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'  # 每天UTC时间午夜（北京时间早上8点）
 
 permissions:
   contents: read
@@ -29,9 +27,97 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Check Aliyun Maven availability
-        id: check-aliyun
+      - name: Get build file changes
+        id: get-changes
+        run: |
+          # 检测项目类型并获取变更内容
+          if [ -f "pom.xml" ]; then
+            echo "build_type=maven" >> $GITHUB_OUTPUT
+            # PR事件获取当前PR的pom.xml变更
+            git diff origin/${{ github.event.pull_request.base.ref }} -- pom.xml > changes.diff || true
+          elif [ -f "build.gradle" ]; then
+            echo "build_type=gradle" >> $GITHUB_OUTPUT
+            git diff origin/${{ github.event.pull_request.base.ref }} -- build.gradle > changes.diff || true
+          else
+            echo "No supported build file found"
+            exit 0
+          fi
+          echo "changes<<EOF" >> $GITHUB_OUTPUT
+          cat changes.diff >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Parse dependencies
+        id: parse-deps
         uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+
+            try {
+              const buildType = '${{ steps.detect-build.outputs.build_type }}';
+              const changes = '${{ steps.detect-build.outputs.changes }}';
+              const dependencies = [];
+
+              if (buildType === 'gradle') {
+                // Gradle 依赖解析
+                const regex = /([+-])\s*(implementation|api|compile|testImplementation|runtimeOnly)\s*['"]([^'"]+)['"]/g;
+                let match;
+
+                while ((match = regex.exec(changes)) !== null) {
+                  if (match[1] === '+') {
+                    const depParts = match[3].split(':');
+                    if (depParts.length === 3) {
+                      dependencies.push({
+                        group: depParts[0],
+                        artifact: depParts[1],
+                        version: depParts[2]
+                      });
+                    }
+                  }
+                }
+              } else if (buildType === 'maven') {
+                // Maven 依赖解析
+                const diffLines = changes.split('\n');
+                let currentDep = null;
+                let inDependency = false;
+                let isNewDep = false;
+
+                for (const line of diffLines) {
+                  if (line.startsWith('+ <dependency>')) {
+                    inDependency = true;
+                    isNewDep = true;
+                    currentDep = {};
+                  } else if (line.startsWith('+ </dependency>') && isNewDep) {
+                    inDependency = false;
+                    if (currentDep.groupId && currentDep.artifactId && currentDep.version) {
+                      dependencies.push({
+                        group: currentDep.groupId,
+                        artifact: currentDep.artifactId,
+                        version: currentDep.version
+                      });
+                    }
+                  } else if (inDependency && isNewDep) {
+                    if (line.startsWith('+ <groupId>')) {
+                      currentDep.groupId = line.replace(/^\+ <groupId>|<\/groupId>$/g, '').trim();
+                    } else if (line.startsWith('+ <artifactId>')) {
+                      currentDep.artifactId = line.replace(/^\+ <artifactId>|<\/artifactId>$/g, '').trim();
+                    } else if (line.startsWith('+ <version>')) {
+                      currentDep.version = line.replace(/^\+ <version>|<\/version>$/g, '').trim();
+                    }
+                  }
+                }
+              }
+
+              core.setOutput('dependencies', JSON.stringify(dependencies));
+              return dependencies.length;
+            } catch (error) {
+              core.setFailed(`Failed to parse dependencies: ${error}`);
+            }
+
+      - name: Check Aliyun Maven availability
+        if: steps.parse-deps.outputs.dependencies != '[]'
+        id: check-aliyun
+        uses: actions/github-script@v6
         with:
           script: |
             const { execSync } = require('child_process');
@@ -39,35 +125,9 @@ jobs:
             const github = require('@actions/github');
 
             try {
-              // 获取变更的依赖
-              const diffOutput = execSync('git diff origin/${{ github.event.pull_request.base.ref }} -- build.gradle || git diff origin/${{ github.event.pull_request.base.ref }} -- pom.xml').toString();
-
-              // 解析依赖变更
-              const dependencies = [];
-              const regex = /([+-])\s*(implementation|api|compile|testImplementation|runtimeOnly)\s*['"]([^'"]+)['"]/g;
-              let match;
-
-              while ((match = regex.exec(diffOutput)) !== null) {
-                if (match[1] === '+') { // 只关心新增的依赖
-                  const depParts = match[3].split(':');
-                  if (depParts.length === 3) {
-                    dependencies.push({
-                      group: depParts[0],
-                      artifact: depParts[1],
-                      version: depParts[2]
-                    });
-                  }
-                }
-              }
-
-              if (dependencies.length === 0) {
-                core.setOutput('result', 'No dependency changes found');
-                return 'No dependency changes to check';
-              }
-
-              // 检查阿里云Maven是否有这些依赖
-              const results = [];
+              const dependencies = JSON.parse('${{ steps.parse-deps.outputs.dependencies }}');
               const aliMavenUrl = 'https://maven.aliyun.com/repository/public';
+              const results = [];
 
               for (const dep of dependencies) {
                 const artifactPath = dep.group.replace(/\./g, '/') + '/' + dep.artifact + '/' + dep.version;
@@ -81,22 +141,25 @@ jobs:
                 }
               }
 
-              const commentBody = `### 阿里云 Maven 依赖检查结果\n\n${results.join('\n')}`;
-              core.setOutput('result', commentBody);
+              if (results.length > 0) {
+                const commentBody = `### 阿里云 Maven 依赖检查结果\n\n${results.join('\n')}`;
 
-              // 添加PR评论
-              const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
-              await octokit.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: commentBody
-              });
+                const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+                await octokit.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: ${{ github.event.pull_request.number }},
+                  body: commentBody
+                });
 
-              return commentBody;
+                core.setOutput('result', commentBody);
+              }
+
+              return 'Dependency check completed';
             } catch (error) {
               core.setFailed(`Action failed with error: ${error}`);
             }
 
       - name: Output result
+        if: steps.parse-deps.outputs.dependencies != '[]'
         run: echo "${{ steps.check-aliyun.outputs.result }}"


### PR DESCRIPTION
Close #2125

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add a GitHub Actions workflow to check Dependabot dependency availability on Aliyun Maven repository

New Features:
- Implement automated checking of dependency availability for Dependabot pull requests

CI:
- Create a workflow that checks newly added dependencies against Aliyun Maven repository for Dependabot PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 GitHub Actions 工作流，用于在拉取请求中自动检查新增依赖是否可在阿里云 Maven 仓库获取，并在 PR 下方评论反馈检查结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->