### PR TITLE
fix: Fix FxJDKTool run error in Mac

### DIFF
--- a/core/src/main/java/com/tlcsdm/core/javafx/controlsfx/FxJDKToolActionGroup.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controlsfx/FxJDKToolActionGroup.java
@@ -101,7 +101,12 @@ public class FxJDKToolActionGroup {
     }
 
     private void runProgram(String filePath) {
-        ProcessBuilder builder = new ProcessBuilder("cmd", "/c", "start", filePath);
+        ProcessBuilder builder;
+        if (OSUtil.getOS().equals(OSUtil.OS.WINDOWS)) {
+            builder = new ProcessBuilder("cmd", "/c", "start", filePath);
+        } else {
+            builder = new ProcessBuilder("sh", "-c", filePath);
+        }
         try {
             builder.start();
         } catch (IOException ex) {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Bug Fixes:
- Fixed tool launching mechanism to work correctly on Mac and non-Windows platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 改进了程序运行方式，现已支持跨平台执行，无论在 Windows 还是类 Unix 系统上均可正常启动指定文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->