### PR TITLE
test: Fix xpath setting

### DIFF
--- a/core/src/test/java/com/tlcsdm/core/util/CSCcrlParseTest.java
+++ b/core/src/test/java/com/tlcsdm/core/util/CSCcrlParseTest.java
@@ -37,6 +37,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -44,6 +45,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -128,9 +130,11 @@ class CSCcrlParseTest {
             // 加载 XML 文档
             DocumentBuilder builder = factory.newDocumentBuilder();
             document = builder.parse(project);
-
+            XPathFactory xpathfactory = XPathFactory.newInstance();
+            // 关闭限制 #2229
+            xpathfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
             // 执行 XPath 查询
-            XPath xpath = XPathFactory.newInstance().newXPath();
+            XPath xpath = xpathfactory.newXPath();
             NodeList nodeList = (NodeList) xpath.evaluate(xpathExpr, document, XPathConstants.NODESET);
 
             // 构造标签->值映射
@@ -151,7 +155,8 @@ class CSCcrlParseTest {
                     System.out.println(tag + " 未找到");
                 }
             }
-        } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException e) {
+        } catch (ParserConfigurationException | SAXException | IOException | XPathExpressionException |
+                 XPathFactoryConfigurationException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
CLose #2229

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Fix XPath setting in parseXpath test to allow unbounded expressions by disabling secure processing feature, adjust factory usage, and expand exception catching

Bug Fixes:
- Disable FEATURE_SECURE_PROCESSING on XPathFactory in parseXpath test to lift evaluation restrictions (#2229)
- Reuse the configured XPathFactory instance for creating the XPath object
- Include XPathFactoryConfigurationException in the test’s exception handling

Tests:
- Update parseXpath test to reflect the new factory configuration and exception handling requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新了测试方法，增强了对XPath工厂配置异常的处理，并调整了XPath工厂的安全处理特性设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->