### PR TITLE
fix: Fix stage hidden action In Mac Arm

### DIFF
--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/PreferencesView.java
@@ -92,6 +92,8 @@ public class PreferencesView extends StackPane {
     private void initVisibilityProperty(Keys... excludeKeys) {
         if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
             supUseEasterEgg.setValue(false);
+            supScreenshotHideWindow.setValue(false);
+            supScreenColorPickerHideWindow.setValue(false);
         }
 
         for (Keys key : excludeKeys) {

--- a/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
+++ b/core/src/main/java/com/tlcsdm/core/javafx/controller/SystemSettingController.java
@@ -69,6 +69,8 @@ public class SystemSettingController extends AbstractSystemSettingView {
     public void disableKeys(Keys... excludeKeys) {
         if (OSUtil.getOS().equals(OSUtil.OS.MAC)) {
             disableNode(useEasterEggCheckBox);
+            disableNode(screenshotHideWindowCheckBox);
+            disableNode(screenColorPickerHideWindowCheckBox);
         }
         for (Keys key : excludeKeys) {
             switch (key) {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Fix stage hidden action compatibility issues on Mac Arm architecture

Bug Fixes:
- Resolved issues with screenshot and screen color picker functionality on Mac systems
- Added thread-safe closing mechanism for screenshot stage
- Disabled specific UI features that were incompatible with Mac OS

Enhancements:
- Improved stage closing logic with a volatile flag
- Added platform-specific UI adjustments for Mac OS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 针对 macOS 系统，部分截图和取色相关设置项默认不可见，且对应选项被禁用。

- **修复**
  - 优化了截图窗口关闭流程，防止多次重复关闭导致的问题，提升稳定性。

- **优化**
  - 截图窗口在关闭时对主窗口的恢复操作更加流畅，保证界面体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->