### PR TITLE
build: 支持打包zip产物

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ The build commands require the installation and setup of Java 17 or higher and M
 
 # Pack
 
-1. IDEA artifact packaging\
+1. IDEA artifact aggregation packaging\
    Configuration: Project Structure -> Artifacts -> Add New JAR -> Extract to Target JAR -> Choose your own manifest
    file
    path -> Done\
    Package: Build -> Build Artifacts -> Build
-2. It is recommended to package through `mvn package`.
+2. It is recommended to package with `mvn package`, and the dependencies are in the lib folder
+3. For smc and qe projects, you can also generate zip products by specifying Profile=zip (javafx.platform=win/mac/linux)
+   `mvn -Djavafx.platform=win -Dmaven.test.skip=true -Pzip package`
 
 # Integration builds
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -45,11 +45,13 @@ frameとloginは基本モジュールで、Java SPI経由でプラグイン可�
 
 # パッケージ化
 
-1. IDEA アーティファクトのパッケージ化\
+1. IDEAアーティファクト集約パッケージ\
    構成：プロジェクト構造 -> アーティファクト -> JARを追加 -> ターゲットJARに展開 ->
    独自のマニフェスト・ファイル・パスを選択 -> 完了\
    パッケージング：ビルド -> アーティファクトのビルド -> ビルド
-2. 「`mvn package`」を通じてパッケージ化することをお勧めします
+2. `mvn package`でパッケージ化することが推奨され、依存関係はlibフォルダにあります。
+3. smc および qe プロジェクトでは、Profile=zip (javafx.platform=win/mac/linux) を指定して zip 製品を生成することもできます。
+   `mvn -Djavafx.platform=win -Dmaven.test.skip=true -Pzip package`
 
 # インテグレーションのビルド
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -44,10 +44,12 @@ frame 和 login 是基础模块, 通过java SPI实现可拔插，方便应用模
 
 # 打包
 
-1. IDEA工件打包\
+1. IDEA工件打聚合包\
    配置: 项目结构 -> 工件 -> 新增JAR -> 提取到目标JAR -> 选择自己的清单文件路径 -> 完成\
    打包: 构建 -> 构建工件 -> 构建
-2. 推荐`mvn package`打包
+2. 推荐`mvn package`打包, 依赖在lib文件夹下
+3. 对于smc和qe工程，通过指定Profile=zip还可以生成zip产物 (javafx.platform=win/mac/linux)
+   `mvn -Djavafx.platform=win -Dmaven.test.skip=true -Pzip package`
 
 # 集成构建
 

--- a/qe/config/zip.xml
+++ b/qe/config/zip.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright (c) 2025 unknowIfGuestInDream.
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without
+  ~ modification, are permitted provided that the following conditions are met:
+  ~     * Redistributions of source code must retain the above copyright
+  ~ notice, this list of conditions and the following disclaimer.
+  ~     * Redistributions in binary form must reproduce the above copyright
+  ~ notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+  ~ names of its contributors may be used to endorse or promote products
+  ~ derived from this software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~ DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+  ~ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ~ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>zip</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <baseDirectory>/</baseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>${project.build.finalName}.jar</include>
+                <include>lib/*</include>
+                <include>license/*</include>
+                <include>CHANGELOG.md</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/reports</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>apidocs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/reports</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>apidocs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>docs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../jenkins/${javafx.platform}/qe</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/qe/config/zip.xml
+++ b/qe/config/zip.xml
@@ -55,14 +55,6 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/reports</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>apidocs/*</include>
-            </includes>
-        </fileSet>
-        <fileSet>
             <directory>../</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>

--- a/qe/pom.xml
+++ b/qe/pom.xml
@@ -277,7 +277,7 @@
                         </dependencies>
                         <executions>
                             <execution>
-                                <id>generate-zip-md5</id>
+                                <id>generate-zip-sha256</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>

--- a/qe/pom.xml
+++ b/qe/pom.xml
@@ -235,4 +235,68 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>zip</id>
+            <properties>
+                <!-- win/mac/linux -->
+                <javafx.platform>win</javafx.platform>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>qeTool-${javafx.platform}</finalName>
+                            <descriptors>
+                                <descriptor>config/zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>commons-codec</groupId>
+                                <artifactId>commons-codec</artifactId>
+                                <version>${commons-codec.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-zip-md5</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <checksum algorithm="SHA-256"
+                                                  file="${project.build.directory}/qeTool-${javafx.platform}.zip"
+                                                  property="file.sha256"/>
+                                        <!--suppress UnresolvedMavenProperty -->
+                                        <echo file="${project.build.directory}/qeTool-${javafx.platform}.zip.sha256"
+                                              message="${file.sha256}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/smc/config/zip.xml
+++ b/smc/config/zip.xml
@@ -55,14 +55,6 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/reports</directory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>apidocs/*</include>
-            </includes>
-        </fileSet>
-        <fileSet>
             <directory>../</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>

--- a/smc/config/zip.xml
+++ b/smc/config/zip.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright (c) 2025 unknowIfGuestInDream.
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without
+  ~ modification, are permitted provided that the following conditions are met:
+  ~     * Redistributions of source code must retain the above copyright
+  ~ notice, this list of conditions and the following disclaimer.
+  ~     * Redistributions in binary form must reproduce the above copyright
+  ~ notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+  ~ names of its contributors may be used to endorse or promote products
+  ~ derived from this software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~ DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+  ~ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ~ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>zip</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <baseDirectory>/</baseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>${project.build.finalName}.jar</include>
+                <include>lib/*</include>
+                <include>license/*</include>
+                <include>CHANGELOG.md</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/reports</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>apidocs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/reports</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>apidocs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>docs/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../jenkins/${javafx.platform}/smc</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -349,7 +349,7 @@
                         </dependencies>
                         <executions>
                             <execution>
-                                <id>generate-zip-md5</id>
+                                <id>generate-zip-sha256</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -309,5 +309,66 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>zip</id>
+            <properties>
+                <!-- win/mac/linux -->
+                <javafx.platform>win</javafx.platform>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>smcTool-${javafx.platform}</finalName>
+                            <descriptors>
+                                <descriptor>config/zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>commons-codec</groupId>
+                                <artifactId>commons-codec</artifactId>
+                                <version>${commons-codec.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-zip-md5</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <checksum algorithm="SHA-256"
+                                                  file="${project.build.directory}/smcTool-${javafx.platform}.zip"
+                                                  property="file.sha256"/>
+                                        <!--suppress UnresolvedMavenProperty -->
+                                        <echo file="${project.build.directory}/smcTool-${javafx.platform}.zip.sha256"
+                                              message="${file.sha256}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Close #2084

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add support for generating zip artifacts for smc and qe projects with platform-specific packaging

Build:
- Added Maven profile to support generating platform-specific zip packages for smc and qe projects
- Implemented SHA-256 checksum generation for zip artifacts

Documentation:
- Updated README files to include instructions for generating zip packages with platform-specific options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 更新了中、英、日三种语言的README，详细说明了打包步骤，并新增了基于Maven profile和平台参数生成zip包的说明及命令示例。

- **新功能**
  - 为 smc 和 qe 项目新增了 Maven zip 打包配置，支持通过指定 profile 和平台参数生成平台专属的 zip 包及对应的 SHA-256 校验文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->