### PR TITLE
ci: Enable javadoc skipping in Maven build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
         stage('Prepare Windows Build') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
-                    sh "$M2_HOME/bin/mvn ${} -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' -DworkEnv=ci clean install"
+                    sh "$M2_HOME/bin/mvn ${MAVEN_CI_ARGS} -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' -DworkEnv=ci clean install"
                     sh "rm -rf jretemp && mkdir -v jretemp && unzip -q *windows*21*.zip -d jretemp && mv jretemp/* jretemp/jre"
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         // 限制 Maven JVM 堆内存，避免在低配服务器(4核4G)上构建时内存压力过大
         MAVEN_OPTS = '-Xmx1024m -XX:MaxMetaspaceSize=256m'
         // Jenkins 构建使用 1 个 Maven 线程，并关闭 javac verbose 日志，降低内存和日志压力
-        MAVEN_CI_ARGS = '-B --no-transfer-progress -T 1 -Dmaven.compiler.verbose=false'
+        MAVEN_CI_ARGS = '-B --no-transfer-progress -T 1 -Dmaven.compiler.verbose=false -Dmaven.javadoc.skip=true'
         PLANTUML_JAR_PATH = '/usr/share/plantuml/plantuml.jar'
     }
     tools {
@@ -99,7 +99,7 @@ pipeline {
         stage('Prepare Windows Build') {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
-                    sh "$M2_HOME/bin/mvn ${MAVEN_CI_ARGS} -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' -DworkEnv=ci clean install"
+                    sh "$M2_HOME/bin/mvn ${} -f pom.xml -s $M2_HOME/conf/settings.xml '-Djavafx.platform=win' '-Dmaven.test.skip=true' '-Dmaven.javadoc.skip=true' -DworkEnv=ci clean install"
                     sh "rm -rf jretemp && mkdir -v jretemp && unzip -q *windows*21*.zip -d jretemp && mv jretemp/* jretemp/jre"
                 }
             }


### PR DESCRIPTION
Added javadoc skipping option to Maven CI arguments in Jenkinsfile.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `dependencies`
- [ ] Verify design and implementation

## Summary by Sourcery

更新 Jenkins CI Maven 配置，以调整全局 CI 参数及其在 Windows 构建阶段中的使用方式。

构建：
- 添加全局 Maven CI 参数标志，用于在 Jenkins 构建中跳过 javadoc 生成。
- 修改 Windows 构建的 Maven 调用，使其不再使用共享的 `MAVEN_CI_ARGS` 变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Jenkins CI Maven configuration to adjust global CI arguments and their use in the Windows build stage.

Build:
- Add global Maven CI arguments flag to skip javadoc generation in Jenkins builds.
- Modify the Windows build Maven invocation to no longer use the shared MAVEN_CI_ARGS variable.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **构建改进**
  * 优化 Maven 构建配置，跳过 Javadoc 生成以提升构建效率。
  * 调整 Windows 构建准备流程，避免继承集中配置的 Maven 参数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->