### PR TITLE
test: Add jaxb XML Signature

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -37,6 +37,7 @@ module com.tlcsdm.core {
     requires java.sql;
     requires java.xml;
     requires java.management;
+    requires static java.xml.crypto;
     requires static java.compiler;
     requires org.apache.commons.lang3;
     requires javafx.controls;


### PR DESCRIPTION
Close #2352

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

Add a JAXB-based XML Signature test for the Book model and declare the XML crypto module dependency needed for signing and validating XML in tests.

Build:
- Declare a static dependency on java.xml.crypto in the module descriptor to support XML digital signature APIs in the core module.

Tests:
- Add a unit test that serializes a Book to XML, applies an RSA-based XML Signature, and verifies the signature for correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试改进**
  * 新增XML签名与验证工作流测试，覆盖JAXB序列化、RSA-SHA256签名生成及数字签名验证功能

* **杂项**
  * 更新模块配置以增强编译时API可访问性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->