### PR TITLE
test: Improve cs parse

### DIFF
--- a/core/src/test/java/com/tlcsdm/core/util/CSCcrlParseTest.java
+++ b/core/src/test/java/com/tlcsdm/core/util/CSCcrlParseTest.java
@@ -30,6 +30,7 @@ package com.tlcsdm.core.util;
 import cn.hutool.core.io.resource.ResourceUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -52,8 +53,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * 解析mtpj构建ccrl命令
@@ -87,22 +86,21 @@ class CSCcrlParseTest {
             //Code generation changing
             "COptionDblSize-0", "COptionSignedChar-0", "COptionSignedBitfield-0", "COptionSwitch-0", "COptionVolatile-0",
             "COptionMergeString-0", "COptionPack-0", "COptionStuffBSS-0", "COptionStuffData-0", "COptionStuffConst-0",
-            "COptionStackProtector-0", "COptionStackProtectorValue-0", "COptionControlFlowIntegrity-0", "COptionInsertNopWithLabel-0",
             //Extensions
             "COptionLargeVariable-0",
             //Compiler transition support
             "COptionConvertCc-0", "COptionUnalignedPointerForCA78K0R-0",
             //rlink
             //Input control
-            "LinkOptionDefine-0", "LinkOptionInput-0", "LinkOptionBinary-0", "LinkOptionEntry-0", "LinkOptionEntryPoint-0", "LibOptionAllowDuplicateModuleName-0",
+            "LinkOptionDefine-0", "LinkOptionInput-0", "LinkOptionLibrary-0", "LinkOptionBinary-0", "LinkOptionEntry-0",
+            "LinkOptionEntryPoint-0", "LibOptionAllowDuplicateModuleName-0",
             //Output control
-            "HexOptionForm-0", "LinkOptionDebug-0", "LinkOptionRom-0", "HexOptionSpace-0", "HexOptionSpaceValue-0", "LinkOptionMessage-0",
-            "LinkOptionVect-0", "LinkOptionVectN-0",
+            "HexOptionForm-0", "LinkOptionDebug-0", "LinkOptionRom-0", "LinkOptionMessage-0", "LinkOptionVect-0", "LinkOptionVectN-0",
             //List output
             "LinkOptionShowVector-0", "LinkOptionShowStruct-0", "LinkOptionShowRelocationAttribute-0", "LinkOptionShowCFI-0",
             "LinkOptionShowSymbol-0", "LinkOptionShowReference-0", "LinkOptionShowXreference-0", "LinkOptionShowTotalSize-0",
             //Optimization
-            "COptionGoptimize-0", "LinkOptionOptimize-0", "LinkOptionOptimizeSymbolDelete-0", "LinkOptionOptimizeBranch-0",
+            "LinkOptionOptimize-0", "LinkOptionOptimizeSymbolDelete-0", "LinkOptionOptimizeBranch-0",
             "LinkOptionSectionForbid-0", "LinkOptionAbsoluteForbid-0", "LinkOptionSymbolForbid-0",
             //Section specification
             "LinkOptionStart-0", "LinkOptionFSymbol-0", "LinkOptionUserOptByte-0", "LinkOptionUserOptByteValue-0", "LinkOptionOcdbg-0",
@@ -114,7 +112,7 @@ class CSCcrlParseTest {
             //dspasm
             "DSPAsmOptionOutputAsm-0", "DSPAsmOptionOutputVerilog-0", "DSPAsmOptionTextmacro-0", "DSPAsmOptionDefine-0",
             "DSPAsmOptionAllowTextMacroRedefine-0", "DSPAsmOptionCore-0", "DSPAsmOptionCodeSectionStart-0", "DSPAsmOptionDataSectionStart-0",
-            "DSPAsmOptionNoDebugInfo-0", "DSPAsmOptionLabel-0", "DSPAsmOptionMacroIdentifyExact-0"
+            "DSPAsmOptionLabel-0", "DSPAsmOptionMacroIdentifyExact-0"
         };
     }
 


### PR DESCRIPTION
CLose #2195

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Adjust CSCcrlParseTest expectations by removing obsolete options and adding updated linker options to reflect recent parser support changes

Enhancements:
- Update CSCcrlParseTest to align expected option names with current parser behavior
- Remove deprecated CS options (e.g., stack protector, Goptimize, NoDebugInfo) from test expectations
- Add and reorder Linker options (e.g., LinkOptionLibrary) in the expected list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 测试
  - 在 CI 环境条件禁用相关解析用例，提升稳定性。
  - 更新测试使用的 CCRL 标签清单，移除过时选项并调整分组与顺序，使之与最新配置对齐，减少噪声与误报。
- 杂务
  - 无用户可见变更；生产功能与公开接口不受影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->