### PR TITLE
ci: Improve aliyun check action

### DIFF
--- a/.github/workflows/check-aliyun-maven.yml
+++ b/.github/workflows/check-aliyun-maven.yml
@@ -1,4 +1,4 @@
-name: Check Aliyun Maven Dependencies
+name: Check Aliyun Maven Dependencies and Plugins
 
 on:
   pull_request_target:
@@ -72,7 +72,7 @@ jobs:
           cat changes.diff >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Parse dependencies
+      - name: Parse dependencies and plugins
         if: steps.check-author.outputs.is_dependabot == 'true'
         id: parse-deps
         uses: actions/github-script@v7
@@ -83,107 +83,144 @@ jobs:
             try {
               const buildType = '${{ steps.get-changes.outputs.build_type }}';
               const changes = '${{ steps.get-changes.outputs.changes }}';
-              const dependencies = [];
+              const allComponents = []; // Changed to allComponents to include both deps and plugins
 
               if (buildType === 'gradle') {
                 // Gradle 依赖解析
+                // Note: This script currently only handles added dependencies (lines starting with '+')
+                // For a more robust solution, you might need to compare the entire build.gradle
+                // before and after the PR to identify actual changes.
                 const regex = /([+-])\s*(implementation|api|compile|testImplementation|runtimeOnly)\s*['"]([^'"]+)['"]/g;
                 let match;
 
                 while ((match = regex.exec(changes)) !== null) {
-                  if (match[1] === '+') {
+                  if (match[1] === '+') { // Only consider added dependencies for simplicity
                     const depParts = match[3].split(':');
                     if (depParts.length === 3) {
-                      dependencies.push({
+                      allComponents.push({
                         group: depParts[0],
                         artifact: depParts[1],
-                        version: depParts[2]
+                        version: depParts[2],
+                        type: 'dependency' // Mark as dependency
                       });
                     }
                   }
                 }
               } else if (buildType === 'maven') {
-                // Maven 依赖解析
-                // 1. 读取并解析整个pom.xml
+                // Maven 依赖和插件解析
                 const pomContent = fs.readFileSync('pom.xml', 'utf-8');
-
-                // 使用xml2js解析pom.xml
                 const parser = new xml2js.Parser({ explicitArray: false });
                 const result = await parser.parseStringPromise(pomContent);
 
-                // 2. 分析变更
                 const diffLines = changes.split('\n');
                 const changedProperties = {};
-                // 提取properties
+
+                // Extract properties
                 const properties = result.project?.properties || {};
-                // 找出变更的属性
-                const propertyRegex = /^([+-])\s*<([^>]+\.version)>\s*([^<]+)\s*<\/[^>]+>$/;
+
+                // Identify changed properties from the diff
+                const propertyRegex = /^([+-])\s*<([^>]+)>\s*([^<]+)\s*<\/[^>]+>$/; // Updated regex to be more general for properties
                 for (const line of diffLines) {
                     const match = line.match(propertyRegex);
                     if (match && match[1] === '+') {
-                      const propName = match[2]; // 获取属性名
-                      const propValue = match[3].trim(); // 获取新值
-                      changedProperties[propName] = propValue;
+                        const propName = match[2];
+                        const propValue = match[3].trim();
+                        changedProperties[propName] = propValue;
                     }
                 }
-                // 3. 合并变更后的属性
                 const effectiveProperties = { ...properties, ...changedProperties };
 
                 console.log("=====changedProperties=====");
                 console.log(changedProperties);
 
-                // 递归提取依赖的函数
-                const extractDeps = (deps, scope) => {
-                  if (!deps?.dependency) return;
-                  const depList = Array.isArray(deps.dependency) ? deps.dependency : [deps.dependency];
+                // Helper function to resolve versions from properties
+                const resolveVersion = (version, effectiveProps) => {
+                    if (version && version.startsWith('${') && version.endsWith('}')) {
+                        const propName = version.slice(2, -1);
+                        return effectiveProps[propName] || version; // Return resolved version or original if not found
+                    }
+                    return version;
+                };
+
+                // Recursive function to extract dependencies
+                const extractDeps = (depsContainer, scope) => {
+                  if (!depsContainer?.dependency) return;
+                  const depList = Array.isArray(depsContainer.dependency) ? depsContainer.dependency : [depsContainer.dependency];
 
                   depList.forEach(dep => {
                     if (!dep.groupId || !dep.artifactId) return;
-                    // 处理版本号（可能是直接值或属性引用）
-                    let version = dep.version || '';
-                    let fromProperty = '';
 
-                    if (version.startsWith('${') && version.endsWith('}')) {
-                        const propName = version.slice(2, -1);
-                        version = effectiveProperties[propName] || version;
-                        fromProperty = propName;
-                    }
+                    let version = resolveVersion(dep.version, effectiveProperties);
 
-                    // 只有当属性有变更或版本直接变更时才包含
-                    if (fromProperty in changedProperties || !version.startsWith('${')) {
-                        dependencies.push({
+                    // Only include if the version was directly changed or its property changed
+                    if (changedProperties[dep.version?.slice(2,-1)] || (!dep.version || !dep.version.startsWith('${'))) {
+                        allComponents.push({
                             group: dep.groupId,
                             artifact: dep.artifactId,
                             version: version,
                             scope: scope || dep.scope || 'compile',
-                            fromProperty: fromProperty || undefined,
+                            type: 'dependency', // Mark as dependency
                             isManaged: scope === 'management'
                         });
                     }
                   });
                 };
 
-                // 1. 提取dependencyManagement中的依赖
+                // Recursive function to extract plugins
+                const extractPlugins = (pluginsContainer, scope) => {
+                    if (!pluginsContainer?.plugin) return;
+                    const pluginList = Array.isArray(pluginsContainer.plugin) ? pluginsContainer.plugin : [pluginsContainer.plugin];
+
+                    pluginList.forEach(plugin => {
+                        if (!plugin.groupId || !plugin.artifactId) return;
+
+                        let version = resolveVersion(plugin.version, effectiveProperties);
+
+                        // Only include if the version was directly changed or its property changed
+                        if (changedProperties[plugin.version?.slice(2,-1)] || (!plugin.version || !plugin.version.startsWith('${'))) {
+                            allComponents.push({
+                                group: plugin.groupId,
+                                artifact: plugin.artifactId,
+                                version: version,
+                                type: 'plugin', // Mark as plugin
+                                isManaged: scope === 'pluginManagement'
+                            });
+                        }
+                    });
+                };
+
+                // 1. Extract dependencies from dependencyManagement
                 if (result.project?.dependencyManagement?.dependencies) {
                     extractDeps(result.project.dependencyManagement.dependencies, 'management');
                 }
 
-                // 2. 提取普通dependencies
+                // 2. Extract regular dependencies
                 if (result.project?.dependencies) {
                     extractDeps(result.project.dependencies);
                 }
+
+                // 3. Extract plugins from pluginManagement
+                if (result.project?.build?.pluginManagement?.plugins) {
+                    extractPlugins(result.project.build.pluginManagement.plugins, 'pluginManagement');
+                }
+
+                // 4. Extract regular plugins
+                if (result.project?.build?.plugins) {
+                    extractPlugins(result.project.build.plugins);
+                }
+
               }
 
-              core.setOutput('dependencies', JSON.stringify(dependencies));
-              console.log("=====dependencies.length=====");
-              console.log(dependencies.length);
-              return dependencies.length;
+              core.setOutput('components', JSON.stringify(allComponents)); // Output as 'components'
+              console.log("=====allComponents.length=====");
+              console.log(allComponents.length);
+              return allComponents.length;
             } catch (error) {
-              core.setFailed(`Failed to parse dependencies: ${error}`);
+              core.setFailed(`Failed to parse dependencies and plugins: ${error}`);
             }
 
       - name: Check Aliyun Maven availability
-        if: steps.check-author.outputs.is_dependabot == 'true' && steps.parse-deps.outputs.dependencies != '[]'
+        if: steps.check-author.outputs.is_dependabot == 'true' && steps.parse-deps.outputs.components != '[]'
         id: check-aliyun
         uses: actions/github-script@v7
         with:
@@ -192,43 +229,47 @@ jobs:
             const { execSync } = require('child_process');
 
             try {
-              const dependencies = JSON.parse('${{ steps.parse-deps.outputs.dependencies }}');
+              const components = JSON.parse('${{ steps.parse-deps.outputs.components }}'); // Get 'components'
               const aliMavenUrl = 'https://maven.aliyun.com/repository/public';
               const results = [];
               const errresults = [];
 
-              for (const dep of dependencies) {
-                if (dep.artifact.startsWith("javafxTool-")) {
-                    continue;
+              for (const comp of components) {
+                // Skip specific artifacts if needed (e.g., javafxTool- which might not be in public repos)
+                if (comp.artifact.startsWith("javafxTool-")) {
+                  continue;
                 }
-                const artifactPath = dep.group.replace(/\./g, '/') + '/' + dep.artifact + '/' + dep.version;
-                const pomUrl = `${aliMavenUrl}/${artifactPath}/${dep.artifact}-${dep.version}.pom`;
-                console.log(pomUrl);
+
+                const artifactPath = comp.group.replace(/\./g, '/') + '/' + comp.artifact + '/' + comp.version;
+                const pomUrl = `${aliMavenUrl}/${artifactPath}/${comp.artifact}-${comp.version}.pom`;
+                console.log(`Checking: ${pomUrl}`);
 
                 try {
-                  execSync(`curl -I -s -o /dev/null -w "%{http_code}" ${pomUrl} | grep 200`);
-                  results.push(`✅ ${dep.group}:${dep.artifact}:${dep.version} - 可用`);
+                  // Use a timeout for curl to prevent hanging
+                  execSync(`curl -m 10 -I -s -o /dev/null -w "%{http_code}" ${pomUrl} | grep 200`);
+                  results.push(`✅ [${comp.type === 'plugin' ? '插件' : '依赖'}] ${comp.group}:${comp.artifact}:${comp.version} - 可用`);
                 } catch (e) {
-                  errresults.push(`❌ ${dep.group}:${dep.artifact}:${dep.version} - 不可用`);
+                  errresults.push(`❌ [${comp.type === 'plugin' ? '插件' : '依赖'}] ${comp.group}:${comp.artifact}:${comp.version} - 不可用`);
                 }
               }
 
-                if (results.length > 0) {
-                  const { data: comments } = await github.rest.issues.listComments({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      issue_number: context.issue.number,
+              if (results.length > 0 || errresults.length > 0) { // Ensure comment is made even if all are available
+                const { data: comments } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
                 });
 
-                // 查找我们之前发布的评论（通过特定标识）
+                // Find our previously posted comment (by specific identifier)
                 const botComment = comments.find(comment =>
                   comment.user.login === 'github-actions[bot]' &&
-                  comment.body.startsWith('### 阿里云 Maven 依赖检查结果')
+                  comment.body.startsWith('### 阿里云 Maven 组件检查结果') // Updated comment identifier
                 );
 
-                const commentBody = `### 阿里云 Maven 依赖检查结果\n\n${errresults.join('\n')}\n\n<details><summary>点击查看可用的依赖</summary>${results.join('<br>\n')}<br></details>`;
+                const commentBody = `### 阿里云 Maven 组件检查结果\n\n${errresults.join('\n')}\n\n<details><summary>点击查看可用的组件</summary>${results.join('<br>\n')}<br></details>`;
+
                 if (botComment) {
-                  // 更新现有评论
+                  // Update existing comment
                   await github.rest.issues.updateComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
@@ -236,7 +277,7 @@ jobs:
                       body: commentBody
                   });
                 } else {
-                  // 创建新评论
+                  // Create new comment
                   github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
@@ -246,14 +287,15 @@ jobs:
                 }
 
                 core.setOutput('result', commentBody);
+              } else {
+                  core.setOutput('result', 'No new dependencies or plugins found to check.');
               }
-
-              return 'Dependency check completed';
+              return 'Component check completed';
             } catch (error) {
               core.setFailed(`Action failed with error: ${error}`);
             }
 
       - name: Output result
-        if: steps.check-author.outputs.is_dependabot == 'true' && steps.parse-deps.outputs.dependencies != '[]'
+        if: steps.check-author.outputs.is_dependabot == 'true' && steps.parse-deps.outputs.components != '[]'
         run: echo "${{ steps.check-aliyun.outputs.result }}"
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2215

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Enhance the Aliyun Maven CI workflow to parse and verify both dependencies and plugins as unified components, improve diff-based parsing logic, and refine reporting of artifact availability.

New Features:
- Add plugin detection and checking alongside dependencies in the Aliyun Maven CI workflow

Enhancements:
- Unify dependency and plugin parsing into a single “components” output
- Extend Maven and Gradle diff parsing to resolve properties, handle managed scopes, and use more robust regex patterns
- Ensure availability reports always post or update a component check comment with timeout handling and detailed logs

CI:
- Rename workflow and step names to reflect component checks and update comment identifiers accordingly