### PR TITLE
test: Add sqlite3 test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -455,6 +455,11 @@
             <artifactId>qrcodegen</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/test/java/com/tlcsdm/core/database/Sqlite1Test.java
+++ b/core/src/test/java/com/tlcsdm/core/database/Sqlite1Test.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import com.tlcsdm.core.database.sqlite.UserDao;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class Sqlite1Test {
+
+    private static String dbParentPath;
+    private static String TEST_DB_URL;
+    private UserDao userDao;
+
+    @BeforeAll
+    static void init() {
+        dbParentPath = new File(ResourceUtil.getResource("database/init.sql").getPath()).getParent();
+        TEST_DB_URL = "jdbc:sqlite:" + Paths.get(dbParentPath).resolve("usersqlite.db");
+        System.out.println(TEST_DB_URL);
+    }
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        userDao = new UserDao(TEST_DB_URL);
+        userDao.deleteAllUsers();
+    }
+
+    @Test
+    void testInsertAndGetUsers() throws SQLException {
+        // 插入测试数据
+        userDao.insertUser("Alice", "alice@example.com");
+        userDao.insertUser("Bob", "bob@example.com");
+
+        // 验证数据
+        List<String> names = userDao.getAllUserNames();
+        Assertions.assertEquals(2, names.size());
+        Assertions.assertTrue(names.contains("Alice"));
+        Assertions.assertTrue(names.contains("Bob"));
+    }
+
+    @Test
+    void testEmptyDatabase() throws SQLException {
+        List<String> names = userDao.getAllUserNames();
+        Assertions.assertTrue(names.isEmpty());
+    }
+
+    @Test
+    void testDuplicateEmail() {
+        // 测试唯一约束
+        Assertions.assertDoesNotThrow(() -> userDao.insertUser("Alice", "alice@example.com"));
+        SQLException exception = Assertions.assertThrows(SQLException.class,
+            () -> userDao.insertUser("Alice", "alice@example.com"));
+        Assertions.assertTrue(exception.getMessage().contains("UNIQUE constraint failed"));
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/Sqlite2Test.java
+++ b/core/src/test/java/com/tlcsdm/core/database/Sqlite2Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import com.tlcsdm.core.database.sqlite.UserDao;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class Sqlite2Test {
+    @TempDir
+    static Path tempDir;
+    private static String TEST_DB_URL;
+    private UserDao userDao;
+
+    @BeforeAll
+    static void init() {
+        TEST_DB_URL = "jdbc:sqlite:" + tempDir.resolve("test.db");
+        System.out.println(TEST_DB_URL);
+    }
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        userDao = new UserDao(TEST_DB_URL);
+        userDao.deleteAllUsers();
+    }
+
+    @Test
+    void testInsertAndGetUsers() throws SQLException {
+        // 插入测试数据
+        userDao.insertUser("Alice", "alice@example.com");
+        userDao.insertUser("Bob", "bob@example.com");
+
+        // 验证数据
+        List<String> names = userDao.getAllUserNames();
+        Assertions.assertEquals(2, names.size());
+        Assertions.assertTrue(names.contains("Alice"));
+        Assertions.assertTrue(names.contains("Bob"));
+    }
+
+    @Test
+    void testEmptyDatabase() throws SQLException {
+        List<String> names = userDao.getAllUserNames();
+        Assertions.assertTrue(names.isEmpty());
+    }
+
+    @Test
+    void testDuplicateEmail() {
+        // 测试唯一约束
+        Assertions.assertDoesNotThrow(() -> userDao.insertUser("Alice", "alice@example.com"));
+        SQLException exception = Assertions.assertThrows(SQLException.class,
+            () -> userDao.insertUser("Alice", "alice@example.com"));
+        Assertions.assertTrue(exception.getMessage().contains("UNIQUE constraint failed"));
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteAccountTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteAccountTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class SqliteAccountTest {
+    /**
+     * 以嵌入式(本地)连接方式连接数据库
+     */
+    private static final String DRIVER_CLASS = "org.sqlite.JDBC";
+    private static final String USER = "root";
+    private static final String PASSWORD = "root";
+    private static String dbParentPath;
+    private static String TEST_DB_URL;
+
+    @BeforeAll
+    static void init() {
+        dbParentPath = new File(ResourceUtil.getResource("database/init.sql").getPath()).getParent();
+        TEST_DB_URL = "jdbc:sqlite:" + Paths.get(dbParentPath).resolve("sqliteDB.db");
+        System.out.println(TEST_DB_URL);
+    }
+
+    @Test
+    void testInsertAndGetUsers() throws ClassNotFoundException, SQLException {
+        //与数据库建立连接
+        Class.forName(DRIVER_CLASS);
+        Connection conn = DriverManager.getConnection(TEST_DB_URL, USER, PASSWORD);
+        Statement statement = conn.createStatement();
+
+        //删除表
+        statement.execute("DROP TABLE IF EXISTS USER_INF");
+        //创建表
+        statement.execute(
+            "CREATE TABLE USER_INF(id VARCHAR(50) PRIMARY KEY, name VARCHAR(50) NOT NULL, sex VARCHAR(50) NOT NULL)");
+
+        //插入数据
+        statement.executeUpdate("INSERT INTO USER_INF VALUES('1', '程咬金', '男') ");
+        statement.executeUpdate("INSERT INTO USER_INF VALUES('2', '孙尚香', '女') ");
+        statement.executeUpdate("INSERT INTO USER_INF VALUES('3', '猴子', '男') ");
+
+        //查询数据
+        ResultSet resultSet = statement.executeQuery("select * from USER_INF");
+        while (resultSet.next()) {
+            System.out.println(
+                resultSet.getInt("id") + ", " + resultSet.getString("name") + ", " + resultSet.getString("sex"));
+        }
+        //关闭连接
+        statement.close();
+        conn.close();
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * 初始化脚本.
+ *
+ * @author unknowIfGuestInDream
+ */
+public class SqliteInitSQLTest {
+
+    private static Connection conn;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        // 创建内存数据库连接
+        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+        // 执行初始化脚本
+        initializeInMemoryDatabase(conn);
+    }
+
+    @Test
+    void testUserCount() throws SQLException {
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM users")) {
+            rs.next();
+            Assertions.assertEquals(3, rs.getInt(1));
+        }
+    }
+
+    @AfterAll
+    static void cleanup() throws SQLException {
+        if (conn != null) {
+            conn.close();
+        }
+    }
+
+    private static void initializeInMemoryDatabase(Connection conn) throws SQLException, IOException {
+        try (InputStream is = ResourceUtil.getResource("database/init.sql").openStream();
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+             Statement stmt = conn.createStatement()) {
+
+            String line;
+            StringBuilder sb = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                // 跳过注释和空行
+                if (!line.trim().startsWith("--") && !line.trim().isEmpty()) {
+                    sb.append(line);
+                    // 检查是否以分号结束（完整SQL语句）
+                    if (line.trim().endsWith(";")) {
+                        String sql = sb.toString();
+                        stmt.execute(sql);
+                        sb = new StringBuilder();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteMemoryTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteMemoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * 内存数据库.
+ *
+ * @author unknowIfGuestInDream
+ */
+public class SqliteMemoryTest {
+    private static Connection conn;
+
+    @BeforeAll
+    static void setup() throws SQLException {
+        // 创建内存数据库连接
+        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+
+        // 初始化数据库结构
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE products (" +
+                "id INTEGER PRIMARY KEY, " +
+                "name TEXT NOT NULL, " +
+                "price REAL)");
+        }
+    }
+
+    @BeforeEach
+    void prepareData() throws SQLException {
+        // 每个测试前清空并插入测试数据
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("DELETE FROM products");
+            stmt.execute("INSERT INTO products(name, price) VALUES('Laptop', 999.99)");
+            stmt.execute("INSERT INTO products(name, price) VALUES('Phone', 699.99)");
+        }
+    }
+
+    @Test
+    void testProductCount() throws SQLException {
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM products")) {
+            rs.next();
+            Assertions.assertEquals(2, rs.getInt(1));
+        }
+    }
+
+    @Test
+    void testProductInsert() throws SQLException {
+        try (PreparedStatement pstmt = conn.prepareStatement(
+            "INSERT INTO products(name, price) VALUES(?, ?)")) {
+            pstmt.setString(1, "Tablet");
+            pstmt.setDouble(2, 499.99);
+            Assertions.assertEquals(1, pstmt.executeUpdate());
+        }
+
+        // 验证插入
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM products")) {
+            rs.next();
+            Assertions.assertEquals(3, rs.getInt(1));
+        }
+    }
+
+    @AfterAll
+    static void cleanup() throws SQLException {
+        if (conn != null && !conn.isClosed()) {
+            conn.close();
+        }
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteShareMemoryTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteShareMemoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * 共享内存数据库.
+ * 默认情况下，每个 :memory: 连接都会创建独立的内存数据库。要共享内存数据库：使用命名内存数据库
+ *
+ * @author unknowIfGuestInDream
+ */
+public class SqliteShareMemoryTest {
+    private static final String SHARED_URL =
+        "jdbc:sqlite:file:sharedmem?mode=memory&cache=shared";
+
+    @Test
+    void testProductCount() {
+        // 线程1创建表并插入数据
+        new Thread(() -> {
+            try (Connection conn = DriverManager.getConnection(SHARED_URL);
+                 Statement stmt = conn.createStatement()) {
+
+                stmt.execute("CREATE TABLE IF NOT EXISTS messages (id INTEGER, content TEXT)");
+                stmt.execute("INSERT INTO messages VALUES(1, 'Hello from Thread 1')");
+                Thread.sleep(1000); // 等待线程2读取
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        // 线程2读取数据
+        new Thread(() -> {
+
+            try (Connection conn = DriverManager.getConnection(SHARED_URL);
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT * FROM messages")) {
+
+                Thread.sleep(2000); // 等待线程1写入
+                while (rs.next()) {
+                    System.out.println(rs.getInt("id") + ": " + rs.getString("content"));
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }).start();
+    }
+}

--- a/core/src/test/java/com/tlcsdm/core/database/sqlite/UserDao.java
+++ b/core/src/test/java/com/tlcsdm/core/database/sqlite/UserDao.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.tlcsdm.core.database.sqlite;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author unknowIfGuestInDream
+ */
+public class UserDao {
+    private final String url;
+
+    static {
+        try {
+            Class.forName("org.sqlite.JDBC");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to load SQLite JDBC driver", e);
+        }
+    }
+
+    public UserDao(String url) {
+        this.url = url;
+        createTable();
+    }
+
+    private Connection connect() throws SQLException {
+        return DriverManager.getConnection(url);
+    }
+
+    public void createTable() {
+        String sql = "CREATE TABLE IF NOT EXISTS users (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "name TEXT NOT NULL," +
+            "email TEXT NOT NULL UNIQUE)";
+
+        try (Connection conn = connect();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        } catch (SQLException e) {
+            System.err.println(e.getMessage());
+        }
+    }
+
+    public void insertUser(String name, String email) throws SQLException {
+        String sql = "INSERT INTO users(name, email) VALUES(?, ?)";
+
+        try (Connection conn = connect();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, name);
+            pstmt.setString(2, email);
+            pstmt.executeUpdate();
+        }
+    }
+
+    public List<String> getAllUserNames() throws SQLException {
+        String sql = "SELECT name FROM users";
+        List<String> names = new ArrayList<>();
+
+        try (Connection conn = connect();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+
+            while (rs.next()) {
+                names.add(rs.getString("name"));
+            }
+        }
+        return names;
+    }
+
+    public void deleteAllUsers() throws SQLException {
+        String sql = "DELETE FROM users";
+
+        try (Connection conn = connect();
+             Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(sql);
+        }
+    }
+}

--- a/core/src/test/resources/database/init.sql
+++ b/core/src/test/resources/database/init.sql
@@ -1,0 +1,224 @@
+-- init.sql - SQLite 内存数据库初始化脚本
+
+-- 创建用户表
+CREATE TABLE IF NOT EXISTS users
+(
+    id
+    INTEGER
+    PRIMARY
+    KEY
+    AUTOINCREMENT,
+    username
+    TEXT
+    NOT
+    NULL
+    UNIQUE,
+    password
+    TEXT
+    NOT
+    NULL,
+    email
+    TEXT
+    NOT
+    NULL
+    UNIQUE,
+    created_at
+    TIMESTAMP
+    DEFAULT
+    CURRENT_TIMESTAMP,
+    is_active
+    BOOLEAN
+    DEFAULT
+    1
+);
+
+-- 创建产品表
+CREATE TABLE IF NOT EXISTS products
+(
+    id
+    INTEGER
+    PRIMARY
+    KEY
+    AUTOINCREMENT,
+    name
+    TEXT
+    NOT
+    NULL,
+    description
+    TEXT,
+    price
+    DECIMAL
+(
+    10,
+    2
+) NOT NULL,
+    stock INTEGER DEFAULT 0,
+    category_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY
+(
+    category_id
+) REFERENCES categories
+(
+    id
+)
+    );
+
+-- 创建分类表
+CREATE TABLE IF NOT EXISTS categories
+(
+    id
+    INTEGER
+    PRIMARY
+    KEY
+    AUTOINCREMENT,
+    name
+    TEXT
+    NOT
+    NULL
+    UNIQUE,
+    description
+    TEXT
+);
+
+-- 创建订单表
+CREATE TABLE IF NOT EXISTS orders
+(
+    id
+    INTEGER
+    PRIMARY
+    KEY
+    AUTOINCREMENT,
+    user_id
+    INTEGER
+    NOT
+    NULL,
+    order_date
+    TIMESTAMP
+    DEFAULT
+    CURRENT_TIMESTAMP,
+    total_amount
+    DECIMAL
+(
+    10,
+    2
+) NOT NULL,
+    status TEXT DEFAULT 'pending',
+    FOREIGN KEY
+(
+    user_id
+) REFERENCES users
+(
+    id
+)
+    );
+
+-- 创建订单详情表
+CREATE TABLE IF NOT EXISTS order_items
+(
+    id
+    INTEGER
+    PRIMARY
+    KEY
+    AUTOINCREMENT,
+    order_id
+    INTEGER
+    NOT
+    NULL,
+    product_id
+    INTEGER
+    NOT
+    NULL,
+    quantity
+    INTEGER
+    NOT
+    NULL,
+    unit_price
+    DECIMAL
+(
+    10,
+    2
+) NOT NULL,
+    FOREIGN KEY
+(
+    order_id
+) REFERENCES orders
+(
+    id
+),
+    FOREIGN KEY
+(
+    product_id
+) REFERENCES products
+(
+    id
+)
+    );
+
+-- 插入初始分类数据
+INSERT INTO categories (name, description)
+VALUES ('Electronics', 'Electronic devices and accessories'),
+       ('Clothing', 'Apparel and fashion items'),
+       ('Books', 'Books and educational materials'),
+       ('Home', 'Home and kitchen products');
+
+-- 插入初始产品数据
+INSERT INTO products (name, description, price, stock, category_id)
+VALUES ('Smartphone X', 'Latest model smartphone with advanced features', 799.99, 100, 1),
+       ('Wireless Headphones', 'Noise cancelling wireless headphones', 199.99, 50, 1),
+       ('Cotton T-Shirt', '100% cotton comfortable t-shirt', 24.99, 200, 2),
+       ('Programming Book', 'Comprehensive guide to modern programming', 49.99, 30, 3),
+       ('Coffee Maker', 'Automatic drip coffee maker', 89.99, 40, 4);
+
+-- 插入测试用户数据
+INSERT INTO users (username, password, email)
+VALUES ('admin', 'hashed_password_here', 'admin@example.com'),
+       ('johndoe', 'hashed_password_here', 'john.doe@example.com'),
+       ('janedoe', 'hashed_password_here', 'jane.doe@example.com');
+
+-- 插入测试订单数据
+INSERT INTO orders (user_id, total_amount, status)
+VALUES (2, 1049.98, 'completed'),
+       (3, 74.98, 'shipped');
+
+-- 插入订单详情数据
+INSERT INTO order_items (order_id, product_id, quantity, unit_price)
+VALUES (1, 1, 1, 799.99),
+       (1, 2, 1, 199.99),
+       (2, 3, 2, 24.99),
+       (2, 5, 1, 89.99);
+
+
+/*
+ * Copyright (c) 2025 unknowIfGuestInDream.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+-- 创建索引提高查询性能
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_products_category ON products(category_id);
+CREATE INDEX IF NOT EXISTS idx_orders_user ON orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_order_items_order ON order_items(order_id);

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
         <nashorn.version>15.6</nashorn.version>
         <jruby.version>9.4.12.1</jruby.version>
         <qrcodegen.version>1.8.0</qrcodegen.version>
+        <sqlite.version>3.49.1.0</sqlite.version>
     </properties>
 
     <issueManagement>
@@ -1245,6 +1246,11 @@
                 <groupId>io.nayuki</groupId>
                 <artifactId>qrcodegen</artifactId>
                 <version>${qrcodegen.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial</groupId>
+                <artifactId>sqlite-jdbc</artifactId>
+                <version>${sqlite.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
CLose #1131

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add SQLite testing support by including the sqlite-jdbc dependency, providing an SQL initialization script, and implementing a UserDao alongside a suite of JUnit tests covering various SQLite scenarios

Build:
- Add sqlite-jdbc dependency to root and core POMs

Tests:
- Add SQL initialization script for an in-memory SQLite database
- Implement UserDao and add comprehensive JUnit tests covering SQLite operations (in-memory, initialization script execution, file-based DB, unique constraints, and shared-memory cache)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增多项基于 SQLite 的数据库单元测试，包括用户、产品及订单等表的插入、查询及唯一约束验证。
  - 引入 SQLite 内存数据库和共享内存数据库测试用例，验证多线程和多连接场景下的数据一致性。
  - 新增测试用数据库初始化脚本，自动建表并插入初始数据。

- **杂项**
  - 新增 SQLite JDBC 依赖，提升测试环境数据库兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->