### PR TITLE
build: 修复-Pzip 打包时缺少文件的问题

### DIFF
--- a/qe/config/zip.xml
+++ b/qe/config/zip.xml
@@ -42,7 +42,7 @@
             <includes>
                 <include>${project.build.finalName}.jar</include>
                 <include>lib/*</include>
-                <include>license/*</include>
+                <include>license/**</include>
                 <include>CHANGELOG.md</include>
             </includes>
         </fileSet>
@@ -51,7 +51,7 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>
             <includes>
-                <include>apidocs/*</include>
+                <include>apidocs/**</include>
             </includes>
         </fileSet>
         <fileSet>
@@ -59,7 +59,7 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>
             <includes>
-                <include>docs/*</include>
+                <include>docs/**</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/qe/pom.xml
+++ b/qe/pom.xml
@@ -250,7 +250,7 @@
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>qeTool-${javafx.platform}</finalName>
+                            <finalName>qeTool-${javafx.platform}-${project.version}</finalName>
                             <descriptors>
                                 <descriptor>config/zip.xml</descriptor>
                             </descriptors>
@@ -285,10 +285,10 @@
                                 <configuration>
                                     <target>
                                         <checksum algorithm="SHA-256"
-                                                  file="${project.build.directory}/qeTool-${javafx.platform}.zip"
+                                                  file="${project.build.directory}/qeTool-${javafx.platform}-${project.version}.zip"
                                                   property="file.sha256"/>
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo file="${project.build.directory}/qeTool-${javafx.platform}.zip.sha256"
+                                        <echo file="${project.build.directory}/qeTool-${javafx.platform}-${project.version}.zip.sha256"
                                               message="${file.sha256}"/>
                                     </target>
                                 </configuration>

--- a/smc/config/zip.xml
+++ b/smc/config/zip.xml
@@ -42,7 +42,7 @@
             <includes>
                 <include>${project.build.finalName}.jar</include>
                 <include>lib/*</include>
-                <include>license/*</include>
+                <include>license/**</include>
                 <include>CHANGELOG.md</include>
             </includes>
         </fileSet>
@@ -51,7 +51,7 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>
             <includes>
-                <include>apidocs/*</include>
+                <include>apidocs/**</include>
             </includes>
         </fileSet>
         <fileSet>
@@ -59,7 +59,7 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>/</outputDirectory>
             <includes>
-                <include>docs/*</include>
+                <include>docs/**</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/smc/pom.xml
+++ b/smc/pom.xml
@@ -322,7 +322,7 @@
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>smcTool-${javafx.platform}</finalName>
+                            <finalName>smcTool-${javafx.platform}-${project.version}</finalName>
                             <descriptors>
                                 <descriptor>config/zip.xml</descriptor>
                             </descriptors>
@@ -357,10 +357,10 @@
                                 <configuration>
                                     <target>
                                         <checksum algorithm="SHA-256"
-                                                  file="${project.build.directory}/smcTool-${javafx.platform}.zip"
+                                                  file="${project.build.directory}/smcTool-${javafx.platform}-${project.version}.zip"
                                                   property="file.sha256"/>
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo file="${project.build.directory}/smcTool-${javafx.platform}.zip.sha256"
+                                        <echo file="${project.build.directory}/smcTool-${javafx.platform}-${project.version}.zip.sha256"
                                               message="${file.sha256}"/>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2144

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Fix missing files in packaging by expanding include patterns and append project version to the generated zip filenames and checksum artifacts for qeTool and smcTool.

Bug Fixes:
- Change zip includes to use recursive patterns for license, apidocs, and docs directories to ensure nested files are packaged.

Build:
- Update Maven assembly plugin configurations to append project version to qeTool and smcTool zip filenames and their checksum artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 生成的 ZIP 文件及其校验文件名称现包含项目版本号，便于区分不同版本的构建产物。
- **优化**
  - 打包时将递归包含 license、apidocs 和 docs 目录下的所有文件及子目录，确保文档和许可证完整收录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->