### PR TITLE
fix(common): 修改TableView无数据时的显示文本

### DIFF
--- a/common/src/main/java/com/tlcsdm/jfxcommon/debug/HttpTool.java
+++ b/common/src/main/java/com/tlcsdm/jfxcommon/debug/HttpTool.java
@@ -51,6 +51,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -186,6 +187,10 @@ public class HttpTool extends CommonSample {
         paramsDataTableView.setItems(paramsDatatableData);
         paramsHeaderTableView.setItems(paramsHeadertableData);
         paramsCookieTableView.setItems(paramsCookietableData);
+
+        paramsDataTableView.setPlaceholder(new Label(I18nUtils.get("common.tool.debug.httpTool.table.noData")));
+        paramsHeaderTableView.setPlaceholder(new Label(I18nUtils.get("common.tool.debug.httpTool.table.noData")));
+        paramsCookieTableView.setPlaceholder(new Label(I18nUtils.get("common.tool.debug.httpTool.table.noData")));
     }
 
     private void initializeUI() {

--- a/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_en.properties
+++ b/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_en.properties
@@ -133,3 +133,4 @@ common.tool.debug.httpTool.column.paramValue=Parameter\nValue
 common.tool.debug.httpTool.column.remark=Remark
 common.tool.debug.httpTool.tab.responseContent=Response Content
 common.tool.debug.httpTool.tab.responseHeader=Response Header
+common.tool.debug.httpTool.table.noData=No data to display

--- a/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_ja.properties
+++ b/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_ja.properties
@@ -133,3 +133,4 @@ common.tool.debug.httpTool.column.paramValue=\u30D1\u30E9\u30E1\u30FC\u30BF\u502
 common.tool.debug.httpTool.column.remark=\u5099\u8003
 common.tool.debug.httpTool.tab.responseContent=\u56DE\u7B54\u5185\u5BB9
 common.tool.debug.httpTool.tab.responseHeader=\u5FDC\u7B54\u30D8\u30C3\u30C0\u30FC
+common.tool.debug.httpTool.table.noData=\u8868\u793A\u3059\u308B\u30C7\u30FC\u30BF\u304C\u3042\u308A\u307E\u305B\u3093

--- a/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_zh.properties
+++ b/common/src/main/resources/com/tlcsdm/jfxcommon/i18n/messages_zh.properties
@@ -133,3 +133,4 @@ common.tool.debug.httpTool.column.paramValue=\u53C2\u6570\u503C
 common.tool.debug.httpTool.column.remark=\u5907\u6CE8
 common.tool.debug.httpTool.tab.responseContent=\u54CD\u5E94\u5185\u5BB9
 common.tool.debug.httpTool.tab.responseHeader=\u54CD\u5E94\u5934\u90E8
+common.tool.debug.httpTool.table.noData=\u6CA1\u6709\u53EF\u663E\u793A\u7684\u6570\u636E


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2145

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add a localized placeholder message for empty TableViews in the HTTP debugging tool and supply the corresponding translations.

Bug Fixes:
- Show a localized "no data" placeholder in the parameters, headers, and cookies tables when they are empty.

Enhancements:
- Introduce the common.tool.debug.httpTool.table.noData key and add its translations in English, Japanese, and Chinese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 当 HTTP 工具的表格无数据时，新增本地化“无数据显示”占位提示，支持中、英、日三种语言。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->