### PR TITLE
build: Upgrade pom.xml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,18 +10,12 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "unknowIfGuestInDream"
-      - "DreamAwakenFateBroke"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "friday"
       timezone: "Asia/Shanghai"
-    reviewers:
-      - "unknowIfGuestInDream"
-      - "DreamAwakenFateBroke"
     labels:
       - "workflow"
       - "github_actions"

--- a/core/src/main/java/com/tlcsdm/core/util/DependencyInfo.java
+++ b/core/src/main/java/com/tlcsdm/core/util/DependencyInfo.java
@@ -224,7 +224,7 @@ public class DependencyInfo {
                 "https://github.com/JonathanGiles/TeenyHttpd", "MIT License",
                 "http://www.opensource.org/licenses/mit-license.php"),
 
-            new Dependency("com.cedarsoftware", "java-util", "", false,
+            new Dependency("com.cedarsoftware", "java-util", "3.3.2", false,
                 "https://github.com/jdereg/java-util", "Apache License, Version 2.0",
                 "https://www.apache.org/licenses/LICENSE-2.0"),
 

--- a/core/src/main/java/com/tlcsdm/core/util/DependencyInfo.java
+++ b/core/src/main/java/com/tlcsdm/core/util/DependencyInfo.java
@@ -53,7 +53,7 @@ public class DependencyInfo {
                 "https://github.com/controlsfx/controlsfx", "The 3-Clause BSD License",
                 "http://www.opensource.org/licenses/bsd-license.php"),
 
-            new Dependency("org.junit.jupiter", "junit", "5.12.2", true, "https://github.com/junit-team/junit5",
+            new Dependency("org.junit.jupiter", "junit", "5.13.0", true, "https://github.com/junit-team/junit5",
                 "Eclipse Public License - v 2.0", "https://www.eclipse.org/legal/epl-v20.html"),
 
             new Dependency("org.apache.poi", "poi", "5.4.1", false, "https://poi.apache.org/",
@@ -138,7 +138,7 @@ public class DependencyInfo {
                 "https://github.com/FXMisc/RichTextFX", "The BSD 2-Clause License",
                 "http://opensource.org/licenses/BSD-2-Clause"),
 
-            new Dependency("org.apache.groovy", "groovy", "4.0.26", false, "https://groovy-lang.org",
+            new Dependency("org.apache.groovy", "groovy", "4.0.27", false, "https://groovy-lang.org",
                 "Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"),
 
             new Dependency("com.sikulix", "sikulixapi", "2.0.5", false, "https://github.com/RaiMan/SikuliX1",
@@ -224,7 +224,7 @@ public class DependencyInfo {
                 "https://github.com/JonathanGiles/TeenyHttpd", "MIT License",
                 "http://www.opensource.org/licenses/mit-license.php"),
 
-            new Dependency("com.cedarsoftware", "java-util", "3.3.1", false,
+            new Dependency("com.cedarsoftware", "java-util", "", false,
                 "https://github.com/jdereg/java-util", "Apache License, Version 2.0",
                 "https://www.apache.org/licenses/LICENSE-2.0"),
 

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
@@ -96,8 +96,8 @@ public class SqliteInitSQLTest {
                     // 检查是否以分号结束（完整SQL语句）
                     if (line.trim().endsWith(";")) {
                         String sql = sb.toString();
-                        stmt.execute(sql);
                         sb = new StringBuilder();
+                        stmt.execute(sql);
                     }
                 }
             }

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
@@ -74,11 +74,7 @@ public class SqliteInitSQLTest {
     @AfterAll
     static void cleanup() throws SQLException {
         if (conn != null) {
-            try {
-                conn.rollback(); // 回滚任何未提交的更改
-            } finally {
-                conn.close();
-            }
+            conn.close();
         }
     }
 
@@ -97,7 +93,9 @@ public class SqliteInitSQLTest {
                     if (line.trim().endsWith(";")) {
                         String sql = sb.toString();
                         sb = new StringBuilder();
-                        stmt.execute(sql);
+                        if (!sql.trim().isEmpty()) {
+                            stmt.execute(sql);
+                        }
                     }
                 }
             }

--- a/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
+++ b/core/src/test/java/com/tlcsdm/core/database/SqliteInitSQLTest.java
@@ -58,6 +58,8 @@ public class SqliteInitSQLTest {
         conn = DriverManager.getConnection("jdbc:sqlite::memory:");
         // 执行初始化脚本
         initializeInMemoryDatabase(conn);
+        // 禁用自动提交以确保连接保持活跃
+        conn.setAutoCommit(false);
     }
 
     @Test
@@ -72,7 +74,11 @@ public class SqliteInitSQLTest {
     @AfterAll
     static void cleanup() throws SQLException {
         if (conn != null) {
-            conn.close();
+            try {
+                conn.rollback(); // 回滚任何未提交的更改
+            } finally {
+                conn.close();
+            }
         }
     }
 

--- a/core/src/test/resources/database/init.sql
+++ b/core/src/test/resources/database/init.sql
@@ -188,35 +188,6 @@ VALUES (1, 1, 1, 799.99),
        (2, 3, 2, 24.99),
        (2, 5, 1, 89.99);
 
-
-/*
- * Copyright (c) 2025 unknowIfGuestInDream.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- *     * Neither the name of unknowIfGuestInDream, any associated website, nor the
- * names of its contributors may be used to endorse or promote products
- * derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL UNKNOWIFGUESTINDREAM BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-
 -- 创建索引提高查询性能
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_products_category ON products(category_id);

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,14 +20,14 @@ JavaFXTool基于JDK17 + JavaFX 21 + controlsfx 11 + maven构建的javafx脚手�
 | cssfx                  | 11.5.1       | css 实时重载工具                       |
 | dom4j                  | 2.1.4        | XML 框架                           |
 | freemarker             | 2.3.34       | 模板引擎库                            |
-| groovy                 | 4.0.26       | Groovy                           |
+| groovy                 | 4.0.27       | Groovy                           |
 | hutool                 | 5.8.38       | Java工具类库                         |
 | icns                   | 1.2          | 处理 Apple Icon Image 格式图标的 Java 库 |
 | image4j                | 0.7.2        | 处理 BMP 和 ICO 图像格式的 Java 库        |
 | java-diff-utils        | 4.15         | 用于在文本或某种数据之间执行比较/差异操作            |
 | jackson                | 2.19.0       | JSON解析库                          |
 | jSerialComm            | 2.11.0       | 串口通信库                            |
-| junit                  | 5.12.2       | 单元测试框架                           |
+| junit                  | 5.13.0       | 单元测试框架                           |
 | logback                | 1.5.18       | Java日志框架                         |
 | poi-ooxml              | 5.4.1        | 用于Microsoft Documents的Java API   |
 | preferencesfx          | 11.17.0      | 为应用程序设置/首选项创建 UI 的框架             |

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <plantuml.version>1.2025.2</plantuml.version>
         <cssfx.version>11.5.1</cssfx.version>
         <teenyhttpd.version>1.0.5</teenyhttpd.version>
-        <java-util.version></java-util.version>
+        <java-util.version>3.3.2</java-util.version>
         <eclipse-collections.version>11.1.0</eclipse-collections.version>
         <jep.version>4.2.2</jep.version>
         <imageio.version>3.12.0</imageio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <maven.wagon.http.ssl.insecure>true</maven.wagon.http.ssl.insecure>
         <maven.wagon.http.ssl.allowall>true</maven.wagon.http.ssl.allowall>
         <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
-        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <git-commit-id-maven-plugin.version>9.0.2</git-commit-id-maven-plugin.version>
@@ -99,7 +99,7 @@
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <junit.version>5.12.2</junit.version>
+        <junit.version>5.13.0</junit.version>
         <jcip-annotations.version>1.0-1</jcip-annotations.version>
         <javafx.version>21.0.7</javafx.version>
         <javafx.swt.version>21.0.4</javafx.swt.version>
@@ -150,7 +150,7 @@
         <bootstrapfx.version>0.4.0</bootstrapfx.version>
         <ikonli.version>12.4.0</ikonli.version>
         <richtextfx.version>0.11.5</richtextfx.version>
-        <groovy.version>4.0.26</groovy.version>
+        <groovy.version>4.0.27</groovy.version>
         <thumbnailator.version>0.4.20</thumbnailator.version>
         <gson.version>2.13.1</gson.version>
         <tabula.version>1.0.5</tabula.version>
@@ -168,11 +168,11 @@
         <jython.version>2.7.4</jython.version>
         <violations.version>1.157.3</violations.version>
         <asm.version>9.8</asm.version>
-        <pmd.version>7.13.0</pmd.version>
+        <pmd.version>7.14.0</pmd.version>
         <bytebuddy.version>1.17.5</bytebuddy.version>
         <tess4j.version>5.15.0</tess4j.version>
         <hikariCP.version>6.3.0</hikariCP.version>
-        <druid.version>1.2.24</druid.version>
+        <druid.version>1.2.25</druid.version>
         <h2.version>2.3.232</h2.version>
         <jcommander.version>2.0</jcommander.version>
         <jssc.version>2.10.0</jssc.version>
@@ -187,7 +187,7 @@
         <plantuml.version>1.2025.2</plantuml.version>
         <cssfx.version>11.5.1</cssfx.version>
         <teenyhttpd.version>1.0.5</teenyhttpd.version>
-        <java-util.version>3.3.1</java-util.version>
+        <java-util.version></java-util.version>
         <eclipse-collections.version>11.1.0</eclipse-collections.version>
         <jep.version>4.2.2</jep.version>
         <imageio.version>3.12.0</imageio.version>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Upgrade project’s Maven build to use the latest patch releases for key plugins and dependencies

Chores:
- Upgrade Maven plugins and dependencies to new patch versions (exec-maven-plugin 3.5.1, JUnit 5.13.0, Groovy 4.0.27, PMD 7.14.0, Druid 1.2.25)
- Clear the java-util version placeholder in pom.xml
- Synchronize version changes in the DependencyInfo class and README documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 升级了多个依赖项和插件的版本，包括 JUnit、Groovy、java-util、exec-maven-plugin、pmd 和 druid。
  - 调整了 Dependabot 配置，移除了 Maven 和 GitHub Actions 生态系统的默认审阅者。
- **Documentation**
  - 更新了 README 文档中相关依赖的版本信息。
- **Bug Fixes**
  - 优化了 SQLite 内存数据库测试，禁用自动提交并避免执行空 SQL 语句。
- **Chores**
  - 移除了 SQL 初始化脚本末尾的版权和许可声明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->