### PR TITLE
fix(qe): 修复SkipBootAnimation 初始值异常

### DIFF
--- a/qe/src/main/java/com/tlcsdm/qe/provider/QeSplashProvider.java
+++ b/qe/src/main/java/com/tlcsdm/qe/provider/QeSplashProvider.java
@@ -105,7 +105,7 @@ public class QeSplashProvider implements SplashScreen {
         SequentialTransition animation = new SequentialTransition(fadeTransition, pathTransition, scaleTransition);
         animation.setInterpolator(Interpolator.EASE_IN);
         animation.setOnFinished(event -> EventBus.getDefault().post(new SplashAnimFinishedEvent()));
-        if (Config.getBoolean(Keys.SkipBootAnimation, true)) {
+        if (Config.getBoolean(Keys.SkipBootAnimation, false)) {
             animation.setRate(10);
         }
         animation.play();


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2137

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Bug Fixes:
- Changed the default value of SkipBootAnimation from true to false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **变更优化**
  - 调整了启动动画的播放速度控制逻辑，默认情况下动画将以正常速度播放，仅在特定配置下才加速。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->